### PR TITLE
Fix JSON parsing error for missingRequiredFields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is an MCP (Model Context Protocol) server for Contrast Security that enables AI agents to access and analyze vulnerability data from Contrast's security platform. It serves as a bridge between Contrast Security's API and AI tools like Claude, enabling automated vulnerability remediation and security analysis.
+
+## Build and Development Commands
+
+### Building the Project
+- **Build**: `mvn clean install` or `./mvnw clean install`
+- **Test**: `mvn test` or `./mvnw test`
+- **Run locally**: `java -jar target/mcp-contrast-0.0.9.jar --CONTRAST_HOST_NAME=<host> --CONTRAST_API_KEY=<key> --CONTRAST_SERVICE_KEY=<key> --CONTRAST_USERNAME=<user> --CONTRAST_ORG_ID=<org>`
+
+### Docker Commands
+- **Build Docker image**: `docker build -t mcp-contrast .`
+- **Run with Docker**: `docker run -e CONTRAST_HOST_NAME=<host> -e CONTRAST_API_KEY=<key> -e CONTRAST_SERVICE_KEY=<key> -e CONTRAST_USERNAME=<user> -e CONTRAST_ORG_ID=<org> -i --rm mcp-contrast:latest -t stdio`
+
+### Requirements
+- Java 17+
+- Maven 3.6+ (or use included wrapper `./mvnw`)
+- Docker (optional, for containerized deployment)
+
+## Architecture
+
+### Core Components
+
+**Main Application**: `McpContrastApplication.java` - Spring Boot application that registers MCP tools from all service classes.
+
+**Service Layer**: Each service handles a specific aspect of Contrast Security data:
+- `AssessService` - Vulnerability analysis and trace data
+- `SastService` - Static application security testing data
+- `SCAService` - Software composition analysis (library vulnerabilities)
+- `ADRService` - Attack detection and response events
+- `RouteCoverageService` - Route coverage analysis
+- `PromptService` - AI prompt management
+
+**SDK Extensions**: Located in `sdkexstension/` package, these extend the Contrast SDK with enhanced data models and helper methods for better AI integration.
+
+**Data Models**: Comprehensive POJOs in `data/` package representing vulnerability information, library data, applications, and attack events.
+
+**Hint System**: `hints/` package provides context-aware security guidance for vulnerability remediation.
+
+### Configuration
+
+The application uses Spring Boot configuration with the following key properties:
+- `spring.ai.mcp.server.name=mcp-contrast`
+- `spring.main.web-application-type=none` (CLI application, not web server)
+- `contrast.api.protocol=https` (configurable for local development)
+
+Required environment variables/arguments:
+- `CONTRAST_HOST_NAME` - Contrast TeamServer URL
+- `CONTRAST_API_KEY` - API authentication key
+- `CONTRAST_SERVICE_KEY` - Service authentication key  
+- `CONTRAST_USERNAME` - User account
+- `CONTRAST_ORG_ID` - Organization identifier
+
+### Technology Stack
+
+- **Framework**: Spring Boot 3.4.5 with Spring AI 1.0.0-RC1
+- **MCP Integration**: Spring AI MCP Server starter
+- **Contrast Integration**: Contrast SDK Java 3.4.2
+- **Testing**: JUnit 5
+- **Build Tool**: Maven with wrapper
+- **Packaging**: Executable JAR and Docker container
+
+### Development Patterns
+
+1. **MCP Tools**: Services expose methods via `@Tool` annotation for AI agent consumption
+2. **SDK Extension Pattern**: Enhanced data models extend base SDK classes with AI-friendly representations
+3. **Hint Generation**: Rule-based system provides contextual security guidance
+4. **Defensive Design**: All external API calls include error handling and logging
+
+### Security Considerations
+
+This codebase handles sensitive vulnerability data. The README contains critical warnings about data privacy when using with AI models. Never expose Contrast credentials or vulnerability data to untrusted AI services.
+
+### Logging
+
+- Default log location: `/tmp/mcp-contrast.log`
+- Debug logging: Add `--logging.level.root=DEBUG` to startup arguments
+- Console logging is minimal by design for MCP protocol compatibility

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkexstension/data/application/Application.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkexstension/data/application/Application.java
@@ -68,7 +68,7 @@ public class Application {
     private List<ValidationErrorFields> validationErrorFields;
 
     @SerializedName("missingRequiredFields")
-    private List<String> missingRequiredFields;
+    private List<ValidationErrorFields> missingRequiredFields;
 
     @SerializedName("protect")
     private Object protect;
@@ -268,11 +268,11 @@ public class Application {
         this.validationErrorFields = validationErrorFields;
     }
 
-    public List<String> getMissingRequiredFields() {
+    public List<ValidationErrorFields> getMissingRequiredFields() {
         return missingRequiredFields;
     }
 
-    public void setMissingRequiredFields(List<String> missingRequiredFields) {
+    public void setMissingRequiredFields(List<ValidationErrorFields> missingRequiredFields) {
         this.missingRequiredFields = missingRequiredFields;
     }
 

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkexstension/data/application/Application.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkexstension/data/application/Application.java
@@ -65,10 +65,10 @@ public class Application {
     private List<Metadata> metadataEntities;
 
     @SerializedName("validationErrorFields")
-    private List<ValidationErrorFields> validationErrorFields;
+    private List<ValidationErrorField> validationErrorFields;
 
     @SerializedName("missingRequiredFields")
-    private List<ValidationErrorFields> missingRequiredFields;
+    private List<ValidationErrorField> missingRequiredFields;
 
     @SerializedName("protect")
     private Object protect;
@@ -260,19 +260,19 @@ public class Application {
         this.metadataEntities = metadataEntities;
     }
 
-    public List<ValidationErrorFields> getValidationErrorFields() {
+    public List<ValidationErrorField> getValidationErrorFields() {
         return validationErrorFields;
     }
 
-    public void setValidationErrorFields(List<ValidationErrorFields> validationErrorFields) {
+    public void setValidationErrorFields(List<ValidationErrorField> validationErrorFields) {
         this.validationErrorFields = validationErrorFields;
     }
 
-    public List<ValidationErrorFields> getMissingRequiredFields() {
+    public List<ValidationErrorField> getMissingRequiredFields() {
         return missingRequiredFields;
     }
 
-    public void setMissingRequiredFields(List<ValidationErrorFields> missingRequiredFields) {
+    public void setMissingRequiredFields(List<ValidationErrorField> missingRequiredFields) {
         this.missingRequiredFields = missingRequiredFields;
     }
 

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkexstension/data/application/Application.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkexstension/data/application/Application.java
@@ -2,7 +2,6 @@ package com.contrast.labs.ai.mcp.contrast.sdkexstension.data.application;
 
 import com.google.gson.annotations.SerializedName;
 
-import javax.validation.Validation;
 import java.util.List;
 
 /**
@@ -65,10 +64,10 @@ public class Application {
     private List<Metadata> metadataEntities;
 
     @SerializedName("validationErrorFields")
-    private List<ValidationErrorField> validationErrorFields;
+    private List<Field> validationErrorFields;
 
     @SerializedName("missingRequiredFields")
-    private List<ValidationErrorField> missingRequiredFields;
+    private List<Field> missingRequiredFields;
 
     @SerializedName("protect")
     private Object protect;
@@ -260,19 +259,19 @@ public class Application {
         this.metadataEntities = metadataEntities;
     }
 
-    public List<ValidationErrorField> getValidationErrorFields() {
+    public List<Field> getValidationErrorFields() {
         return validationErrorFields;
     }
 
-    public void setValidationErrorFields(List<ValidationErrorField> validationErrorFields) {
+    public void setValidationErrorFields(List<Field> validationErrorFields) {
         this.validationErrorFields = validationErrorFields;
     }
 
-    public List<ValidationErrorField> getMissingRequiredFields() {
+    public List<Field> getMissingRequiredFields() {
         return missingRequiredFields;
     }
 
-    public void setMissingRequiredFields(List<ValidationErrorField> missingRequiredFields) {
+    public void setMissingRequiredFields(List<Field> missingRequiredFields) {
         this.missingRequiredFields = missingRequiredFields;
     }
 

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkexstension/data/application/Field.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkexstension/data/application/Field.java
@@ -2,13 +2,12 @@ package com.contrast.labs.ai.mcp.contrast.sdkexstension.data.application;
 
 import com.google.gson.annotations.SerializedName;
 
-import javax.validation.Validation;
 import java.util.List;
 
-public class ValidationErrorField {
+public class Field {
 
     /**
-     * Represents ValidationErrorField information for an application.
+     * Represents Field information for an application.
      */
 
     /**
@@ -43,7 +42,7 @@ public class ValidationErrorField {
     private boolean unique;
 
     @SerializedName("subfields")
-    private List<ValidationErrorField> subfields;
+    private List<Field> subfields;
 
     @SerializedName("links")
     private List<String> links;
@@ -85,10 +84,10 @@ public class ValidationErrorField {
     public void setUnique(boolean unique) {
         this.unique = unique;
     }
-    public List<ValidationErrorField> getSubfields() {
+    public List<Field> getSubfields() {
         return subfields;
     }
-    public void setSubfields(List<ValidationErrorField> subfields) {
+    public void setSubfields(List<Field> subfields) {
         this.subfields = subfields;
     }
     public List<String> getLinks() {
@@ -100,7 +99,7 @@ public class ValidationErrorField {
 
     @Override
     public String toString() {
-        return "ValidationErrorField{" +
+        return "Field{" +
                 "fieldId='" + fieldId + '\'' +
                 ", fieldType='" + fieldType + '\'' +
                 ", displayLabel='" + displayLabel + '\'' +

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkexstension/data/application/ValidationErrorField.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkexstension/data/application/ValidationErrorField.java
@@ -5,10 +5,10 @@ import com.google.gson.annotations.SerializedName;
 import javax.validation.Validation;
 import java.util.List;
 
-public class ValidationErrorFields {
+public class ValidationErrorField {
 
     /**
-     * Represents ValidationErrorFields information for an application.
+     * Represents ValidationErrorField information for an application.
      */
 
     /**
@@ -43,7 +43,7 @@ public class ValidationErrorFields {
     private boolean unique;
 
     @SerializedName("subfields")
-    private List<ValidationErrorFields> subfields;
+    private List<ValidationErrorField> subfields;
 
     @SerializedName("links")
     private List<String> links;
@@ -85,10 +85,10 @@ public class ValidationErrorFields {
     public void setUnique(boolean unique) {
         this.unique = unique;
     }
-    public List<ValidationErrorFields> getSubfields() {
+    public List<ValidationErrorField> getSubfields() {
         return subfields;
     }
-    public void setSubfields(List<ValidationErrorFields> subfields) {
+    public void setSubfields(List<ValidationErrorField> subfields) {
         this.subfields = subfields;
     }
     public List<String> getLinks() {
@@ -100,7 +100,7 @@ public class ValidationErrorFields {
 
     @Override
     public String toString() {
-        return "ValidationErrorFields{" +
+        return "ValidationErrorField{" +
                 "fieldId='" + fieldId + '\'' +
                 ", fieldType='" + fieldType + '\'' +
                 ", displayLabel='" + displayLabel + '\'' +

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/ApplicationJsonParsingTest.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/ApplicationJsonParsingTest.java
@@ -1,7 +1,7 @@
 package com.contrast.labs.ai.mcp.contrast;
 
 import com.contrast.labs.ai.mcp.contrast.sdkexstension.data.application.Application;
-import com.contrast.labs.ai.mcp.contrast.sdkexstension.data.application.ValidationErrorField;
+import com.contrast.labs.ai.mcp.contrast.sdkexstension.data.application.Field;
 import com.google.gson.Gson;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -72,7 +72,7 @@ public class ApplicationJsonParsingTest {
         assertEquals(2, application.getMissingRequiredFields().size(), "Should have 2 missing required fields");
 
         // Verify first missing required field
-        ValidationErrorField firstField = application.getMissingRequiredFields().get(0);
+        Field firstField = application.getMissingRequiredFields().get(0);
         assertEquals("29", firstField.getFieldId(), "First field ID should match");
         assertEquals("STRING", firstField.getFieldType(), "First field type should match");
         assertEquals("Custom Name", firstField.getDisplayLabel(), "First field display label should match");
@@ -81,7 +81,7 @@ public class ApplicationJsonParsingTest {
         assertFalse(firstField.isUnique(), "First field should not be unique");
 
         // Verify second missing required field
-        ValidationErrorField secondField = application.getMissingRequiredFields().get(1);
+        Field secondField = application.getMissingRequiredFields().get(1);
         assertEquals("30", secondField.getFieldId(), "Second field ID should match");
         assertEquals("SELECT", secondField.getFieldType(), "Second field type should match");
         assertEquals("Environment", secondField.getDisplayLabel(), "Second field display label should match");

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/ApplicationJsonParsingTest.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/ApplicationJsonParsingTest.java
@@ -1,0 +1,146 @@
+package com.contrast.labs.ai.mcp.contrast;
+
+import com.contrast.labs.ai.mcp.contrast.sdkexstension.data.application.Application;
+import com.contrast.labs.ai.mcp.contrast.sdkexstension.data.application.ValidationErrorField;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class for Application JSON parsing.
+ * Tests the deserialization of Application objects from JSON, specifically
+ * focusing on the missingRequiredFields structure that caused parsing issues.
+ */
+public class ApplicationJsonParsingTest {
+
+    private final Gson gson = new Gson();
+
+    @Test
+    @DisplayName("Test Application JSON parsing with missingRequiredFields as objects")
+    public void testApplicationParsingWithMissingRequiredFieldsObjects() {
+        // JSON that matches what TeamServer API returns
+        String applicationJson = """
+            {
+                "app_id": "test-app-123",
+                "name": "Test Application",
+                "status": "online",
+                "language": "JAVA",
+                "last_seen": 1692467436000,
+                "size": 12345,
+                "missingRequiredFields": [
+                    {
+                        "fieldId": "29",
+                        "fieldType": "STRING",
+                        "displayLabel": "Custom Name",
+                        "agentLabel": "customName",
+                        "required": true,
+                        "unique": false,
+                        "subfields": null,
+                        "links": []
+                    },
+                    {
+                        "fieldId": "30",
+                        "fieldType": "SELECT",
+                        "displayLabel": "Environment",
+                        "agentLabel": "environment",
+                        "required": true,
+                        "unique": false,
+                        "subfields": null,
+                        "links": []
+                    }
+                ],
+                "validationErrorFields": [],
+                "metadataEntities": [],
+                "tags": [],
+                "techs": []
+            }
+            """;
+
+        // This should not throw an exception with the fix
+        Application application = gson.fromJson(applicationJson, Application.class);
+
+        // Verify basic fields
+        assertNotNull(application, "Application should not be null");
+        assertEquals("test-app-123", application.getAppId(), "App ID should match");
+        assertEquals("Test Application", application.getName(), "App name should match");
+        assertEquals("online", application.getStatus(), "Status should match");
+
+        // Verify missingRequiredFields parsing
+        assertNotNull(application.getMissingRequiredFields(), "Missing required fields should not be null");
+        assertEquals(2, application.getMissingRequiredFields().size(), "Should have 2 missing required fields");
+
+        // Verify first missing required field
+        ValidationErrorField firstField = application.getMissingRequiredFields().get(0);
+        assertEquals("29", firstField.getFieldId(), "First field ID should match");
+        assertEquals("STRING", firstField.getFieldType(), "First field type should match");
+        assertEquals("Custom Name", firstField.getDisplayLabel(), "First field display label should match");
+        assertEquals("customName", firstField.getAgentLabel(), "First field agent label should match");
+        assertTrue(firstField.isRequired(), "First field should be required");
+        assertFalse(firstField.isUnique(), "First field should not be unique");
+
+        // Verify second missing required field
+        ValidationErrorField secondField = application.getMissingRequiredFields().get(1);
+        assertEquals("30", secondField.getFieldId(), "Second field ID should match");
+        assertEquals("SELECT", secondField.getFieldType(), "Second field type should match");
+        assertEquals("Environment", secondField.getDisplayLabel(), "Second field display label should match");
+        assertEquals("environment", secondField.getAgentLabel(), "Second field agent label should match");
+        assertTrue(secondField.isRequired(), "Second field should be required");
+        assertFalse(secondField.isUnique(), "Second field should not be unique");
+    }
+
+    @Test
+    @DisplayName("Test Application JSON parsing with empty missingRequiredFields")
+    public void testApplicationParsingWithEmptyMissingRequiredFields() {
+        String applicationJson = """
+            {
+                "app_id": "test-app-456",
+                "name": "Test Application 2",
+                "status": "offline",
+                "language": "JAVASCRIPT",
+                "last_seen": 1692467436000,
+                "size": 54321,
+                "missingRequiredFields": [],
+                "validationErrorFields": [],
+                "metadataEntities": [],
+                "tags": [],
+                "techs": []
+            }
+            """;
+
+        Application application = gson.fromJson(applicationJson, Application.class);
+
+        assertNotNull(application, "Application should not be null");
+        assertEquals("test-app-456", application.getAppId(), "App ID should match");
+        assertNotNull(application.getMissingRequiredFields(), "Missing required fields should not be null");
+        assertTrue(application.getMissingRequiredFields().isEmpty(), "Missing required fields should be empty");
+    }
+
+    @Test
+    @DisplayName("Test Application JSON parsing with null missingRequiredFields")
+    public void testApplicationParsingWithNullMissingRequiredFields() {
+        String applicationJson = """
+            {
+                "app_id": "test-app-789",
+                "name": "Test Application 3",
+                "status": "online",
+                "language": "PYTHON",
+                "last_seen": 1692467436000,
+                "size": 98765,
+                "validationErrorFields": [],
+                "metadataEntities": [],
+                "tags": [],
+                "techs": []
+            }
+            """;
+
+        // Should handle missing missingRequiredFields field gracefully
+        Application application = gson.fromJson(applicationJson, Application.class);
+
+        assertNotNull(application, "Application should not be null");
+        assertEquals("test-app-789", application.getAppId(), "App ID should match");
+        // Field should be null when not present in JSON
+        assertNull(application.getMissingRequiredFields(), "Missing required fields should be null when not in JSON");
+    }
+}


### PR DESCRIPTION
Changes the type of missingRequiredFields from List<String> to List<ValidationErrorFields> to match the actual JSON structure returned by the TeamServer API.

Fixes error: Expected a string but was BEGIN_OBJECT at line 1219 column 34 path $.applications[19].missingRequiredFields[0]

🤖 Generated with [Claude Code](https://claude.ai/code)