### PR TITLE
AIML-641: Fix Wiz CLI scan authentication

### DIFF
--- a/.github/workflows/wiz-scan.yaml
+++ b/.github/workflows/wiz-scan.yaml
@@ -22,7 +22,7 @@ jobs:
         run: curl -o wizcli https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64 && chmod +x wizcli
 
       - name: Run Wiz CLI container image scan
-        run: ./wizcli scan container-image contrast-mcp:dev --id "$WIZ_CLIENT_ID" --secret "$WIZ_CLIENT_SECRET" --policies "Block-VM" --csv-output-file="mcp-contrast-wiz-report.zip" --by-policy-hits="BLOCK" --show-ignored-by-grace-period
+        run: ./wizcli scan container-image contrast-mcp:dev --policies "Block-VM" --csv-output-file="mcp-contrast-wiz-report.zip" --by-policy-hits="BLOCK" --show-ignored-by-grace-period
         env:
           WIZ_CLIENT_ID: ${{ secrets.WIZ_CLIENT_ID }}
           WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}

--- a/.github/workflows/wiz-scan.yaml
+++ b/.github/workflows/wiz-scan.yaml
@@ -22,7 +22,7 @@ jobs:
         run: curl -o wizcli https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64 && chmod +x wizcli
 
       - name: Run Wiz CLI container image scan
-        run: ./wizcli scan container-image contrast-mcp:dev --policies "Block-VM" --csv-output-file="mcp-contrast-wiz-report.zip" --by-policy-hits="BLOCK" --show-ignored-by-grace-period
+        run: ./wizcli scan container-image contrast-mcp:dev --client-id "$WIZ_CLIENT_ID" --client-secret "$WIZ_CLIENT_SECRET" --policies "Block-VM" --csv-output-file="mcp-contrast-wiz-report.zip" --by-policy-hits="BLOCK" --show-ignored-by-grace-period
         env:
           WIZ_CLIENT_ID: ${{ secrets.WIZ_CLIENT_ID }}
           WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}

--- a/.github/workflows/wiz-scan.yaml
+++ b/.github/workflows/wiz-scan.yaml
@@ -21,14 +21,11 @@ jobs:
       - name: Download Wiz CLI
         run: curl -o wizcli https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64 && chmod +x wizcli
 
-      - name: Authenticate to Wiz
-        run: ./wizcli auth --id "$WIZ_CLIENT_ID" --secret "$WIZ_CLIENT_SECRET"
+      - name: Run Wiz CLI container image scan
+        run: ./wizcli scan container-image contrast-mcp:dev --id "$WIZ_CLIENT_ID" --secret "$WIZ_CLIENT_SECRET" --policies "Block-VM" --csv-output-file="mcp-contrast-wiz-report.zip" --by-policy-hits="BLOCK" --show-ignored-by-grace-period
         env:
           WIZ_CLIENT_ID: ${{ secrets.WIZ_CLIENT_ID }}
           WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}
-
-      - name: Run Wiz CLI container image scan
-        run: ./wizcli scan container-image contrast-mcp:dev --policies "Block-VM" --csv-output-file="mcp-contrast-wiz-report.zip" --by-policy-hits="BLOCK" --show-ignored-by-grace-period
 
       - name: Capture Wiz Output
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/wiz-scan.yaml
+++ b/.github/workflows/wiz-scan.yaml
@@ -22,7 +22,7 @@ jobs:
         run: curl -o wizcli https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64 && chmod +x wizcli
 
       - name: Run Wiz CLI container image scan
-        run: ./wizcli scan container-image contrast-mcp:dev --client-id "$WIZ_CLIENT_ID" --client-secret "$WIZ_CLIENT_SECRET" --policies "Block-VM" --csv-output-file="mcp-contrast-wiz-report.zip" --by-policy-hits="BLOCK" --show-ignored-by-grace-period
+        run: ./wizcli scan container-image contrast-mcp:dev --client-id "$WIZ_CLIENT_ID" --client-secret "$WIZ_CLIENT_SECRET" --assist-migration --policies "Block-VM" --csv-output-file="mcp-contrast-wiz-report.zip" --by-policy-hits="BLOCK" --show-ignored-by-grace-period
         env:
           WIZ_CLIENT_ID: ${{ secrets.WIZ_CLIENT_ID }}
           WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}


### PR DESCRIPTION
## Why

The Wiz CLI updated its authentication model. The separate `wizcli auth` command is now a no-op — it outputs:

> Auth is done automatically when running a scan, no need to run this command. Please add the auth parameters to the scan command.

As a result, the scan step ran unauthenticated and failed with:

```
ERROR: failed running command: Failed processing auth options: either use device code flow or provide both client ID and secret
```

This was causing the `wiz-scan` CI check to fail on all PRs (e.g. PR #89).

## What

Updated `.github/workflows/wiz-scan.yaml` to remove the separate authentication step and pass `--id` / `--secret` directly to the scan command.

## How

- Removed the "Authenticate to Wiz" step entirely
- Added `--id "$WIZ_CLIENT_ID" --secret "$WIZ_CLIENT_SECRET"` to the `wizcli scan container-image` command
- Moved the `WIZ_CLIENT_ID` / `WIZ_CLIENT_SECRET` env vars to the scan step

## Walkthrough

Only one file changed: `.github/workflows/wiz-scan.yaml`

**Before:**
```yaml
- name: Authenticate to Wiz
  run: ./wizcli auth --id "$WIZ_CLIENT_ID" --secret "$WIZ_CLIENT_SECRET"
  env:
    WIZ_CLIENT_ID: ${{ secrets.WIZ_CLIENT_ID }}
    WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}

- name: Run Wiz CLI container image scan
  run: ./wizcli scan container-image contrast-mcp:dev --policies "Block-VM" ...
```

**After:**
```yaml
- name: Run Wiz CLI container image scan
  run: ./wizcli scan container-image contrast-mcp:dev --id "$WIZ_CLIENT_ID" --secret "$WIZ_CLIENT_SECRET" --policies "Block-VM" ...
  env:
    WIZ_CLIENT_ID: ${{ secrets.WIZ_CLIENT_ID }}
    WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}
```

## Testing

No unit/integration tests applicable — this is a CI workflow change. Verification is via the wiz-scan job passing on this PR.