### PR TITLE
AIML-591: Add Checkstyle for automated style enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ test-plans-archive/
 .abacus/
 .cass/
 compound-engineering.local.md
+decisions/
 docs/brainstorms/
 docs/superpowers/
 todos/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # AI Agent Guidelines
 
-## Issue Tracking with bd (beads)
+## Issue Tracking with br (beads)
 
-**IMPORTANT**: This project uses **bd (beads)** for ALL issue tracking. Do NOT use markdown TODOs, task lists, or other tracking methods.
+**IMPORTANT**: This project uses **br (beads)** for ALL issue tracking. Do NOT use markdown TODOs, task lists, or other tracking methods.
 
-### Why bd?
+### Why br?
 
 - Dependency-aware: Track blockers and relationships between issues
 - Git-friendly: Auto-syncs to JSONL for version control
@@ -15,24 +15,24 @@
 
 **Check for ready work:**
 ```bash
-bd ready --json
+br ready --json
 ```
 
 **Create new issues:**
 ```bash
-bd create "Issue title" -t bug|feature|task -p 0-4 --json
-bd create "Issue title" -p 1 --deps discovered-from:bd-123 --json
+br create "Issue title" -t bug|feature|task -p 0-4 --json
+br create "Issue title" -p 1 --deps discovered-from:br-123 --json
 ```
 
 **Claim and update:**
 ```bash
-bd update bd-42 --status in_progress --json
-bd update bd-42 --priority 1 --json
+br update br-42 --status in_progress --json
+br update br-42 --priority 1 --json
 ```
 
 **Complete work:**
 ```bash
-bd close bd-42 --reason "Completed" --json
+br close br-42 --reason "Completed" --json
 ```
 
 ### Issue Types
@@ -53,12 +53,12 @@ bd close bd-42 --reason "Completed" --json
 
 ### Workflow for AI Agents
 
-1. **Check ready work**: `bd ready` shows unblocked issues
-2. **Claim your task**: `bd update <id> --status in_progress`
+1. **Check ready work**: `br ready` shows unblocked issues
+2. **Claim your task**: `br update <id> --status in_progress`
 3. **Work on it**: Implement, test, document
 4. **Discover new work?** Create linked issue:
-   - `bd create "Found bug" -p 1 --deps discovered-from:<parent-id>`
-5. **Complete**: `bd close <id> --reason "Done"`
+   - `br create "Found bug" -p 1 --deps discovered-from:<parent-id>`
+5. **Complete**: `br close <id> --reason "Done"`
 6. **Commit together**: Always commit the `.beads/issues.jsonl` file together with the code changes so issue state stays in sync with code state
 
 ### Jira Integration
@@ -66,9 +66,9 @@ bd close bd-42 --reason "Completed" --json
 When creating beads that relate to Jira tickets:
 - **Always prepend the Jira issue ID to the bead title**
   - Example: `"AIML-224: Consolidate RouteCoverageService tools"`
-  - If creating Jira ticket for existing bead, update title: `bd update <id> --title="AIML-XXX: ..."`
+  - If creating Jira ticket for existing bead, update title: `br update <id> --title "AIML-XXX: ..."`
 - **Set the `external_ref` to the Jira issue ID**
-  - `bd update <id> --external-ref=AIML-224`
+  - `br update <id> --external-ref AIML-224`
 - This creates bidirectional linkage:
   - Bead tracks local technical work (code, tests, implementation)
   - Jira tracks project management (planning, stakeholders, timeline)
@@ -76,7 +76,7 @@ When creating beads that relate to Jira tickets:
 
 ### Auto-Sync
 
-bd automatically syncs with git:
+br automatically syncs with git:
 - Exports to `.beads/issues.jsonl` after changes (5s debounce)
 - Imports from JSONL when newer (e.g., after `git pull`)
 - No manual export/import needed!
@@ -140,7 +140,7 @@ Multiple AI agents may work in the same repository simultaneously. Follow these 
   - Another agent may be mid-task on a different branch
   - Check `git status` and ask before discarding work
 - ✅ If you encounter merge conflicts, pause and ask for guidance
-- ✅ Use bd to check if other work is `in_progress` before touching shared files
+- ✅ Use br to check if other work is `in_progress` before touching shared files
 - ✅ Commit your work frequently to reduce conflict windows
 
 ### Code Refactoring with ast-grep
@@ -172,10 +172,10 @@ sg run -p 'ReflectionTestUtils.setField($T, "config", config)' \
 
 ### Important Rules
 
-- ✅ Use bd for ALL task tracking
+- ✅ Use br for ALL task tracking
 - ✅ Always use `--json` flag for programmatic use
 - ✅ Link discovered work with `discovered-from` dependencies
-- ✅ Check `bd ready` before asking "what should I work on?"
+- ✅ Check `br ready` before asking "what should I work on?"
 - ✅ Store AI planning docs in `history/` directory
 - ❌ Do NOT create markdown TODO lists
 - ❌ Do NOT use external issue trackers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,8 @@ When creating or modifying MCP tools:
 - `RegexpSinglelineJava` — no fully-qualified class names in code; use imports
 - `MagicNumber` — no raw numeric literals; use named constants (HTTP status codes and -1/0/1/2/100 are ignored)
 
+> ⛔ **PROHIBITED:** Modifying checkstyle rules, Spotless config, or any other linter/constraint config is **expressly forbidden** without explicit user permission. When code fails a check, fix the code — never relax the rule.
+
 **String Validation:**
 - `StringUtils.hasText()` or `isNotBlank()` over manual null/empty checks
 - `isBlank()` better than `isEmpty()` (whitespace handling)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,35 @@ Required environment variables/arguments:
 
 **SDK Source Access:** The Contrast SDK Java source code is available in the parent directory at `/Users/chrisedwards/projects/contrast/contrast-sdk-java`. Reference this when you need to understand SDK types, method signatures, or behavior.
 
+### Working with the Contrast Codebase
+
+All Contrast repos live under `/Users/chrisedwards/projects/contrast/`. Most use `develop` as the default branch (not `main`). Always checkout the default branch and pull before reading.
+
+**Finding code in unknown repos — search before guessing:**
+```bash
+gh search code "ClassName" --owner Contrast-Security-Inc --limit 10
+```
+This immediately shows which repo and path contains any class or symbol. Never guess a repo name and try to clone it — search first.
+
+**Reading files from a repo with local changes blocking pull:**
+```bash
+gh api repos/Contrast-Security-Inc/repo-name/contents/path/to/File.java \
+  --jq '.content' | base64 -d
+```
+When `git pull` fails due to local modifications (and `git stash` is hook-blocked), read files directly from GitHub instead of fighting the local state.
+
+**Reliable default branch detection:**
+```bash
+git remote show origin | grep 'HEAD branch' | awk '{print $NF}'
+```
+
+**Do not use the Write tool for `/tmp` files.** A previous failed Bash attempt may have already created the file, causing Write to fail with "read first". Use Bash heredoc instead:
+```bash
+cat > /tmp/file.txt << 'EOF'
+content here
+EOF
+```
+
 ### Development Patterns
 
 1. **Tool-per-Class**: Each MCP tool is a standalone `@Service` class with `@Tool` annotation, extending `BaseMcpTool` or `BaseGetTool`
@@ -200,7 +229,47 @@ This codebase handles sensitive vulnerability data. The README contains critical
 
 ## Beads Workflow Requirements
 
-This project uses Beads (bd) for issue tracking. See the MCP resource `beads://quickstart` for usage details.
+This project uses Beads (br) for issue tracking. See the MCP resource `beads://quickstart` for usage details.
+
+### Bead Command Reference
+
+Exact syntax for the most common operations — do not guess command names:
+
+```bash
+# Status
+br update <bead-id> --status in_progress
+br close <bead-id> --reason "why it's done"   # --reason/-r is REQUIRED; positional arg fails
+br reopen <bead-id>
+
+# Viewing
+br show <bead-id>
+br ready                                       # list unblocked open beads
+br list
+
+# Comments — 'br comment' does NOT exist; use 'br comments add'
+br comments add <bead-id> --message "short single-line text"
+br comments add <bead-id> -f /tmp/comment.txt  # preferred for multi-line content
+
+# Labels
+br label add <bead-id> -l <label>
+br label remove <bead-id> -l <label>
+
+# Dependencies
+br dep add <dependent> <prerequisite>          # dependent "blocks on" prerequisite
+br dep add <child> <parent> --type parent-child
+```
+
+**Multi-line comments — always use a temp file:**
+Shell strings containing backticks, `$()`, or special characters are interpreted by the shell.
+Write content to a temp file with a heredoc, then pass `-f`:
+```bash
+cat > /tmp/comment.txt << 'EOF'
+## My comment with `code`, **markdown**, and special chars
+Content here is never shell-interpreted because of the quoted EOF delimiter.
+EOF
+br comments add <bead-id> -f /tmp/comment.txt
+```
+Never use `$()` substitution to pass multi-line comment text — use `-f` instead.
 
 ### Bead Status Management
 
@@ -208,14 +277,14 @@ This project uses Beads (bd) for issue tracking. See the MCP resource `beads://q
 
 1. **When starting work on a bead**: Immediately set status to `in_progress`
    ```
-   bd update <bead-id> status=in_progress
+   br update <bead-id> --status in_progress
    ```
 
 2. **While working**: Keep the bead `in_progress` until all work is complete, tested, and ready to close
 
 3. **When work is complete**: Close the bead only after all acceptance criteria are met
    ```
-   bd close <bead-id>
+   br close <bead-id> --reason "brief close reason"
    ```
 
 **Status lifecycle:**
@@ -240,8 +309,8 @@ This project uses Beads (bd) for issue tracking. See the MCP resource `beads://q
 2. **Update the bead** - If changes are needed based on review, update the bead description with the approved approach
 3. **Update labels:**
    ```bash
-   bd label remove <bead-id> needs-human-review
-   bd label add <bead-id> human-reviewed
+   br label remove <bead-id> -l needs-human-review
+   br label add <bead-id> -l human-reviewed
    ```
 4. **Proceed to next bead** - Continue reviewing remaining beads with `needs-human-review` label
 
@@ -335,9 +404,9 @@ Promoting Stacked PR (after base PR merges):
    - Record the branch name in the bead (so it's easily found later)
    - **If this is a stacked branch** (based on another PR branch):
      - Label the bead with `stacked-branch`
-     - Create blocks dependency: `bd dep add <new-bead-id> <base-bead-id> --type blocks`
+     - Create blocks dependency: `br dep add <new-bead-id> <base-bead-id> --type blocks`
        - This represents that the base bead "blocks" the new bead from being merged
-       - Example: If AIML-230 is stacked on AIML-228, use `bd dep add mcp-uuv mcp-9kr --type blocks`
+       - Example: If AIML-230 is stacked on AIML-228, use `br dep add mcp-uuv mcp-9kr --type blocks`
 
 **3. Update Jira (if applicable):**
    - If bead has a linked Jira ticket:
@@ -354,16 +423,16 @@ Promoting Stacked PR (after base PR merges):
 
 **When creating new beads from a Jira-linked bead:**
 - Ask user if the new bead should be a child of the Jira-linked bead
-- If yes, establish parent-child relationship using `bd dep add <child> <parent>` with `parent-child` dependency type
+- If yes, establish parent-child relationship using `br dep add <child> <parent>` with `parent-child` dependency type
 - Child beads work on the same branch as their parent
   
 ### Managing Bead Dependencies
 
-**Command syntax:** `bd dep add <dependent-task> <prerequisite-task>`
+**Command syntax:** `br dep add <dependent-task> <prerequisite-task>`
 
-Example: If B must be done after A completes, use `bd dep add B A` (not `bd dep add A B`).
+Example: If B must be done after A completes, use `br dep add B A` (not `br dep add A B`).
 
-Verify with `bd show <task-id>` - dependent tasks show "Depends on", prerequisites show "Blocks".
+Verify with `br show <task-id>` - dependent tasks show "Depends on", prerequisites show "Blocks".
 
 NOTE: This is not for parent-child dependencies, these are blocks dependencies. 
 **IMPORTANT** If you are asked to add a bead as a child or with phrasing that implies a parent-child relationship, ensure you add the dependency of type parent-child. The default is a blocks type.
@@ -720,7 +789,7 @@ This workflow completes the development cycle by closing the bead and updating t
 
 **1. Close the bead:**
    ```bash
-   bd close <bead-id>
+   br close <bead-id>
    ```
    - Provide a brief reason mentioning the merged PR
    - Example: "PR #28 merged to main. Successfully added appID and appName fields to VulnLight record."
@@ -789,14 +858,14 @@ This workflow is for ending the current session while preserving all state so wo
 **When a bead is completed (closed or moved to review), proactively suggest what to work on next:**
 
 **1. Check for parent bead context:**
-   - If the completed bead is a child bead, check the parent bead using `bd show <parent-bead-id>`
+   - If the completed bead is a child bead, check the parent bead using `br show <parent-bead-id>`
    - Look in the parent bead's `notes` field for recommended execution order or priority guidance
    - Example: "Recommended execution order for child beads: 1. mcp-981, 2. mcp-dw1, 3. mcp-j1i..."
 
 **2. Identify next bead options:**
    - Look at other child beads of the same parent (siblings)
    - Check for beads that are `status=open` and have no blocking dependencies
-   - Use `bd ready` to find beads ready to work on
+   - Use `br ready` to find beads ready to work on
    - Consider priority levels (Priority 1 > Priority 2 > Priority 3)
 
 **3. Present recommendations to the user:**
@@ -828,7 +897,7 @@ Would you like to work on **mcp-dw1** next, or would you prefer a different one?
 
 **When there are no more child beads:**
 - If all child beads are closed and parent is complete, suggest moving parent to review
-- If this was a standalone bead, suggest using `bd ready` to find next available work
+- If this was a standalone bead, suggest using `br ready` to find next available work
 - Check for any blocked beads that might now be unblocked
 
 @SECURITY.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,11 @@ When creating or modifying MCP tools:
 - No fully-qualified class names - use imports
 - `isEmpty()` not `size() > 0` for collections
 
+**Checkstyle:** Three rules enforced at `error` severity (run in `validate` phase via `make check`):
+- `AvoidStarImport` — no wildcard imports
+- `RegexpSinglelineJava` — no fully-qualified class names in code; use imports
+- `MagicNumber` — no raw numeric literals; use named constants (HTTP status codes and -1/0/1/2/100 are ignored)
+
 **String Validation:**
 - `StringUtils.hasText()` or `isNotBlank()` over manual null/empty checks
 - `isBlank()` better than `isEmpty()` (whitespace handling)

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ build: ## Build the project (compile + package)
 
 ## Check targets (formatting and static analysis)
 
-check: ## Run format check (quiet output)
+check: ## Run format and static analysis checks (quiet output)
 	@if [ -n "$$VERBOSE" ]; then \
-		$(MVN) spotless:check; \
+		$(MVN) validate; \
 	else \
 		$(MAKE) check-quiet; \
 	fi
@@ -24,7 +24,7 @@ check: ## Run format check (quiet output)
 check-quiet:
 	@. ./hack/run_silent.sh && print_main_header "Running Checks"
 	@. ./hack/run_silent.sh && print_header "mcp-contrast" "Static analysis"
-	@. ./hack/run_silent.sh && run_with_quiet "Format check passed" "$(MVN) spotless:check"
+	@. ./hack/run_silent.sh && run_with_quiet "All checks passed" "$(MVN) validate"
 
 check-verbose: ## Run checks with verbose output
 	@VERBOSE=1 $(MAKE) check

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -4,6 +4,8 @@
   "https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="Checker">
   <module name="TreeWalker">
-    <!-- Rules added incrementally in subsequent tasks -->
+    <module name="AvoidStarImport">
+      <property name="severity" value="error"/>
+    </module>
   </module>
 </module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -15,7 +15,7 @@
     </module>
     <module name="MagicNumber">
       <property name="severity" value="error"/>
-      <property name="ignoreNumbers" value="-1, 0, 1, 2, 8, 60, 100, 401, 403, 404, 429, 500, 502, 503"/>
+      <property name="ignoreNumbers" value="-1, 0, 1, 2, 100, 401, 403, 404, 429, 500, 502, 503"/>
       <property name="ignoreHashCodeMethod" value="true"/>
       <property name="ignoreAnnotation" value="true"/>
       <property name="ignoreFieldDeclaration" value="true"/>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -7,5 +7,11 @@
     <module name="AvoidStarImport">
       <property name="severity" value="error"/>
     </module>
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="^\s+com\.[a-z]+\.[a-zA-Z.]+\.[A-Z][a-zA-Z]+\s"/>
+      <property name="message" value="Use import instead of fully-qualified class name"/>
+      <property name="severity" value="error"/>
+      <property name="ignoreComments" value="true"/>
+    </module>
   </module>
 </module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+  "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <!-- Rules added incrementally in subsequent tasks -->
+  </module>
+</module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -13,5 +13,14 @@
       <property name="severity" value="error"/>
       <property name="ignoreComments" value="true"/>
     </module>
+    <module name="MagicNumber">
+      <property name="severity" value="error"/>
+      <property name="ignoreNumbers" value="-1, 0, 1, 2, 8, 60, 100, 401, 403, 404, 429, 500, 502, 503"/>
+      <property name="ignoreHashCodeMethod" value="true"/>
+      <property name="ignoreAnnotation" value="true"/>
+      <property name="ignoreFieldDeclaration" value="true"/>
+      <property name="constantWaiverParentToken"
+                value="TYPECAST, METHOD_CALL, EXPR, ARRAY_INIT, UNARY_MINUS, UNARY_PLUS, ELIST, STAR, ASSIGN, PLUS, MINUS, DIV, LITERAL_NEW"/>
+    </module>
   </module>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,8 @@
 		<maven-failsafe-plugin.version>3.5.3</maven-failsafe-plugin.version>
 		<spotless-maven-plugin.version>2.43.0</spotless-maven-plugin.version>
 		<google-java-format.version>1.26.0</google-java-format.version>
+		<maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
+		<checkstyle.version>10.12.5</checkstyle.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -211,6 +213,33 @@
 							<goal>check</goal>
 						</goals>
 						<phase>validate</phase>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>${maven-checkstyle-plugin.version}</version>
+				<dependencies>
+					<dependency>
+						<groupId>com.puppycrawl.tools</groupId>
+						<artifactId>checkstyle</artifactId>
+						<version>${checkstyle.version}</version>
+					</dependency>
+				</dependencies>
+				<configuration>
+					<configLocation>checkstyle.xml</configLocation>
+					<consoleOutput>true</consoleOutput>
+					<failsOnError>true</failsOnError>
+					<linkXRef>false</linkXRef>
+				</configuration>
+				<executions>
+					<execution>
+						<id>validate</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
 					</execution>
 				</executions>
 			</plugin>

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/McpContrastApplication.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/McpContrastApplication.java
@@ -47,6 +47,7 @@ import org.springframework.context.annotation.Bean;
 public class McpContrastApplication {
 
   private static final Logger logger = LoggerFactory.getLogger(McpContrastApplication.class);
+  private static final int SEPARATOR_WIDTH = 60;
 
   public static void main(String[] args) {
     SpringApplication.run(McpContrastApplication.class, args);
@@ -57,13 +58,13 @@ public class McpContrastApplication {
       org.springframework.beans.factory.ObjectProvider<BuildProperties> buildPropertiesProvider) {
     return args -> {
       BuildProperties buildProperties = buildPropertiesProvider.getIfAvailable();
-      logger.info("=".repeat(60));
+      logger.info("=".repeat(SEPARATOR_WIDTH));
       if (buildProperties != null) {
         logger.info("Contrast MCP Server - Version {}", buildProperties.getVersion());
       } else {
         logger.info("Contrast MCP Server - Version information not available");
       }
-      logger.info("=".repeat(60));
+      logger.info("=".repeat(SEPARATOR_WIDTH));
     };
   }
 

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/result/VulnLight.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/result/VulnLight.java
@@ -19,8 +19,8 @@ import com.contrastsecurity.models.SessionMetadata;
 import java.util.List;
 
 /**
- * Lightweight vulnerability record for listing operations. Contains essential vulnerability
- * information including application correlation data.
+ * Lightweight vulnerability record for listing and search operations. Contains essential
+ * vulnerability information including application correlation data.
  *
  * @param title Vulnerability title/description
  * @param type Vulnerability type/rule name (e.g., "sql-injection", "xss-reflected")
@@ -51,4 +51,3 @@ public record VulnLight(
     String closedAt,
     List<String> environments,
     List<String> tags) {}
-// test

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/result/VulnLight.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/result/VulnLight.java
@@ -51,3 +51,4 @@ public record VulnLight(
     String closedAt,
     List<String> environments,
     List<String> tags) {}
+// test

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtension.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtension.java
@@ -29,6 +29,7 @@ import com.contrast.labs.ai.mcp.contrast.sdkextension.data.routecoverage.RouteCo
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.sca.LibraryObservation;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.sca.LibraryObservationsResponse;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.sessionmetadata.SessionMetadataResponse;
+import com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants;
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.HttpMethod;
 import com.contrastsecurity.http.LibraryFilterForm;
@@ -59,7 +60,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class SDKExtension {
 
-  private static final int DEFAULT_LIBRARY_OBS_PAGE_SIZE = 25;
   private static final int DEFAULT_ATTACKS_LIMIT = 1000;
 
   private final ContrastSDK contrastSDK;
@@ -145,7 +145,7 @@ public class SDKExtension {
       String organizationId, String applicationId, String libraryId, int pageSize)
       throws IOException, UnauthorizedException {
     if (pageSize <= 0) {
-      pageSize = DEFAULT_LIBRARY_OBS_PAGE_SIZE;
+      pageSize = ValidationConstants.DEFAULT_LIBRARY_OBS_PAGE_SIZE;
     }
 
     var allObservations = new ArrayList<LibraryObservation>();
@@ -178,7 +178,10 @@ public class SDKExtension {
       String organizationId, String applicationId, String libraryId)
       throws IOException, UnauthorizedException {
     return getLibraryObservations(
-        organizationId, applicationId, libraryId, DEFAULT_LIBRARY_OBS_PAGE_SIZE);
+        organizationId,
+        applicationId,
+        libraryId,
+        ValidationConstants.DEFAULT_LIBRARY_OBS_PAGE_SIZE);
   }
 
   /** Builds URL for retrieving library observations */

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtension.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtension.java
@@ -59,6 +59,9 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class SDKExtension {
 
+  private static final int DEFAULT_LIBRARY_OBS_PAGE_SIZE = 25;
+  private static final int DEFAULT_ATTACKS_LIMIT = 1000;
+
   private final ContrastSDK contrastSDK;
   private final UrlBuilder urlBuilder;
   private final Gson gson;
@@ -142,7 +145,7 @@ public class SDKExtension {
       String organizationId, String applicationId, String libraryId, int pageSize)
       throws IOException, UnauthorizedException {
     if (pageSize <= 0) {
-      pageSize = 25; // Default page size
+      pageSize = DEFAULT_LIBRARY_OBS_PAGE_SIZE;
     }
 
     var allObservations = new ArrayList<LibraryObservation>();
@@ -174,7 +177,8 @@ public class SDKExtension {
   public List<LibraryObservation> getLibraryObservations(
       String organizationId, String applicationId, String libraryId)
       throws IOException, UnauthorizedException {
-    return getLibraryObservations(organizationId, applicationId, libraryId, 25);
+    return getLibraryObservations(
+        organizationId, applicationId, libraryId, DEFAULT_LIBRARY_OBS_PAGE_SIZE);
   }
 
   /** Builds URL for retrieving library observations */
@@ -502,7 +506,7 @@ public class SDKExtension {
       throws IOException, UnauthorizedException {
 
     // Set default values if not provided
-    if (limit == null) limit = 1000;
+    if (limit == null) limit = DEFAULT_ATTACKS_LIMIT;
     if (offset == null) offset = 0;
     if (sort == null) sort = "-startTime";
     if (filterBody == null) filterBody = AttacksFilterBody.builder().build();

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKHelper.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKHelper.java
@@ -44,6 +44,11 @@ public class SDKHelper {
   private static final String MCP_SERVER_NAME = "contrast-mcp";
   private static final String HTTPS_PROTOCOL = "https://";
   private static final String HTTP_PROTOCOL = "http://";
+  private static final int API_MAX_PAGE_SIZE = 50;
+  private static final int DEFAULT_LIBRARY_OBS_PAGE_SIZE = 25;
+  private static final int DEFAULT_HTTP_PROXY_PORT = 80;
+  private static final long CACHE_MAX_SIZE = 500000;
+  private static final long CACHE_EXPIRY_MINUTES = 10;
   private static Environment environment;
 
   @Autowired
@@ -52,10 +57,16 @@ public class SDKHelper {
   }
 
   private static final Cache<String, List<LibraryExtended>> libraryCache =
-      CacheBuilder.newBuilder().maximumSize(500000).expireAfterWrite(10, TimeUnit.MINUTES).build();
+      CacheBuilder.newBuilder()
+          .maximumSize(CACHE_MAX_SIZE)
+          .expireAfterWrite(CACHE_EXPIRY_MINUTES, TimeUnit.MINUTES)
+          .build();
 
   private static final Cache<String, List<LibraryObservation>> libraryObservationsCache =
-      CacheBuilder.newBuilder().maximumSize(500000).expireAfterWrite(10, TimeUnit.MINUTES).build();
+      CacheBuilder.newBuilder()
+          .maximumSize(CACHE_MAX_SIZE)
+          .expireAfterWrite(CACHE_EXPIRY_MINUTES, TimeUnit.MINUTES)
+          .build();
 
   /**
    * Retrieves a single page of libraries for an application with server-side pagination. Unlike
@@ -74,7 +85,7 @@ public class SDKHelper {
       throws IOException {
 
     // API enforces max limit of 50
-    int effectiveLimit = Math.min(limit, 50);
+    int effectiveLimit = Math.min(limit, API_MAX_PAGE_SIZE);
 
     var filterForm = new LibraryFilterForm();
     filterForm.setLimit(effectiveLimit);
@@ -93,7 +104,7 @@ public class SDKHelper {
       return cachedLibraries;
     }
     log.info("Cache miss for appId: {}, fetching libraries from SDK", appId);
-    int libraryCallSize = 50;
+    int libraryCallSize = API_MAX_PAGE_SIZE;
     var filterForm = new LibraryFilterForm();
     filterForm.setLimit(libraryCallSize);
     filterForm.setExpand(EnumSet.of(LibraryFilterForm.LibrariesExpandValues.VULNS));
@@ -162,7 +173,8 @@ public class SDKHelper {
   public static List<LibraryObservation> getLibraryObservationsWithCache(
       String libraryId, String appId, String orgId, SDKExtension extendedSDK)
       throws IOException, UnauthorizedException {
-    return getLibraryObservationsWithCache(libraryId, appId, orgId, 25, extendedSDK);
+    return getLibraryObservationsWithCache(
+        libraryId, appId, orgId, DEFAULT_LIBRARY_OBS_PAGE_SIZE, extendedSDK);
   }
 
   /**
@@ -239,7 +251,10 @@ public class SDKHelper {
             .withUserAgentProduct(UserAgentProduct.of(MCP_SERVER_NAME, mcpVersion));
 
     if (StringUtils.hasText(httpProxyHost)) {
-      int port = StringUtils.hasText(httpProxyPort) ? Integer.parseInt(httpProxyPort) : 80;
+      int port =
+          StringUtils.hasText(httpProxyPort)
+              ? Integer.parseInt(httpProxyPort)
+              : DEFAULT_HTTP_PROXY_PORT;
       log.debug("Configuring HTTP proxy: {}:{}", httpProxyHost, port);
 
       var proxy =

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKHelper.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKHelper.java
@@ -19,6 +19,7 @@ import com.contrast.labs.ai.mcp.contrast.sdkextension.data.LibrariesExtended;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.LibraryExtended;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.Application;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.sca.LibraryObservation;
+import com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants;
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.LibraryFilterForm;
 import com.contrastsecurity.sdk.ContrastSDK;
@@ -44,8 +45,6 @@ public class SDKHelper {
   private static final String MCP_SERVER_NAME = "contrast-mcp";
   private static final String HTTPS_PROTOCOL = "https://";
   private static final String HTTP_PROTOCOL = "http://";
-  private static final int API_MAX_PAGE_SIZE = 50;
-  private static final int DEFAULT_LIBRARY_OBS_PAGE_SIZE = 25;
   private static final int DEFAULT_HTTP_PROXY_PORT = 80;
   private static final long CACHE_MAX_SIZE = 500000;
   private static final long CACHE_EXPIRY_MINUTES = 10;
@@ -85,7 +84,7 @@ public class SDKHelper {
       throws IOException {
 
     // API enforces max limit of 50
-    int effectiveLimit = Math.min(limit, API_MAX_PAGE_SIZE);
+    int effectiveLimit = Math.min(limit, ValidationConstants.API_MAX_PAGE_SIZE);
 
     var filterForm = new LibraryFilterForm();
     filterForm.setLimit(effectiveLimit);
@@ -104,7 +103,7 @@ public class SDKHelper {
       return cachedLibraries;
     }
     log.info("Cache miss for appId: {}, fetching libraries from SDK", appId);
-    int libraryCallSize = API_MAX_PAGE_SIZE;
+    int libraryCallSize = ValidationConstants.API_MAX_PAGE_SIZE;
     var filterForm = new LibraryFilterForm();
     filterForm.setLimit(libraryCallSize);
     filterForm.setExpand(EnumSet.of(LibraryFilterForm.LibrariesExpandValues.VULNS));
@@ -174,7 +173,7 @@ public class SDKHelper {
       String libraryId, String appId, String orgId, SDKExtension extendedSDK)
       throws IOException, UnauthorizedException {
     return getLibraryObservationsWithCache(
-        libraryId, appId, orgId, DEFAULT_LIBRARY_OBS_PAGE_SIZE, extendedSDK);
+        libraryId, appId, orgId, ValidationConstants.DEFAULT_LIBRARY_OBS_PAGE_SIZE, extendedSDK);
   }
 
   /**

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
@@ -47,6 +47,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public abstract class PaginatedTool<P extends ToolParams, R> extends BaseTool {
 
+  private static final int REQUEST_ID_PREFIX_LENGTH = 8;
+
   /**
    * Returns the maximum page size for this tool. Default is 100. Override in subclasses to set a
    * lower limit (e.g., when API has stricter limits).
@@ -69,7 +71,7 @@ public abstract class PaginatedTool<P extends ToolParams, R> extends BaseTool {
   protected final PaginatedToolResponse<R> executePipeline(
       Integer page, Integer pageSize, Supplier<P> paramsSupplier) {
 
-    var requestId = UUID.randomUUID().toString().substring(0, 8);
+    var requestId = UUID.randomUUID().toString().substring(0, REQUEST_ID_PREFIX_LENGTH);
     long startTime = System.currentTimeMillis();
 
     // 1. Parse pagination FIRST with tool-specific max (always succeeds with warnings)

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
@@ -44,6 +44,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public abstract class SingleTool<P extends ToolParams, R> extends BaseTool {
 
+  private static final int REQUEST_ID_PREFIX_LENGTH = 8;
+
   /**
    * Template method - defines the mandatory processing pipeline for single-item retrieval.
    * Subclasses implement doExecute() for tool-specific logic. This method is FINAL to enforce
@@ -53,7 +55,7 @@ public abstract class SingleTool<P extends ToolParams, R> extends BaseTool {
    * @return tool response with item or errors
    */
   protected final SingleToolResponse<R> executePipeline(Supplier<P> paramsSupplier) {
-    var requestId = UUID.randomUUID().toString().substring(0, 8);
+    var requestId = UUID.randomUUID().toString().substring(0, REQUEST_ID_PREFIX_LENGTH);
     long startTime = System.currentTimeMillis();
 
     // 1. Parse tool-specific params (collects all errors)

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesTool.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesTool.java
@@ -22,6 +22,7 @@ import com.contrast.labs.ai.mcp.contrast.tool.base.PaginatedTool;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginatedToolResponse;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginationParams;
 import com.contrast.labs.ai.mcp.contrast.tool.library.params.ListApplicationLibrariesParams;
+import com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.tool.annotation.Tool;
@@ -40,11 +41,9 @@ import org.springframework.stereotype.Service;
 public class ListApplicationLibrariesTool
     extends PaginatedTool<ListApplicationLibrariesParams, LibraryExtended> {
 
-  private static final int API_MAX_PAGE_SIZE = 50;
-
   @Override
   protected int getMaxPageSize() {
-    return API_MAX_PAGE_SIZE;
+    return ValidationConstants.API_MAX_PAGE_SIZE;
   }
 
   @Tool(

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ValidationConstants.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ValidationConstants.java
@@ -30,6 +30,9 @@ public final class ValidationConstants {
   /** Maximum allowed page size. */
   public static final int MAX_PAGE_SIZE = 100;
 
+  /** Maximum page size enforced by the Contrast API for library endpoints. */
+  public static final int API_MAX_PAGE_SIZE = 50;
+
   /** Minimum page number (1-indexed). */
   public static final int MIN_PAGE = 1;
 

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ValidationConstants.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ValidationConstants.java
@@ -33,6 +33,9 @@ public final class ValidationConstants {
   /** Maximum page size enforced by the Contrast API for library endpoints. */
   public static final int API_MAX_PAGE_SIZE = 50;
 
+  /** Default page size for library observations endpoint. */
+  public static final int DEFAULT_LIBRARY_OBS_PAGE_SIZE = 25;
+
   /** Minimum page number (1-indexed). */
   public static final int MIN_PAGE = 1;
 

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
@@ -24,6 +24,7 @@ import com.contrast.labs.ai.mcp.contrast.sdkextension.data.LibraryExtended;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.sca.LibraryObservation;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleTool;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleToolResponse;
+import com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants;
 import com.contrast.labs.ai.mcp.contrast.tool.vulnerability.params.GetVulnerabilityParams;
 import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.models.EventResource;
@@ -224,7 +225,8 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
     var lobs = new ArrayList<LibraryLibraryObservation>();
     for (LibraryExtended lib : libs) {
       var observations =
-          SDKHelper.getLibraryObservationsWithCache(lib.getHash(), appId, orgId, 50, extendedSDK);
+          SDKHelper.getLibraryObservationsWithCache(
+              lib.getHash(), appId, orgId, ValidationConstants.API_MAX_PAGE_SIZE, extendedSDK);
       lobs.add(new LibraryLibraryObservation(lib, observations));
     }
     return lobs;

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
@@ -28,6 +28,7 @@ import com.contrast.labs.ai.mcp.contrast.tool.vulnerability.params.GetVulnerabil
 import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.models.EventResource;
 import com.contrastsecurity.models.Stacktrace;
+import com.contrastsecurity.sdk.ContrastSDK;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -112,11 +113,7 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
   }
 
   private VulnerabilityContext buildVulnerabilityContext(
-      com.contrastsecurity.sdk.ContrastSDK sdk,
-      String vulnId,
-      String appId,
-      String orgId,
-      List<String> warnings) {
+      ContrastSDK sdk, String vulnId, String appId, String orgId, List<String> warnings) {
 
     String recommendationText = null;
     String httpRequestText = null;
@@ -162,7 +159,7 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
   }
 
   private void buildStackTraceAndLibraryData(
-      com.contrastsecurity.sdk.ContrastSDK sdk,
+      ContrastSDK sdk,
       String vulnId,
       String appId,
       String orgId,


### PR DESCRIPTION
## Summary
- Adds Checkstyle to the Maven `validate` phase with three rules enforced at `error` severity: no wildcard imports, no fully-qualified class names, no magic numbers
- Fixes all pre-existing violations across the codebase (constants extracted, FQCNs replaced with imports)
- Updates `make check` to run both Spotless and Checkstyle, and documents rules in CLAUDE.md with an explicit prohibition on relaxing them

## Why This Change Exists

Analysis of historical PR review comments found that ~70% were style/convention issues that could have been caught automatically. Reviewers were spending time flagging wildcard imports, fully-qualified class names used inline, and raw numeric literals — all of which are mechanical checks that belong in CI, not code review.

The goal is to move style enforcement from expensive, inconsistent human review to cheap, consistent automated checks. This frees reviewers to focus on logic, architecture, and correctness.

## Approach We Chose

Three Checkstyle rules were selected based on the most common PR comment themes:

1. **`AvoidStarImport`** — Wildcard imports were flagged repeatedly (e.g., PR #30). No current violations; the rule prevents regressions.
2. **`RegexpSinglelineJava`** — Fully-qualified class names in code were flagged in PRs #27 and #39. Fixed in `GetVulnerabilityTool` where `com.contrastsecurity.sdk.ContrastSDK` was used inline in two private method signatures.
3. **`MagicNumber`** — Raw numeric literals were flagged in PRs #38 and #39. Fixed by extracting constants throughout the codebase and centralizing shared values in `ValidationConstants`.

Checkstyle runs in the `validate` phase so it fires before compilation, giving immediate feedback. `make check` was updated to invoke `mvn validate` rather than just `spotless:check`, so both Spotless and Checkstyle run together.

## Outcome of This Change

- `make check` now enforces style automatically — no configuration required from developers
- All three acceptance criteria from AIML-591 are met
- Zero violations in the current codebase; new violations will fail the build at `validate` phase
- CLAUDE.md documents the rules and explicitly prohibits relaxing them without permission, so AI agents cannot work around failing checks

## Reviewer Guide

1. Start with `checkstyle.xml` — this is the single source of truth for all rules
2. Review `pom.xml` for plugin configuration and dependency pinning
3. Review `Makefile` to confirm `make check` now runs `mvn validate`
4. Scan the code changes — they are all mechanical (extract constant, replace FQCN with import)
5. Review `ValidationConstants.java` to see where constants landed
6. Review `CLAUDE.md` for the documented rules and the prohibition banner

## Logic Walkthrough

### 1. Checkstyle configuration (`checkstyle.xml`)
Three rules, all `error` severity. `MagicNumber` ignores HTTP status codes (`401`, `403`, `404`, `429`, `500`, `502`, `503`) and common small integers (`-1`, `0`, `1`, `2`, `100`) to avoid false positives. `ignoreFieldDeclaration=true` allows constants to be declared without triggering the rule on themselves. `RegexpSinglelineJava` matches the pattern `^\s+com.[a-z]+.[...].UpperCase` to catch FQCNs used as method parameter types or variable types.

### 2. Build integration (`pom.xml`, `Makefile`)
Plugin bound to `validate` phase, which runs before `compile`. This means `mvn test` and `mvn verify` also run the check — Checkstyle is inescapable. `make check` calls `mvn validate` so developers get both Spotless and Checkstyle in a single command.

### 3. Constants consolidation (`ValidationConstants.java`)
Two new constants added:
- `API_MAX_PAGE_SIZE = 50` — the Contrast API's hard maximum for library endpoints, previously duplicated as a local constant in `ListApplicationLibrariesTool` and hardcoded in `SDKHelper` and `SDKExtension`
- `DEFAULT_LIBRARY_OBS_PAGE_SIZE = 25` — default page size for library observations, previously hardcoded in three places

### 4. Code fixes — FQCN violations (`GetVulnerabilityTool.java`)
Added `import com.contrastsecurity.sdk.ContrastSDK` and replaced two inline FQCNs in private method signatures with the simple name.

### 5. Code fixes — magic number violations
| File | Extracted constant | Value |
|------|--------------------|-------|
| `McpContrastApplication` | `SEPARATOR_WIDTH` | `60` |
| `SDKExtension` | `DEFAULT_ATTACKS_LIMIT` | `1000` |
| `SDKHelper` | `DEFAULT_HTTP_PROXY_PORT` | `80` |
| `SDKHelper` | `CACHE_MAX_SIZE` | `500000` |
| `SDKHelper` | `CACHE_EXPIRY_MINUTES` | `10` |
| `PaginatedTool` | `REQUEST_ID_PREFIX_LENGTH` | `8` |
| `SingleTool` | `REQUEST_ID_PREFIX_LENGTH` | `8` |

### 6. Documentation
- `CLAUDE.md`: Adds a **Checkstyle** section listing the three rules, and a ⛔ banner prohibiting relaxing linter rules without explicit permission
- `AGENTS.md`: Updates all `bd` references to `br` (the beads CLI was renamed)
- `.gitignore`: Adds `decisions/` directory

## What Changed

### Build configuration
- `checkstyle.xml` — new Checkstyle config with three enforced rules
- `pom.xml` — adds `maven-checkstyle-plugin` (3.3.1) + `checkstyle` (10.12.5) dependencies, bound to `validate` phase
- `Makefile` — `make check` now runs `mvn validate` instead of `spotless:check`

### Constants centralization
- `tool/validation/ValidationConstants.java` — adds `API_MAX_PAGE_SIZE = 50` and `DEFAULT_LIBRARY_OBS_PAGE_SIZE = 25`
- `tool/library/ListApplicationLibrariesTool.java` — removes local `API_MAX_PAGE_SIZE`, uses `ValidationConstants`

### Magic number fixes
- `McpContrastApplication.java` — extracts `SEPARATOR_WIDTH = 60`
- `sdkextension/SDKExtension.java` — extracts `DEFAULT_ATTACKS_LIMIT = 1000`, uses `ValidationConstants`
- `sdkextension/SDKHelper.java` — extracts `DEFAULT_HTTP_PROXY_PORT`, `CACHE_MAX_SIZE`, `CACHE_EXPIRY_MINUTES`; uses `ValidationConstants`
- `tool/base/PaginatedTool.java` — extracts `REQUEST_ID_PREFIX_LENGTH = 8`
- `tool/base/SingleTool.java` — extracts `REQUEST_ID_PREFIX_LENGTH = 8`

### FQCN fix
- `tool/vulnerability/GetVulnerabilityTool.java` — adds `ContrastSDK` import, replaces two inline FQCNs in method signatures

### Documentation
- `CLAUDE.md` — Checkstyle rules + prohibition banner + Contrast codebase navigation tips + full `br` command reference
- `AGENTS.md` — `bd` → `br` rename throughout
- `.gitignore` — adds `decisions/`

## Testing

**Automated tests:**
- All existing unit tests pass (`make check-test`)
- No new unit tests added — this is a build tooling change with no behavioral logic to test
- Test coverage verified: `make verify` passes

**Manual testing:**
- Ran `mvn validate` to confirm Checkstyle passes with 0 violations
- Introduced a deliberate wildcard import and confirmed build failed with clear error message
- Confirmed `make check` output shows "All checks passed" with both Spotless and Checkstyle running

**Test results:** All tests pass, 0 Checkstyle violations

## Risks / Rollout / Follow-ups

- **Risk:** New contributors may be surprised by magic number failures for values like `3` or `5`. The ignored list covers common HTTP codes and small integers; edge cases may require extracting additional constants.
- **No rollout concerns** — this is a build-time check with no runtime behavior change.
- **Follow-up:** The `REQUEST_ID_PREFIX_LENGTH = 8` constant is duplicated in `PaginatedTool` and `SingleTool` — a future refactor could move it to a shared base class or `ValidationConstants`.
