### PR TITLE
Build for amd64 and arm64

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -45,6 +45,9 @@ jobs:
         
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
         
       - name: Extract metadata for Docker
         id: meta
@@ -72,6 +75,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64, linux/arm64
           
       - name: Push and sign Docker image with DCT
         run: |


### PR DESCRIPTION
Would be nice to have an arm image published for Apple Silicon usage.
I'm not sure if this will work as is with the build then push approach used -- presumably because of signing things -- but hard to test.