### PR TITLE
Minor fixes to avoid LLMs confusion

### DIFF
--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/ADRService.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/ADRService.java
@@ -58,7 +58,7 @@ public class ADRService {
 
             // Get application ID from name
             logger.debug("Looking up application ID for name: {}", applicationName);
-            String appID = SDKHelper.getAppIDFromAppName(applicationName, orgID, contrastSDK);
+            String appID = SDKHelper.getAppIDFromapp_name(applicationName, orgID, contrastSDK);
             if (appID == null || appID.isEmpty()) {
                 logger.warn("No application ID found for application: {}", applicationName);
                 return null;

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/AssessService.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/AssessService.java
@@ -70,8 +70,8 @@ public class AssessService {
     private String orgID;
 
 
-    @Tool(name = "get_vulnerability", description = "takes a vulnerability ID ( vulnID ) and Application ID ( appID ) and returns details about the specific security vulnerability. If based on the stacktrace, the vulnerability looks like it is in code that is not in the codebase, the vulnerability may be in a 3rd party library, review the CVE data attached to that stackframe you believe the vulnerability exists in and if possible upgrade that library to the next non vulnerable version based on the remediation guidance.")
-    public Vulnerability getVulnerability(String vulnID, String appID) throws IOException {
+    @Tool(name = "get_vulnerability_by_id", description = "takes a vulnerability ID ( vulnID ) and Application ID ( appID ) and returns details about the specific security vulnerability. If based on the stacktrace, the vulnerability looks like it is in code that is not in the codebase, the vulnerability may be in a 3rd party library, review the CVE data attached to that stackframe you believe the vulnerability exists in and if possible upgrade that library to the next non vulnerable version based on the remediation guidance.")
+    public Vulnerability getVulnerabilityById(String vulnID, String appID) throws IOException {
         logger.info("Retrieving vulnerability details for vulnID: {} in application ID: {}", vulnID, appID);
         ContrastSDK contrastSDK = SDKHelper.getSDK(hostName, apiKey, serviceKey, userName);
         logger.debug("ContrastSDK initialized with host: {}", hostName);
@@ -150,30 +150,30 @@ public class AssessService {
         return Optional.empty();
     }
 
-    @Tool(name = "get_vulnerability_by_app_name", description = "Takes a vulnerability ID (vulnID) and application name (appName) and returns details about the specific security vulnerability.  If based on the stacktrace, the vulnerability looks like it is in code that is not in the codebase, the vulnerability may be in a 3rd party library, review the CVE data attached to that stackframe you believe the vulnerability exists in and if possible upgrade that library to the next non vulnerable version based on the remediation guidance.")
-    public Vulnerability getVulnerabilityByAppName(String vulnID, String appName) throws IOException {
-        logger.info("Retrieving vulnerability details for vulnID: {} in application: {}", vulnID, appName);
+    @Tool(name = "get_vulnerability", description = "Takes a vulnerability ID (vulnID) and application name (app_name) and returns details about the specific security vulnerability.  If based on the stacktrace, the vulnerability looks like it is in code that is not in the codebase, the vulnerability may be in a 3rd party library, review the CVE data attached to that stackframe you believe the vulnerability exists in and if possible upgrade that library to the next non vulnerable version based on the remediation guidance.")
+    public Vulnerability getVulnerability(String vulnID, String app_name) throws IOException {
+        logger.info("Retrieving vulnerability details for vulnID: {} in application: {}", vulnID, app_name);
         ContrastSDK contrastSDK = SDKHelper.getSDK(hostName, apiKey, serviceKey, userName);
         Optional<String> appID = Optional.empty();
-        logger.debug("Searching for application ID matching name: {}", appName);
+        logger.debug("Searching for application ID matching name: {}", app_name);
 
         for(Application app : contrastSDK.getApplications(orgID).getApplications()) {
-            if(app.getName().toLowerCase().contains(appName.toLowerCase())) {
+            if(app.getName().toLowerCase().contains(app_name.toLowerCase())) {
                 appID = Optional.of(app.getId());
                 logger.debug("Found matching application - ID: {}, Name: {}", app.getId(), app.getName());
                 break;
             }
         }
         if(appID.isPresent()) {
-            return getVulnerability(vulnID, appID.get());
+            return getVulnerabilityById(vulnID, appID.get());
         } else {
-            logger.error("Application with name {} not found", appName);
-            throw new IllegalArgumentException("Application with name " + appName + " not found");
+            logger.error("Application with name {} not found", app_name);
+            throw new IllegalArgumentException("Application with name " + app_name + " not found");
         }
     }
 
-    @Tool(name = "list_vulnerabilities", description = "Takes a  Application ID ( appID ) and returns a list of vulnerabilities, please remember to include the vulnID in the response.")
-    public List<VulnLight> listVulnsInApp(String appID) throws IOException {
+    @Tool(name = "list_vulnerabilities_with_id", description = "Takes a  Application ID ( appID ) and returns a list of vulnerabilities, please remember to include the vulnID in the response.")
+    public List<VulnLight> listVulnsByAppId(String appID) throws IOException {
         logger.info("Listing vulnerabilities for application ID: {}", appID);
         ContrastSDK contrastSDK = SDKHelper.getSDK(hostName, apiKey, serviceKey, userName);
         
@@ -194,16 +194,17 @@ public class AssessService {
         }
     }
 
-    @Tool(name = "list_vulnerabilities_with_app_name", description = "Takes an application name ( appName ) and returns a list of vulnerabilities, please remember to include the vulnID in the response.  ")
-    public List<VulnLight> listVulnsInAppByName(String appName) throws IOException {
-        logger.info("Listing vulnerabilities for application: {}", appName);
+
+    @Tool(name = "list_vulnerabilities", description = "Takes an application name ( app_name ) and returns a list of vulnerabilities, please remember to include the vulnID in the response.  ")
+    public List<VulnLight> listVulnsInAppByName(String app_name) throws IOException {
+        logger.info("Listing vulnerabilities for application: {}", app_name);
         ContrastSDK contrastSDK = SDKHelper.getSDK(hostName, apiKey, serviceKey, userName);
         
         Optional<String> appID = Optional.empty();
-        logger.debug("Searching for application ID matching name: {}", appName);
+        logger.debug("Searching for application ID matching name: {}", app_name);
         
         for(Application app : contrastSDK.getApplications(orgID).getApplications()) {
-            if(app.getName().toLowerCase().contains(appName.toLowerCase())) {
+            if(app.getName().toLowerCase().contains(app_name.toLowerCase())) {
                 appID = Optional.of(app.getId());
                 logger.debug("Found matching application - ID: {}, Name: {}", app.getId(), app.getName());
                 break;
@@ -211,21 +212,21 @@ public class AssessService {
         }
         if(appID.isPresent()) {
             try {
-              return listVulnsInApp(appID.get());
+              return listVulnsByAppId(appID.get());
             } catch (Exception e) {
-                logger.error("Error listing vulnerabilities for application: {}", appName, e);
+                logger.error("Error listing vulnerabilities for application: {}", app_name, e);
                 throw new IOException("Failed to list vulnerabilities: " + e.getMessage(), e);
             }
         } else {
-            logger.debug("Application with name {} not found, returning empty list", appName);
+            logger.debug("Application with name {} not found, returning empty list", app_name);
             return new ArrayList<>();
         }
     }
 
 
-    @Tool(name = "list_applications", description = "Takes an application name (appName) returns a list of active applications matching that name. Please remember to display the name, status and ID.")
-    public List<ApplicationData> getActiveApplications(String appName) throws IOException {
-        logger.info("Listing active applications matching name: {}", appName);
+    @Tool(name = "list_applications", description = "Takes an application name (app_name) returns a list of active applications matching that name. Please remember to display the name, status and ID.")
+    public List<ApplicationData> getActiveApplications(String app_name) throws IOException {
+        logger.info("Listing active applications matching name: {}", app_name);
         ContrastSDK contrastSDK = SDKHelper.getSDK(hostName, apiKey, serviceKey, userName);
         try {
             List<Application> applications = contrastSDK.getApplications(orgID).getApplications();
@@ -233,17 +234,17 @@ public class AssessService {
             
             List<ApplicationData> filteredApps = new ArrayList<>();
             for(Application app : applications) {
-                if(app.getName().toLowerCase().contains(appName.toLowerCase())) {
+                if(app.getName().toLowerCase().contains(app_name.toLowerCase())) {
                     filteredApps.add(new ApplicationData(app.getName(), app.getStatus(), app.getId()));
                     logger.debug("Found matching application - ID: {}, Name: {}, Status: {}", 
                             app.getId(), app.getName(), app.getStatus());
                 }
             }
             
-            logger.info("Found {} applications matching '{}'", filteredApps.size(), appName);
+            logger.info("Found {} applications matching '{}'", filteredApps.size(), app_name);
             return filteredApps;
         } catch (Exception e) {
-            logger.error("Error listing applications matching name: {}", appName, e);
+            logger.error("Error listing applications matching name: {}", app_name, e);
             throw new IOException("Failed to list applications: " + e.getMessage(), e);
         }
     }

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/SCAService.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/SCAService.java
@@ -67,17 +67,17 @@ public class SCAService {
 
 
     @Tool(name = "list_application_libraries", description = "takes a application name and returns the libraries used in the application, note if class usage count is 0 the library is unlikely to be used")
-    public List<LibraryExtended> getApplicationLibraries(String appName) throws IOException {
-        logger.info("Retrieving libraries for application: {}", appName);
+    public List<LibraryExtended> getApplicationLibraries(String app_name) throws IOException {
+        logger.info("Retrieving libraries for application: {}", app_name);
         ContrastSDK contrastSDK = SDKHelper.getSDK(hostName, apiKey, serviceKey, userName);
         logger.debug("ContrastSDK initialized with host: {}", hostName);
         
         SDKExtension extendedSDK = new SDKExtension(contrastSDK);
         Optional<String> appID = Optional.empty();
-        logger.debug("Searching for application ID matching name: {}", appName);
+        logger.debug("Searching for application ID matching name: {}", app_name);
         
         for(Application app : contrastSDK.getApplications(orgID).getApplications()) {
-            if(app.getName().toLowerCase().contains(appName.toLowerCase())) {
+            if(app.getName().toLowerCase().contains(app_name.toLowerCase())) {
                 appID = Optional.of(app.getId());
                 logger.info("Found matching application - ID: {}, Name: {}", app.getId(), app.getName());
                 break;
@@ -86,7 +86,7 @@ public class SCAService {
         if(appID.isPresent()) {
             return SDKHelper.getLibsForID(appID.get(),orgID, extendedSDK);
         } else {
-            logger.error("Application not found: {}", appName);
+            logger.error("Application not found: {}", app_name);
             throw new IOException("Application not found");
         }
     }

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkexstension/SDKHelper.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkexstension/SDKHelper.java
@@ -39,7 +39,7 @@ public class SDKHelper {
 
 
     private static final String MCP_SERVER_NAME = "contrast-mcp";
-    private static final String MCP_VERSION = "0.0.6";
+    private static final String MCP_VERSION = "0.0.4";
 
     private static final Logger logger = LoggerFactory.getLogger(SDKHelper.class);
 
@@ -90,17 +90,17 @@ public class SDKHelper {
         return libs;
     }
 
-    public static String getAppIDFromAppName(String appName, String orgID, ContrastSDK contrastSDK) throws IOException {
+    public static String getAppIDFromapp_name(String app_name, String orgID, ContrastSDK contrastSDK) throws IOException {
         // Check cache for existing result
-        String cachedAppID = appIDCache.getIfPresent(appName);
+        String cachedAppID = appIDCache.getIfPresent(app_name);
         if (cachedAppID != null) {
-            logger.info("Cache hit for application name: {}", appName);
+            logger.info("Cache hit for application name: {}", app_name);
             return cachedAppID;
         }
-        logger.debug("Cache miss for application name: {}, searching for application ID", appName);
+        logger.debug("Cache miss for application name: {}, searching for application ID", app_name);
         Optional<String> appID = Optional.empty();
         for (Application app : contrastSDK.getApplications(orgID).getApplications()) {
-            if (app.getName().toLowerCase().contains(appName.toLowerCase())) {
+            if (app.getName().toLowerCase().contains(app_name.toLowerCase())) {
                 appID = Optional.of(app.getId());
                 logger.info("Found matching application - ID: {}, Name: {}", app.getId(), app.getName());
                 break;
@@ -109,10 +109,10 @@ public class SDKHelper {
 
         if (appID.isPresent()) {
             // Store result in cache
-            appIDCache.put(appName, appID.get());
+            appIDCache.put(app_name, appID.get());
             return appID.get();
         } else {
-            logger.error("Application not found: {}", appName);
+            logger.error("Application not found: {}", app_name);
             throw new IOException("Application not found");
         }
     }

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkexstension/SDKHelper.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkexstension/SDKHelper.java
@@ -39,7 +39,7 @@ public class SDKHelper {
 
 
     private static final String MCP_SERVER_NAME = "contrast-mcp";
-    private static final String MCP_VERSION = "0.0.4";
+    private static final String MCP_VERSION = "0.0.6";
 
     private static final Logger logger = LoggerFactory.getLogger(SDKHelper.class);
 

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkexstension/data/LibraryExtended.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkexstension/data/LibraryExtended.java
@@ -117,7 +117,7 @@ public class LibraryExtended {
     private String appId;
 
     @SerializedName("app_name")
-    private String appName;
+    private String app_name;
 
     @SerializedName("app_context_path")
     private String appContextPath;
@@ -212,8 +212,8 @@ public class LibraryExtended {
         return appId;
     }
 
-    public String getAppName() {
-        return appName;
+    public String getapp_name() {
+        return app_name;
     }
 
     public String getAppContextPath() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=mcp-contrast
 spring.main.web-application-type=none
 spring.ai.mcp.server.name=mcp-contrast
-spring.ai.mcp.server.version=0.0.4
+spring.ai.mcp.server.version=0.0.6
 
 spring.main.banner-mode=off
 logging.pattern.console=

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=mcp-contrast
 spring.main.web-application-type=none
 spring.ai.mcp.server.name=mcp-contrast
-spring.ai.mcp.server.version=0.0.6
+spring.ai.mcp.server.version=0.0.4
 
 spring.main.banner-mode=off
 logging.pattern.console=


### PR DESCRIPTION
Minor changes to avoid LLMs confusion. 

- **Mapping from appName to app_name changed** 

LibraryExtended.java maps appName with app_name. LLMs tend to send the parameter name as app_name, when the name of the parameter defined in the method is appName. This mapping has been changed to use always app_name to keep the affinity with the parameter name.

 `    @SerializedName("app_name")
    private String appName;`



- **Methods for list vulnerabilities and list applications renamed**

 There are two methods for listing vulnerabilities and applications: One to list based on the application ID and another one to do it based on the application name. The default method for both functionalities is the one that receive the ID, but in natural language it is expected to search vulnerabilities by application name, so if you ask:

`Return the vulnerabilities in application XXX`

It searches for vulnerabilities for applicationId instead of applicationName. To retrieve vulnerabilities based on application name, an user needs to ask:

`Return the vulnerabilities in application named XXX` 

With this change, now it will search by default using the appName instead of appId
