### PR TITLE
AIML-391: Add medium/low/note vulnerability count fields to list_application_libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,7 @@ test-plans-archive/
 ### Local tools ###
 .abacus/
 .cass/
+compound-engineering.local.md
 docs/brainstorms/
+docs/superpowers/
+todos/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is an MCP (Model Context Protocol) server for Contrast Security that enables AI agents to access and analyze vulnerability data from Contrast's security platform. It serves as a bridge between Contrast Security's API and AI tools like Claude, enabling automated vulnerability remediation and security analysis.
 
+## Branching Requirements
+
+**All code changes must be made on a feature branch.** Never commit directly to `main`.
+
+Branch naming: `AIML-<ticket-id>-<short-description>` (e.g., `AIML-391-add-medium-low-note-counts`)
+
 ## Build and Development Commands
 
 ### Building the Project

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,9 @@ When creating or modifying MCP tools:
 - `StringUtils.hasText()` or `isNotBlank()` over manual null/empty checks
 - `isBlank()` better than `isEmpty()` (whitespace handling)
 
+**Enums:**
+- Before using a string literal for a known set of values (e.g., severity codes), check for an existing enum in the SDK or codebase — use `MyEnum.VALUE.name()` instead of `"VALUE"`
+
 **Lombok:**
 - `@RequiredArgsConstructor` on `@Service` classes with `final` fields
 - `@Slf4j` for logging (not manual `Logger` declaration)
@@ -244,6 +247,15 @@ This project is tracked in Jira under the **AIML** project. When creating Jira t
   - `Epic` - for large features with many dependent tasks (typically managed by Product Management)
 
 **Access**: Use the Atlassian MCP server to read or write Jira tickets programmatically.
+
+**AIML Project Transition IDs** (use with `transitionJiraIssue`, cloudId: `https://contrast.atlassian.net`):
+- `11` → To Do
+- `21` → In Progress
+- `41` → In Review
+- `51` → Ready to Deploy
+- `61` → Blocked
+- `71` → Backlog
+- `81` → Closed
 
 **IMPORTANT**: When a jira ticket is created for a bead, you must do 2 things:
 1. Update the `external-ref` of the bead to be the jira ticket id

--- a/manual-tests/list-application-libraries-manual-test.md
+++ b/manual-tests/list-application-libraries-manual-test.md
@@ -17,6 +17,9 @@ The `list_application_libraries` tool retrieves all third-party libraries used b
 - `totalVulnerabilities` - Total CVE count
 - `criticalVulnerabilities` - CRITICAL severity CVE count only
 - `highVulnerabilities` - HIGH severity CVE count only (does not include CRITICAL)
+- `mediumVulnerabilities` - MEDIUM severity CVE count
+- `lowVulnerabilities` - LOW severity CVE count
+- `noteVulnerabilities` - NOTE severity CVE count
 - `vulnerabilities` - List of CVE details
 - `grade` - Security grade (A, B, C, D, F)
 - `monthsOutdated` - Months since latest version
@@ -140,7 +143,8 @@ use contrast mcp to list libraries for application 7949c260-6ae9-477f-970a-60d8f
   - Multiple HIGH severity CVEs
 - `criticalVulnerabilities` counts CRITICAL severity CVEs only
 - `highVulnerabilities` counts only HIGH severity CVEs (not CRITICAL)
-- `totalVulnerabilities` = `criticalVulnerabilities` + `highVulnerabilities` + other severities
+- `totalVulnerabilities` = `criticalVulnerabilities` + `highVulnerabilities` + `mediumVulnerabilities` + `lowVulnerabilities` + `noteVulnerabilities`
+- `mediumVulnerabilities`, `lowVulnerabilities`, `noteVulnerabilities` counts available
 
 ---
 
@@ -650,6 +654,9 @@ use contrast mcp to list libraries for application 1d5cdd44-19b9-44df-88b1-ad02c
       "totalVulnerabilities": 6,
       "criticalVulnerabilities": 1,
       "highVulnerabilities": 5,
+      "mediumVulnerabilities": 0,
+      "lowVulnerabilities": 0,
+      "noteVulnerabilities": 1,
       "vulnerabilities": [
         {
           "name": "CVE-2025-31651",

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/LibraryExtended.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/LibraryExtended.java
@@ -15,6 +15,7 @@
  */
 package com.contrast.labs.ai.mcp.contrast.sdkextension.data;
 
+import com.contrastsecurity.http.RuleSeverity;
 import com.contrastsecurity.models.Application;
 import com.contrastsecurity.models.Server;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -101,6 +102,26 @@ public class LibraryExtended {
       return vulnerabilities.size();
     }
     return totalVulnerabilities;
+  }
+
+  private int countBySeverity(RuleSeverity severity) {
+    if (vulnerabilities == null) return 0;
+    return (int)
+        vulnerabilities.stream()
+            .filter(v -> severity.name().equalsIgnoreCase(v.getSeverityCode()))
+            .count();
+  }
+
+  public int getMediumVulnerabilities() {
+    return countBySeverity(RuleSeverity.MEDIUM);
+  }
+
+  public int getLowVulnerabilities() {
+    return countBySeverity(RuleSeverity.LOW);
+  }
+
+  public int getNoteVulnerabilities() {
+    return countBySeverity(RuleSeverity.NOTE);
   }
 
   private boolean custom;

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesTool.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesTool.java
@@ -64,6 +64,9 @@ public class ListApplicationLibrariesTool
           - totalVulnerabilities: Total CVE count
           - criticalVulnerabilities: CRITICAL severity CVE count
           - highVulnerabilities: HIGH severity CVE count (not CRITICAL)
+          - mediumVulnerabilities: MEDIUM severity CVE count
+          - lowVulnerabilities: LOW severity CVE count
+          - noteVulnerabilities: NOTE severity CVE count
           - vulnerabilities: Known CVEs affecting this library version
           - grade: Library security grade (A-F)
 

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/AnonymousLibraryExtendedBuilder.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/AnonymousLibraryExtendedBuilder.java
@@ -47,6 +47,9 @@ public class AnonymousLibraryExtendedBuilder {
   private int totalVulnerabilities = 0;
   private int criticalVulnerabilities = 0;
   private int highVulnerabilities = 0;
+  private int mediumVulnerabilities = 0;
+  private int lowVulnerabilities = 0;
+  private int noteVulnerabilities = 0;
   private boolean custom = false;
   private double libScore = 75.0;
   private int monthsOutdated = 0;
@@ -163,6 +166,21 @@ public class AnonymousLibraryExtendedBuilder {
     return this;
   }
 
+  public AnonymousLibraryExtendedBuilder withMediumVulnerabilities(int mediumVulnerabilities) {
+    this.mediumVulnerabilities = mediumVulnerabilities;
+    return this;
+  }
+
+  public AnonymousLibraryExtendedBuilder withLowVulnerabilities(int lowVulnerabilities) {
+    this.lowVulnerabilities = lowVulnerabilities;
+    return this;
+  }
+
+  public AnonymousLibraryExtendedBuilder withNoteVulnerabilities(int noteVulnerabilities) {
+    this.noteVulnerabilities = noteVulnerabilities;
+    return this;
+  }
+
   public AnonymousLibraryExtendedBuilder withCustom(boolean custom) {
     this.custom = custom;
     return this;
@@ -219,6 +237,9 @@ public class AnonymousLibraryExtendedBuilder {
     lenient().when(library.getTotalVulnerabilities()).thenReturn(totalVulnerabilities);
     lenient().when(library.getCriticalVulnerabilities()).thenReturn(criticalVulnerabilities);
     lenient().when(library.getHighVulnerabilities()).thenReturn(highVulnerabilities);
+    lenient().when(library.getMediumVulnerabilities()).thenReturn(mediumVulnerabilities);
+    lenient().when(library.getLowVulnerabilities()).thenReturn(lowVulnerabilities);
+    lenient().when(library.getNoteVulnerabilities()).thenReturn(noteVulnerabilities);
     lenient().when(library.isCustom()).thenReturn(custom);
     lenient().when(library.getLibScore()).thenReturn(libScore);
     lenient().when(library.getMonthsOutdated()).thenReturn(monthsOutdated);

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/LibraryExtendedTest.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/LibraryExtendedTest.java
@@ -81,4 +81,110 @@ class LibraryExtendedTest {
 
     assertThat(library.getCriticalVulnerabilities()).isEqualTo(5);
   }
+
+  // ---- helper ----
+
+  private LibraryVulnerabilityExtended vuln(String severityCode) {
+    var v = new LibraryVulnerabilityExtended();
+    v.setSeverityCode(severityCode);
+    return v;
+  }
+
+  // ---- getMediumVulnerabilities ----
+
+  @Test
+  void getMediumVulnerabilities_should_return_count_when_medium_vulns_present() {
+    var library = new LibraryExtended();
+    library.setVulnerabilities(List.of(vuln("MEDIUM"), vuln("MEDIUM"), vuln("HIGH")));
+
+    assertThat(library.getMediumVulnerabilities()).isEqualTo(2);
+  }
+
+  @Test
+  void getMediumVulnerabilities_should_return_0_when_vulnerabilities_null() {
+    var library = new LibraryExtended();
+    // vulnerabilities is null by default
+
+    assertThat(library.getMediumVulnerabilities()).isEqualTo(0);
+  }
+
+  @Test
+  void getMediumVulnerabilities_should_return_0_when_vulnerabilities_empty() {
+    var library = new LibraryExtended();
+    library.setVulnerabilities(new ArrayList<>());
+
+    assertThat(library.getMediumVulnerabilities()).isEqualTo(0);
+  }
+
+  // ---- getLowVulnerabilities ----
+
+  @Test
+  void getLowVulnerabilities_should_return_count_when_low_vulns_present() {
+    var library = new LibraryExtended();
+    library.setVulnerabilities(List.of(vuln("LOW"), vuln("HIGH")));
+
+    assertThat(library.getLowVulnerabilities()).isEqualTo(1);
+  }
+
+  @Test
+  void getLowVulnerabilities_should_return_0_when_vulnerabilities_null() {
+    var library = new LibraryExtended();
+
+    assertThat(library.getLowVulnerabilities()).isEqualTo(0);
+  }
+
+  @Test
+  void getLowVulnerabilities_should_return_0_when_vulnerabilities_empty() {
+    var library = new LibraryExtended();
+    library.setVulnerabilities(new ArrayList<>());
+
+    assertThat(library.getLowVulnerabilities()).isEqualTo(0);
+  }
+
+  // ---- getNoteVulnerabilities ----
+
+  @Test
+  void getNoteVulnerabilities_should_return_count_when_note_vulns_present() {
+    var library = new LibraryExtended();
+    library.setVulnerabilities(List.of(vuln("NOTE"), vuln("NOTE"), vuln("NOTE")));
+
+    assertThat(library.getNoteVulnerabilities()).isEqualTo(3);
+  }
+
+  @Test
+  void getNoteVulnerabilities_should_return_0_when_vulnerabilities_null() {
+    var library = new LibraryExtended();
+
+    assertThat(library.getNoteVulnerabilities()).isEqualTo(0);
+  }
+
+  @Test
+  void getNoteVulnerabilities_should_return_0_when_vulnerabilities_empty() {
+    var library = new LibraryExtended();
+    library.setVulnerabilities(new ArrayList<>());
+
+    assertThat(library.getNoteVulnerabilities()).isEqualTo(0);
+  }
+
+  // ---- cross-severity isolation ----
+
+  @Test
+  void get_vulnerability_counts_should_return_only_matching_severity_from_mixed_array() {
+    var library = new LibraryExtended();
+    library.setVulnerabilities(List.of(vuln("MEDIUM"), vuln("MEDIUM"), vuln("LOW"), vuln("NOTE")));
+
+    assertThat(library.getMediumVulnerabilities()).isEqualTo(2);
+    assertThat(library.getLowVulnerabilities()).isEqualTo(1);
+    assertThat(library.getNoteVulnerabilities()).isEqualTo(1);
+  }
+
+  @Test
+  void getLowVulnerabilities_should_return_0_when_absent_from_non_empty_array() {
+    var library = new LibraryExtended();
+    library.setVulnerabilities(List.of(vuln("MEDIUM"), vuln("MEDIUM"), vuln("NOTE")));
+
+    assertThat(library.getMediumVulnerabilities()).isEqualTo(2);
+    assertThat(library.getLowVulnerabilities()).isEqualTo(0);
+    assertThat(library.getNoteVulnerabilities()).isEqualTo(1);
+  }
 }

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolIT.java
@@ -113,6 +113,24 @@ class ListApplicationLibrariesToolIT
     assertThat(firstLib.getFilename()).as("Library filename should not be null").isNotNull();
     assertThat(firstLib.getHash()).as("Library hash should not be null").isNotNull();
     assertThat(firstLib.getClassCount()).as("Class count should be non-negative").isNotNegative();
+
+    // Validate new severity count fields
+    log.info(
+        "First library severity counts — medium: {}, low: {}, note: {}",
+        firstLib.getMediumVulnerabilities(),
+        firstLib.getLowVulnerabilities(),
+        firstLib.getNoteVulnerabilities());
+
+    // Counts must be non-negative
+    assertThat(firstLib.getMediumVulnerabilities())
+        .as("mediumVulnerabilities should be non-negative")
+        .isNotNegative();
+    assertThat(firstLib.getLowVulnerabilities())
+        .as("lowVulnerabilities should be non-negative")
+        .isNotNegative();
+    assertThat(firstLib.getNoteVulnerabilities())
+        .as("noteVulnerabilities should be non-negative")
+        .isNotNegative();
   }
 
   @Test
@@ -187,5 +205,59 @@ class ListApplicationLibrariesToolIT
         page1.items().size(),
         page2.items().size(),
         totalLibraries);
+  }
+
+  @Test
+  void listApplicationLibraries_should_have_consistent_severity_counts() {
+    log.info("\n=== Integration Test: Severity count consistency ===");
+
+    var result = tool.listApplicationLibraries(null, null, testData.appId);
+    assertThat(result.isSuccess()).isTrue();
+
+    // Find a library with vulnerabilities to validate the severityToUse format assumption
+    var vulnLib =
+        result.items().stream()
+            .filter(lib -> lib.getVulnerabilities() != null && !lib.getVulnerabilities().isEmpty())
+            .findFirst();
+
+    if (vulnLib.isEmpty()) {
+      log.info("No libraries with vulnerabilities found — skipping severity format validation");
+      return;
+    }
+
+    var lib = vulnLib.get();
+    // Compare array-computed counts only — avoids mixing API-provided critical/high fields
+    // with array-computed medium/low/note, which would cause spurious failures.
+    int arraySize = lib.getVulnerabilities().size();
+    int sumFromArray =
+        lib.getMediumVulnerabilities()
+            + lib.getLowVulnerabilities()
+            + lib.getNoteVulnerabilities()
+            + (int)
+                lib.getVulnerabilities().stream()
+                    .filter(v -> "CRITICAL".equalsIgnoreCase(v.getSeverityCode()))
+                    .count()
+            + (int)
+                lib.getVulnerabilities().stream()
+                    .filter(v -> "HIGH".equalsIgnoreCase(v.getSeverityCode()))
+                    .count();
+
+    log.info(
+        "Library: {}, vulns array size: {}, sum of severity counts: {}, "
+            + "medium: {}, low: {}, note: {}",
+        lib.getFilename(),
+        arraySize,
+        sumFromArray,
+        lib.getMediumVulnerabilities(),
+        lib.getLowVulnerabilities(),
+        lib.getNoteVulnerabilities());
+
+    assertThat(sumFromArray)
+        .as(
+            "Sum of all severity counts should equal vulnerabilities array size for %s. "
+                + "If medium/low/note are 0 when vulns exist, severityToUse format may differ "
+                + "from expected — check log output for actual values.",
+            lib.getFilename())
+        .isEqualTo(arraySize);
   }
 }


### PR DESCRIPTION
## Why

The `list_application_libraries` tool exposed `criticalVulnerabilities` and `highVulnerabilities` counts, but not medium, low, or note severity counts. Some customers care about MEDIUM severity in their security posture and need these counts to make accurate risk assessments. This change makes the full severity breakdown available to AI agents without any new API calls.

## What

- Added `getMediumVulnerabilities()`, `getLowVulnerabilities()`, `getNoteVulnerabilities()` computed getters to `LibraryExtended`
- Updated `list_application_libraries` `@Tool` description to document the three new fields
- Updated `AnonymousLibraryExtendedBuilder` with matching stubs for test use
- Added 11 new unit tests covering null, empty, count, and cross-severity isolation cases
- Added integration test assertions to validate severity counts and the `severityToUse` format assumption
- Updated manual test documentation

## How

The Contrast API does not provide per-severity counts directly beyond CRITICAL and HIGH — only the raw `vulnerabilities` array (already fetched via `VULNS` expand) is available. The implementation counts entries by `severityCode` using `RuleSeverity` enum values:

```java
private int countBySeverity(RuleSeverity severity) {
    if (vulnerabilities == null) return 0;
    return (int) vulnerabilities.stream()
        .filter(v -> severity.name().equalsIgnoreCase(v.getSeverityCode()))
        .count();
}
```

Key design decisions:
- **No backing fields** — these are purely computed, same pattern as `getTotalVulnerabilities()`
- **`equalsIgnoreCase`** — defensive against API case variation (API expected to return uppercase but not confirmed by fixture)
- **`RuleSeverity` enum** — follows project convention (no string literals for known enum values)
- **Returns 0 for null array** — consistent with `criticalVulnerabilities`/`highVulnerabilities` returning 0 when absent; always safe because `list_application_libraries` always fetches with `VULNS` expand

## Step-by-step Walkthrough

**1. `LibraryExtended.java`** — Core change. Private `countBySeverity(RuleSeverity)` helper + 3 public computed getters, placed after the existing `getTotalVulnerabilities()` method. Import `com.contrastsecurity.http.RuleSeverity` added.

**2. `ListApplicationLibrariesTool.java`** — 3 lines added to the `@Tool` description field list (medium/low/note), no logic changes.

**3. `LibraryExtendedTest.java`** — 11 new unit tests using real `LibraryExtended` objects (not mocks):
   - null array → returns 0 (×3 severities)
   - empty array → returns 0 (×3 severities)
   - matching entries counted correctly (×3 severities)
   - mixed array: verifies each getter counts only its own severity
   - sparse array: verifies a zero count amid non-zero counts

**4. `AnonymousLibraryExtendedBuilder.java`** — 3 new fields (default 0), 3 fluent builder methods, 3 `lenient()` stubs in `build()`. Follows the exact pattern of existing `criticalVulnerabilities`/`highVulnerabilities` stubs.

**5. `ListApplicationLibrariesToolIT.java`** — Two additions:
   - Non-negative assertions + logging for the 3 new getters in the existing `listApplicationLibraries_should_return_libraries` test
   - New test `listApplicationLibraries_should_have_consistent_severity_counts`: finds a library with vulnerabilities and asserts that sum of all per-severity counts (CRITICAL + HIGH + MEDIUM + LOW + NOTE, all computed from the same array) equals the vulnerabilities array size. This validates the `severityToUse` format assumption at runtime.

**6. `manual-tests/list-application-libraries-manual-test.md`** — Key response fields section, Test 5 expected result, and Appendix JSON example updated to include the three new fields.

## Testing

**Unit tests:** 646 tests, 0 failures (`mvn clean test`)

New test coverage added:
- `LibraryExtendedTest` — 11 new tests (null/empty/count per severity, mixed-array isolation, sparse-array isolation)
- `AnonymousLibraryExtendedBuilderTest` — existing builder tests continue to pass with new stubs
- `ListApplicationLibrariesToolTest` — 11 existing tests continue to pass

**Integration tests:** Require Contrast credentials (`.env.integration-test`). The new `listApplicationLibraries_should_have_consistent_severity_counts` test validates the `severityToUse` field format assumption against real API data. If severity counts are unexpectedly all 0 on a library with vulnerabilities, the log output will show actual `severityCode` values for diagnosis.