### PR TITLE
AIML-674: Harden integration tests before Hosted MCP Server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,12 +206,36 @@ When creating or modifying MCP tools:
 **Testing:**
 - Simplified `mock()`: `ClassName mock = mock()` not `mock(ClassName.class)`
 - AssertJ fluent: `assertThat(x).isEqualTo(y)` not `assertEquals(y, x)`
-- Naming: `methodName_should_expectedBehavior_when_condition()`
+- Naming: `methodName_should_expectedBehavior_when_condition()` — body must verify the behavior the name promises. If assertions don't match the name, strengthen the assertions. Do **not** delete or weaken the name.
 - Example: `getVulnerability_should_return_data_when_valid_id()`
 - **Anonymous builders**: Use `AnonymousXxxBuilder` pattern for complex mocks (see `AnonymousApplicationBuilder.java`)
   - Provides valid defaults for all fields with lenient stubbing
   - Tests only specify fields they care about: `AnonymousApplicationBuilder.validApp().withName("MyApp").build()`
   - Avoids over-mocking anti-pattern and UnnecessaryStubbingException
+
+**Assertion quality (applies to every test):**
+- **Never delete a failing, flaky, or weak test to make it go away.** Strengthen, un-flake, or fix the underlying bug. Deletion is only allowed when the behavior itself is being deliberately removed — and requires user approval.
+- **Exercise ≠ verify.** `assertThat(x).isNotNull()` + `log.info("✓ ...")` is not a test. No `✓` in logs as a stand-in for an assertion.
+- **Mutation check.** Before committing, ask: *if I deleted the production logic under test, would this test go red?* If no, strengthen it until the answer is yes.
+- **AAA completeness.** Every parameter set in arrange must appear in at least one assertion. Setting `severity="HIGH"` without asserting over returned severities means the arrange step is decorative.
+- **Fail fast on missing data.** If a test requires seeded data, `assertThat(data).as("requires seeded X — ...").isNotEmpty()` as the first assertion. Never skip, never silently pass.
+- **Prefer behavioral over shape assertions**: `allSatisfy`, `isSortedAccordingTo`, `containsExactlyInAnyOrderElementsOf`, `extracting(...).allMatch(...)` over `isNotNull` / `isNotEmpty`.
+- **Deterministic expectations.** A test must assert a single expected outcome. Never write `if (response.isSuccess()) { ... } else { ... }` treating both branches as pass. If both outcomes are legitimate, split into two named tests, each with one expected outcome.
+- **Populated ≠ non-null.** When a test name promises to "populate" or "return" a field, assert `isNotBlank()` for strings and `isNotEmpty()` for collections — not `isNotNull()`. An empty list is not populated; an empty string is not populated.
+
+**Testing anti-patterns (do not reintroduce):**
+- `if (data.isEmpty()) return;` — silent skip; assert `isNotEmpty()` up front with diagnostic message instead
+- `Assumptions.assumeTrue(...)` — skipping hides data rot from CI; fail loudly instead
+- `assertThat(items).isNotEmpty(); log.info("✓ filter works")` — logging is not an assertion
+- Filter test that never calls `allSatisfy` over the filter predicate
+- Sort test that never calls `isSortedAccordingTo`
+- Pagination test that fetches page 2 without comparing IDs to page 1
+- Combined-filter test that doesn't verify every filter predicate holds
+- Error-path test using `errors().anyMatch(e -> e.contains("x"))` where `"x"` is just the parameter name — assert full message shape including valid options listed
+- Dual-path test: `if (response.isSuccess()) { assertX } else { assertY }` — both branches treated as pass; split into deterministic tests
+- Filter verified with `anyMatch(...)` — only proves one item matches; use `allMatch` / `allSatisfy` to prove every result matches the predicate
+- Manual loop for sort/filter verification (e.g., `for (int i=1; i<list.size(); i++)`) — use `isSortedAccordingTo` / `allSatisfy` for clearer failure messages
+- `_populate_*` or `_return_*` test using `isNotNull()` on the claimed field — asserts shape, not content; use `isNotBlank` / `isNotEmpty` / content-level check
 
 ### Security Considerations
 
@@ -455,6 +479,35 @@ NOTE: This is not for parent-child dependencies, these are blocks dependencies.
 All code changes require corresponding test coverage. Do not move to review without tests.
 
 See INTEGRATION_TESTS.md for integration test setup and credentials.
+
+### Integration Test Standards
+
+`*IT.java` tests verify the contract across the SDK/API boundary. Shape-only smoke checks belong in unit tests; an IT that only confirms "no exception thrown" has degraded into an auth smoke test.
+
+**Required assertion patterns:**
+- Filter by field → `allSatisfy(item -> assertThat(item.field())...)`
+- Sort by field → `isSortedAccordingTo(Comparator.comparing(...))`
+- Pagination → page N+1 items disjoint from page N by ID; count = `min(pageSize, remaining)`
+- Combined filters → `allSatisfy` over every filter predicate, not `isSuccess()`
+- Error path → specific message content + `noneMatch("Contrast API error")`
+- Field mapping → response values reflect inputs (e.g., response `appID` equals filter `appId`)
+- "Populate" claim → `isNotBlank` for strings, `isNotEmpty` for collections, content-level check — never just `isNotNull`
+- Deterministic behavior → single expected outcome per test — no `if (isSuccess) ... else ...` dual-path
+
+**Data dependency rule:**
+ITs that depend on seeded data must assert the precondition up front with a descriptive `.as(...)` clause. Missing data must fail loudly with an actionable message — never skip, never silently pass.
+
+```java
+assertThat(libraries)
+    .as("requires seeded libraries with CVE associations — see INTEGRATION_TESTS.md")
+    .isNotEmpty();
+```
+
+**Canonical examples to emulate:**
+- `SearchAttacksToolIT` sort-validation tests (`_should_reject_invalid_sort_fields`, `_should_return_validation_error_for_invalid_sort_field`)
+- `GetVulnerabilityToolIT` — comprehensive field verification
+- `GetRouteCoverageToolIT` — pagination + filter + edge cases
+- `GetSastProjectToolIT` — regression coverage for field mapping
 
 ### Creating High-Quality PR Descriptions
 

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectTool.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectTool.java
@@ -51,13 +51,14 @@ public class GetSastProjectTool extends SingleTool<GetSastProjectParams, ScanPro
           Usage examples:
           - Get project: projectName="my-application"
 
-          Note: Project names are case-sensitive and must match exactly.
+          Note: Project name matching is case-insensitive. The returned project's name field
+          reflects the canonical casing as stored in Contrast.
 
           Related tools:
           - get_scan_results: Get SARIF results for a project's latest scan
           """)
   public SingleToolResponse<ScanProject> getScanProject(
-      @ToolParam(description = "Scan project name (case-sensitive, must match exactly)")
+      @ToolParam(description = "Scan project name (matched case-insensitively)")
           String projectName) {
     return executePipeline(() -> GetSastProjectParams.of(projectName));
   }

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataToolIT.java
@@ -55,15 +55,42 @@ public class GetSessionMetadataToolIT
   @Autowired private GetSessionMetadataTool getSessionMetadataTool;
   @Autowired private SearchApplicationsTool searchApplicationsTool;
 
-  /** Container for discovered test data. */
+  // SingleTool's 5xx mapping — validation errors must never look like this.
+  private static final String CONTRAST_API_ERROR = "Contrast API error";
+
+  // SingleTool's 401/403 mapping — see BaseTool#mapHttpErrorCode and
+  // SingleTool#executePipeline (UnauthorizedException branch). Surfaces for both invalid
+  // credentials and unknown application IDs (TeamServer returns 403 rather than 404 for an
+  // appId the caller cannot see).
+  private static final String AUTH_OR_NOT_FOUND_ERROR =
+      "Authentication failed or resource not found. Verify credentials and that the resource ID"
+          + " is correct.";
+
+  // Tool warning emitted when the SDK returns null (no recorded sessions).
+  private static final String NO_METADATA_WARNING_FRAGMENT = "No session metadata found";
+
+  // Probe depth for discovering an app with populated session metadata. Bounded to keep
+  // discovery fast on orgs with many applications.
+  private static final int METADATA_PROBE_DEPTH = 10;
+
+  // String the API will not match against any real application.
+  private static final String NONEXISTENT_APP_ID = "nonexistent-app-id-12345";
+
+  /** Discovered test data — populated once per class by {@link #performDiscovery()}. */
   static class TestData {
-    boolean hasApplications;
     String sampleAppId;
+
+    /**
+     * App ID known to expose at least one populated session metadata filter group. Remains blank if
+     * no probed app surfaced metadata; the populate test fails loudly in that case.
+     */
+    String sampleAppIdWithMetadata;
 
     @Override
     public String toString() {
       return String.format(
-          "TestData{hasApplications=%s, sampleAppId='%s'}", hasApplications, sampleAppId);
+          "TestData{sampleAppId='%s', sampleAppIdWithMetadata='%s'}",
+          sampleAppId, sampleAppIdWithMetadata);
     }
   }
 
@@ -79,75 +106,178 @@ public class GetSessionMetadataToolIT
 
   @Override
   protected void logTestDataDetails(TestData data) {
-    log.info(
-        "Test data: hasApplications={}, sampleAppId={}", data.hasApplications, data.sampleAppId);
+    log.info("Test data: {}", data);
   }
 
   @Override
   protected TestData performDiscovery() throws IOException {
-    var response = searchApplicationsTool.searchApplications(1, 5, null, null, null);
+    var response =
+        searchApplicationsTool.searchApplications(1, METADATA_PROBE_DEPTH, null, null, null);
 
-    var testData = new TestData();
-    testData.hasApplications = response.isSuccess() && !response.items().isEmpty();
-
-    if (testData.hasApplications) {
-      testData.sampleAppId = response.items().get(0).appID();
+    if (!response.isSuccess() || response.items().isEmpty()) {
+      throw new NoTestDataException(
+          "GetSessionMetadataToolIT requires at least one application in the organization — "
+              + "see INTEGRATION_TESTS.md");
     }
 
-    log.info(
-        "Discovery: found {} applications (hasApps={})",
-        response.items().size(),
-        testData.hasApplications);
+    var data = new TestData();
+    data.sampleAppId = response.items().get(0).appID();
 
-    return testData;
+    // Probe the page for an app that has accumulated session metadata. Stops at the first
+    // hit so discovery cost stays bounded. If no app surfaces metadata, the populate test
+    // fails loudly with a precondition message.
+    for (var app : response.items()) {
+      var probe = getSessionMetadataTool.getSessionMetadata(app.appID());
+      if (probe.isSuccess()
+          && probe.found()
+          && probe.data() != null
+          && probe.data().getFilters() != null
+          && !probe.data().getFilters().isEmpty()) {
+        data.sampleAppIdWithMetadata = app.appID();
+        break;
+      }
+    }
+
+    return data;
   }
+
+  // ---------- Discovery precondition ----------
+
+  @Test
+  void testDiscoveredTestDataExists() {
+    assertThat(testData).as("discovery must populate test data").isNotNull();
+    assertThat(testData.sampleAppId)
+        .as("discovery must resolve at least one application — see INTEGRATION_TESTS.md")
+        .isNotBlank();
+  }
+
+  // ---------- Validation errors ----------
 
   @Test
   void getSessionMetadata_should_return_validation_error_for_missing_app_id() {
     var result = getSessionMetadataTool.getSessionMetadata(null);
 
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("appId") && e.contains("required"));
+    assertThat(result.isSuccess()).as("null appId must fail validation").isFalse();
+    assertThat(result.found()).as("validation failure must not report found").isFalse();
+    assertThat(result.data()).as("validation failure must not carry data").isNull();
+    // Assert full message shape — a bare "appId" + "required" substring would coincidentally
+    // match an unrelated message containing the parameter name.
+    assertThat(result.errors())
+        .as("validation error must state appId is required")
+        .containsExactly("appId is required");
+    assertThat(result.errors())
+        .as("validation error must not surface as a Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
   }
 
   @Test
   void getSessionMetadata_should_return_validation_error_for_empty_app_id() {
     var result = getSessionMetadataTool.getSessionMetadata("");
 
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("appId") && e.contains("required"));
+    assertThat(result.isSuccess()).as("empty appId must fail validation").isFalse();
+    assertThat(result.found()).as("validation failure must not report found").isFalse();
+    assertThat(result.data()).as("validation failure must not carry data").isNull();
+    assertThat(result.errors())
+        .as("validation error must state appId is required")
+        .containsExactly("appId is required");
+    assertThat(result.errors())
+        .as("validation error must not surface as a Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
   }
 
   @Test
-  void getSessionMetadata_should_handle_valid_app_id() {
-    // First discover an app ID
-    var appsResponse = searchApplicationsTool.searchApplications(1, 1, null, null, null);
+  void getSessionMetadata_should_return_validation_error_for_blank_app_id() {
+    var result = getSessionMetadataTool.getSessionMetadata("   ");
 
-    if (appsResponse.isSuccess() && !appsResponse.items().isEmpty()) {
-      var appId = appsResponse.items().get(0).appID();
+    assertThat(result.isSuccess()).as("whitespace-only appId must fail validation").isFalse();
+    assertThat(result.found()).as("validation failure must not report found").isFalse();
+    assertThat(result.errors())
+        .as("validation error must state appId is required")
+        .containsExactly("appId is required");
+    assertThat(result.errors())
+        .as("validation error must not surface as a Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
+  }
 
-      var result = getSessionMetadataTool.getSessionMetadata(appId);
+  // ---------- Successful retrieval ----------
 
-      // Should succeed without errors (may or may not have session data)
-      assertThat(result.isSuccess()).isTrue();
-      assertThat(result.errors()).isEmpty();
+  @Test
+  void getSessionMetadata_should_succeed_for_valid_app_id() {
+    // Single deterministic outcome: a valid appId must produce a successful response with no
+    // errors. Whether the app has accumulated session metadata is exercised separately by
+    // _should_populate_metadata_fields.
+    var result = getSessionMetadataTool.getSessionMetadata(testData.sampleAppId);
 
-      // If no session metadata, should have a warning
-      if (!result.found() || result.data() == null) {
-        assertThat(result.warnings()).anyMatch(w -> w.contains("session metadata"));
-      }
-    } else {
-      log.warn("No applications found in org - skipping session metadata test");
-    }
+    assertThat(result.isSuccess())
+        .as("valid appId %s must produce a successful response", testData.sampleAppId)
+        .isTrue();
+    assertThat(result.errors()).as("successful query must have no errors").isEmpty();
+    assertThat(result.errors())
+        .as("successful response must not surface as a Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
   }
 
   @Test
-  void getSessionMetadata_should_handle_nonexistent_app_id_gracefully() {
-    var result = getSessionMetadataTool.getSessionMetadata("nonexistent-app-id-12345");
+  void getSessionMetadata_should_populate_metadata_fields() {
+    // Precondition: requires a seeded app with at least one populated session metadata filter
+    // group. Discovery surfaces this via testData.sampleAppIdWithMetadata; if absent across the
+    // probe depth, fail loudly with a diagnostic message rather than silently passing.
+    assertThat(testData.sampleAppIdWithMetadata)
+        .as(
+            "requires a seeded application with populated session metadata within the first %d"
+                + " applications — see INTEGRATION_TESTS.md",
+            METADATA_PROBE_DEPTH)
+        .isNotBlank();
 
-    // Should not throw an exception - should return an error or not-found response
-    assertThat(result).isNotNull();
-    // The API may return an error for invalid app IDs
-    // or return null/empty response - either is acceptable
+    var result = getSessionMetadataTool.getSessionMetadata(testData.sampleAppIdWithMetadata);
+
+    assertThat(result.isSuccess()).as("seeded session metadata query must succeed").isTrue();
+    assertThat(result.errors()).as("seeded query must produce no errors").isEmpty();
+    assertThat(result.found()).as("seeded session metadata must be reported as found").isTrue();
+    assertThat(result.data()).as("seeded query must carry data").isNotNull();
+    // "Populate ≠ non-null": the @Tool description promises filter groups exposing branch
+    // names, build IDs, and other custom metadata. Assert the collection is non-empty and
+    // every group carries a non-blank identifier so a regression that decoded an empty list
+    // or null group ids would surface here.
+    assertThat(result.data().getFilters())
+        .as("response must include at least one filter group")
+        .isNotNull()
+        .isNotEmpty();
+    assertThat(result.data().getFilters())
+        .as("every filter group must populate a non-blank id and a non-null values list")
+        .allSatisfy(
+            group -> {
+              assertThat(group.getId()).as("group.id must be non-blank").isNotBlank();
+              assertThat(group.getValues())
+                  .as("group %s values must be a non-null list", group.getId())
+                  .isNotNull();
+            });
+  }
+
+  // ---------- API-rejection path ----------
+
+  @Test
+  void getSessionMetadata_should_surface_actionable_error_for_unknown_app_id() {
+    // TeamServer rejects unknown applications with 403 Forbidden ("Authorization failure"),
+    // which the SDK surfaces as UnauthorizedException and SingleTool maps to the
+    // auth-or-not-found user message. Single deterministic outcome — no isSuccess?A:B
+    // dual-path. A regression that surfaced this as a generic 5xx error or a stack trace
+    // would surface here.
+    var result = getSessionMetadataTool.getSessionMetadata(NONEXISTENT_APP_ID);
+
+    assertThat(result.isSuccess())
+        .as("unknown appId must surface as a non-success response")
+        .isFalse();
+    assertThat(result.found()).as("unknown appId must not report found").isFalse();
+    assertThat(result.data()).as("error response must not carry data").isNull();
+    assertThat(result.errors())
+        .as("unknown appId must produce the documented auth-or-not-found error")
+        .containsExactly(AUTH_OR_NOT_FOUND_ERROR);
+    assertThat(result.errors())
+        .as("unknown appId must not be surfaced as a generic 5xx Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
+    assertThat(result.warnings())
+        .as("error path must not also emit the no-metadata warning")
+        .noneMatch(w -> w.contains(NO_METADATA_WARNING_FRAGMENT));
   }
 }

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataToolIT.java
@@ -109,6 +109,21 @@ public class GetSessionMetadataToolIT
     log.info("Test data: {}", data);
   }
 
+  /**
+   * Captures two app IDs from the first page of applications:
+   *
+   * <ul>
+   *   <li>{@code sampleAppId} — any app in the org. Drives baseline retrieval tests and the
+   *       error-path test for an unknown-but-syntactically-valid app ID.
+   *   <li>{@code sampleAppIdWithMetadata} — the first probed app whose session metadata response
+   *       carries a populated filter group. The "populate" test asserts {@code isNotEmpty} on the
+   *       returned filters and would otherwise fail or pass vacuously if every probed app had no
+   *       accumulated session metadata.
+   * </ul>
+   *
+   * Probing stops at the first metadata-bearing app to keep discovery cost bounded; if none is
+   * found the populate test fails loudly with a precondition message.
+   */
   @Override
   protected TestData performDiscovery() throws IOException {
     var response =

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolIT.java
@@ -18,8 +18,11 @@ package com.contrast.labs.ai.mcp.contrast.tool.application;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrast.labs.ai.mcp.contrast.config.IntegrationTestConfig;
+import com.contrast.labs.ai.mcp.contrast.result.ApplicationData;
 import com.contrast.labs.ai.mcp.contrast.util.AbstractIntegrationTest;
+import com.contrast.labs.ai.mcp.contrast.util.IntegrationTestDataCache;
 import java.io.IOException;
+import java.util.Locale;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -28,10 +31,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 
 /**
- * Integration test for SearchApplicationsTool that validates application search against real
- * TeamServer.
+ * Integration tests for SearchApplicationsTool.
  *
- * <p>This test only runs if CONTRAST_HOST_NAME environment variable is set.
+ * <p>Requires CONTRAST_HOST_NAME environment variable to be set.
  *
  * <p>Required environment variables:
  *
@@ -49,22 +51,47 @@ import org.springframework.context.annotation.Import;
 @SpringBootTest
 @Import(IntegrationTestConfig.class)
 @EnabledIfEnvironmentVariable(named = "CONTRAST_HOST_NAME", matches = ".+")
-public class SearchApplicationsToolIT
-    extends AbstractIntegrationTest<SearchApplicationsToolIT.TestData> {
+class SearchApplicationsToolIT extends AbstractIntegrationTest<SearchApplicationsToolIT.TestData> {
 
   @Autowired private SearchApplicationsTool searchApplicationsTool;
 
-  /** Container for discovered test data. */
+  // Shared pagination constants — keep in sync with ValidationConstants.
+  private static final int DEFAULT_PAGE_SIZE = 50;
+  private static final int MAX_PAGE_SIZE = 100;
+  private static final int PAGINATION_PROBE_SIZE = 2;
+  private static final int MIN_APPS_FOR_PAGINATION = PAGINATION_PROBE_SIZE + 1;
+
+  // SingleTool/PaginatedTool's 5xx mapping — validation errors must never look like this.
+  private static final String CONTRAST_API_ERROR = "Contrast API error";
+
+  // A value that no real application will plausibly carry — used for OR/narrowing assertions.
+  private static final String UNLIKELY_METADATA_VALUE = "never-matching-value-xyzqwer987654321";
+
+  /** Discovered test data. Populated once per class by {@link #performDiscovery()}. */
   static class TestData {
-    boolean hasApplications;
+    int totalApplications;
     String sampleAppName;
     String sampleAppId;
+    // Tag discovery: any app with at least one tag contributes the first tag value.
+    String sampleTag;
+    String appIdWithSampleTag;
+    // Metadata discovery: first app carrying at least one populated metadata entry contributes
+    // the (field, value) pair. Field name uses the displayLabel exposed by the metadata-fields
+    // endpoint so case-insensitivity tests exercise the real server mapping.
+    String sampleMetadataField;
+    String sampleMetadataValue;
 
     @Override
     public String toString() {
       return String.format(
-          "TestData{hasApplications=%s, sampleAppName='%s', sampleAppId='%s'}",
-          hasApplications, sampleAppName, sampleAppId);
+          "TestData{totalApplications=%d, sampleAppName='%s', sampleAppId='%s', "
+              + "sampleTag='%s', sampleMetadataField='%s', sampleMetadataValue='%s'}",
+          totalApplications,
+          sampleAppName,
+          sampleAppId,
+          sampleTag,
+          sampleMetadataField,
+          sampleMetadataValue);
     }
   }
 
@@ -80,110 +107,571 @@ public class SearchApplicationsToolIT
 
   @Override
   protected void logTestDataDetails(TestData data) {
-    log.info(
-        "Test data: hasApplications={}, sampleAppName={}, sampleAppId={}",
-        data.hasApplications,
-        data.sampleAppName,
-        data.sampleAppId);
+    log.info("Test data: {}", data);
   }
 
   @Override
   protected TestData performDiscovery() throws IOException {
-    var response = searchApplicationsTool.searchApplications(1, 5, null, null, null);
+    var data = new TestData();
 
-    var testData = new TestData();
-    testData.hasApplications = response.isSuccess() && !response.items().isEmpty();
-
-    if (testData.hasApplications) {
-      var firstApp = response.items().get(0);
-      testData.sampleAppName = firstApp.name();
-      testData.sampleAppId = firstApp.appID();
+    var applications = IntegrationTestDataCache.getApplications(orgId, sdkExtension);
+    if (applications == null || applications.isEmpty()) {
+      throw new NoTestDataException(
+          "SearchApplicationsToolIT requires at least one application in the organization — "
+              + "see INTEGRATION_TESTS.md");
     }
 
-    log.info(
-        "Discovery: found {} applications (hasApps={})",
-        response.items().size(),
-        testData.hasApplications);
+    data.totalApplications = applications.size();
+    var firstApp = applications.get(0);
+    data.sampleAppName = firstApp.getName();
+    data.sampleAppId = firstApp.getAppId();
 
-    return testData;
+    for (var app : applications) {
+      if (data.sampleTag == null && app.getTags() != null && !app.getTags().isEmpty()) {
+        var firstTag = app.getTags().get(0);
+        if (firstTag != null && !firstTag.isBlank()) {
+          data.sampleTag = firstTag;
+          data.appIdWithSampleTag = app.getAppId();
+        }
+      }
+
+      if (data.sampleMetadataField == null
+          && app.getMetadataEntities() != null
+          && !app.getMetadataEntities().isEmpty()) {
+        for (var entry : app.getMetadataEntities()) {
+          if (entry != null
+              && entry.getName() != null
+              && !entry.getName().isBlank()
+              && entry.getValue() != null
+              && !entry.getValue().isBlank()) {
+            data.sampleMetadataField = entry.getName();
+            data.sampleMetadataValue = entry.getValue();
+            break;
+          }
+        }
+      }
+
+      if (data.sampleTag != null && data.sampleMetadataField != null) {
+        break;
+      }
+    }
+
+    return data;
   }
+
+  // ---------- Discovery precondition ----------
+
+  @Test
+  void testDiscoveredTestDataExists() {
+    assertThat(testData).as("discovery must populate test data").isNotNull();
+    assertThat(testData.totalApplications)
+        .as("organization must carry at least one application")
+        .isPositive();
+    assertThat(testData.sampleAppId).as("sample appId must be non-blank").isNotBlank();
+    assertThat(testData.sampleAppName).as("sample appName must be non-blank").isNotBlank();
+  }
+
+  // ---------- Response shape and identity ----------
 
   @Test
   void searchApplications_should_return_valid_response() {
+    // Focus on server-driven behavior: totalItems must be a non-negative count, and
+    // hasMorePages must be internally consistent with items + pageSize. Input echoes
+    // (page=1, pageSize=10) are tautologies — asserting them would only prove that the
+    // tool returns what it was given, not that it behaves correctly against the server.
     var response = searchApplicationsTool.searchApplications(1, 10, null, null, null);
 
-    assertThat(response).isNotNull();
-    assertThat(response.isSuccess()).isTrue();
-    assertThat(response.page()).isEqualTo(1);
-    assertThat(response.pageSize()).isEqualTo(10);
-    assertThat(response.items()).isNotNull();
+    assertThat(response).as("response must never be null").isNotNull();
+    assertThat(response.isSuccess()).as("baseline query must succeed").isTrue();
+    assertThat(response.errors()).as("baseline query must have no errors").isEmpty();
+    assertThat(response.items()).as("items list must never be null").isNotNull();
+    assertThat(response.totalItems())
+        .as("totalItems must be a non-negative count, never a sentinel")
+        .isNotNull()
+        .isNotNegative();
+    // hasMorePages consistency: if this page did not fill up, there must be no more pages.
+    if (response.items().size() < response.pageSize()) {
+      assertThat(response.hasMorePages())
+          .as("partial page must report hasMorePages=false")
+          .isFalse();
+    }
   }
 
   @Test
   void searchApplications_should_include_application_details() {
     var response = searchApplicationsTool.searchApplications(1, 10, null, null, null);
 
-    assertThat(response.isSuccess()).isTrue();
+    assertThat(response.isSuccess()).as("response must be successful").isTrue();
+    assertThat(response.items())
+        .as("requires seeded applications — see INTEGRATION_TESTS.md")
+        .isNotEmpty();
 
-    if (!response.items().isEmpty()) {
-      var app = response.items().get(0);
-      assertThat(app.name()).isNotBlank();
-      assertThat(app.appID()).isNotBlank();
-      // Status and language should be present for most apps
-      assertThat(app.status()).isNotNull();
-    }
+    // Core identity invariants across every returned app. The defensive getters on
+    // ApplicationData reflect API defaults (collections never null), so a regression that
+    // drops one to null would surface here.
+    assertThat(response.items())
+        .as("every app must populate core identity and expose non-null collection fields")
+        .allSatisfy(
+            app -> {
+              assertThat(app.name()).as("app.name").isNotBlank();
+              assertThat(app.appID()).as("%s.appID", app.name()).isNotBlank();
+              assertThat(app.metadata())
+                  .as("%s.metadata must be non-null collection", app.name())
+                  .isNotNull();
+              assertThat(app.tags())
+                  .as("%s.tags must be non-null collection", app.name())
+                  .isNotNull();
+              assertThat(app.technologies())
+                  .as("%s.technologies must be non-null collection", app.name())
+                  .isNotNull();
+            });
   }
+
+  @Test
+  void searchApplications_should_populate_status_field_somewhere() {
+    // status is nullable on the Contrast Application model (some SCA-only apps decline to
+    // report a status), so blanket allSatisfy(isNotBlank) would produce false positives.
+    // Instead, prove the field decodes end-to-end by requiring at least one returned app
+    // with a populated status — a regression that always left status null would surface here.
+    var response = searchApplicationsTool.searchApplications(1, MAX_PAGE_SIZE, null, null, null);
+
+    assertThat(response.isSuccess()).as("response must be successful").isTrue();
+    assertThat(response.items())
+        .as("requires seeded applications — see INTEGRATION_TESTS.md")
+        .isNotEmpty();
+    assertThat(response.items())
+        .as("at least one app must populate a non-blank status — proves field decodes")
+        .anyMatch(app -> app.status() != null && !app.status().isBlank());
+  }
+
+  @Test
+  void searchApplications_should_populate_language_field_somewhere() {
+    // Same rationale as status: nullable on the model, so anyMatch is the correct
+    // end-to-end existence proof rather than allSatisfy.
+    var response = searchApplicationsTool.searchApplications(1, MAX_PAGE_SIZE, null, null, null);
+
+    assertThat(response.isSuccess()).as("response must be successful").isTrue();
+    assertThat(response.items())
+        .as("requires seeded applications — see INTEGRATION_TESTS.md")
+        .isNotEmpty();
+    assertThat(response.items())
+        .as("at least one app must populate a non-blank language — proves field decodes")
+        .anyMatch(app -> app.language() != null && !app.language().isBlank());
+  }
+
+  // ---------- Name filter ----------
 
   @Test
   void searchApplications_should_filter_by_name() {
-    // First get an app to search for
-    var allApps = searchApplicationsTool.searchApplications(1, 1, null, null, null);
+    // The server-side text filter searches displayName, contextPath, tags, and metadata
+    // values (OR across fields). ApplicationData exposes three of the four (contextPath
+    // is not projected), so every returned row must match the partial on at least one of
+    // name/tags/metadata. A legitimate contextPath-only match would surface as a row
+    // failing this disjunction, which is tolerable for the assertion as a tightening
+    // signal; a regression that broadened the filter to unrelated rows would surface the
+    // same way. Keeping pageSize at MAX_PAGE_SIZE reduces flakiness when many rows match.
+    var partialName =
+        testData.sampleAppName.substring(0, Math.min(3, testData.sampleAppName.length()));
 
-    if (allApps.isSuccess() && !allApps.items().isEmpty()) {
-      var appName = allApps.items().get(0).name();
+    var response =
+        searchApplicationsTool.searchApplications(1, MAX_PAGE_SIZE, partialName, null, null);
 
-      // Search for it by partial name (first 3 chars)
-      var partialName = appName.substring(0, Math.min(3, appName.length()));
-      var filteredResponse =
-          searchApplicationsTool.searchApplications(1, 50, partialName, null, null);
+    assertThat(response.isSuccess()).as("name-filtered query must succeed").isTrue();
+    assertThat(response.items())
+        .as(
+            "name filter '%s' (derived from seed app %s) must return at least one result",
+            partialName, testData.sampleAppName)
+        .isNotEmpty();
 
-      assertThat(filteredResponse.isSuccess()).isTrue();
-      // The original app should be in the filtered results
-      assertThat(filteredResponse.items())
-          .anyMatch(a -> a.name().toLowerCase().contains(partialName.toLowerCase()));
-    }
+    var lowerPartial = partialName.toLowerCase(Locale.ROOT);
+    assertThat(response.items())
+        .as(
+            "every result must carry '%s' in name, tags, or metadata value"
+                + " (contextPath is not projected on ApplicationData)",
+            partialName)
+        .allSatisfy(
+            app -> {
+              boolean inName =
+                  app.name() != null && app.name().toLowerCase(Locale.ROOT).contains(lowerPartial);
+              boolean inTags =
+                  app.tags().stream()
+                      .anyMatch(
+                          t -> t != null && t.toLowerCase(Locale.ROOT).contains(lowerPartial));
+              boolean inMetadata =
+                  app.metadata().stream()
+                      .anyMatch(
+                          m ->
+                              m != null
+                                  && m.value() != null
+                                  && m.value().toLowerCase(Locale.ROOT).contains(lowerPartial));
+              assertThat(inName || inTags || inMetadata)
+                  .as(
+                      "%s must match '%s' in name/tags/metadata (name=%s, tags=%s,"
+                          + " metadataValues=%s)",
+                      app.appID(),
+                      partialName,
+                      app.name(),
+                      app.tags(),
+                      app.metadata().stream().map(m -> m == null ? null : m.value()).toList())
+                  .isTrue();
+            });
   }
+
+  // ---------- Pagination ----------
 
   @Test
   void searchApplications_should_handle_pagination() {
-    // First page with small page size
-    var page1 = searchApplicationsTool.searchApplications(1, 2, null, null, null);
+    // Fail fast if the org is too small to exercise multi-page behavior.
+    assertThat(testData.totalApplications)
+        .as(
+            "pagination test requires org to have > %d applications — see INTEGRATION_TESTS.md",
+            PAGINATION_PROBE_SIZE)
+        .isGreaterThanOrEqualTo(MIN_APPS_FOR_PAGINATION);
 
-    assertThat(page1.isSuccess()).isTrue();
+    var page1 =
+        searchApplicationsTool.searchApplications(1, PAGINATION_PROBE_SIZE, null, null, null);
+    assertThat(page1.isSuccess()).as("page 1 must succeed").isTrue();
+    assertThat(page1.items())
+        .as("page 1 must contain exactly %d items", PAGINATION_PROBE_SIZE)
+        .hasSize(PAGINATION_PROBE_SIZE);
+    assertThat(page1.hasMorePages()).as("page 1 must report hasMorePages=true").isTrue();
 
-    // If there are more pages, fetch page 2
-    if (page1.hasMorePages()) {
-      var page2 = searchApplicationsTool.searchApplications(2, 2, null, null, null);
+    var page2 =
+        searchApplicationsTool.searchApplications(2, PAGINATION_PROBE_SIZE, null, null, null);
+    assertThat(page2.isSuccess()).as("page 2 must succeed").isTrue();
+    assertThat(page2.page()).as("page 2 page number").isEqualTo(2);
 
-      assertThat(page2.isSuccess()).isTrue();
-      assertThat(page2.page()).isEqualTo(2);
-    }
+    int totalItems = page1.totalItems();
+    int expectedPage2Size = Math.min(PAGINATION_PROBE_SIZE, totalItems - PAGINATION_PROBE_SIZE);
+    assertThat(page2.items())
+        .as("page 2 must contain min(pageSize, remaining) = %d items", expectedPage2Size)
+        .hasSize(expectedPage2Size);
+
+    // Disjointness by appID proves the server honored the offset rather than returning the
+    // same page twice. appID is a stable per-app identifier.
+    var page1Ids = page1.items().stream().map(ApplicationData::appID).toList();
+    var page2Ids = page2.items().stream().map(ApplicationData::appID).toList();
+    assertThat(page2Ids)
+        .as("page 2 IDs must be disjoint from page 1 IDs")
+        .doesNotContainAnyElementsOf(page1Ids);
   }
 
   @Test
-  void searchApplications_should_return_total_count() {
-    var response = searchApplicationsTool.searchApplications(1, 10, null, null, null);
+  void searchApplications_should_return_total_count_consistent_with_items() {
+    // When a single page captures the entire result set, totalItems must equal items.size().
+    // A server regression that returned a sentinel total would surface here.
+    var response = searchApplicationsTool.searchApplications(1, MAX_PAGE_SIZE, null, null, null);
 
-    assertThat(response.isSuccess()).isTrue();
-    assertThat(response.totalItems()).isNotNull();
-    assertThat(response.totalItems()).isGreaterThanOrEqualTo(0);
+    assertThat(response.isSuccess()).as("response must be successful").isTrue();
+    assertThat(response.totalItems())
+        .as("totalItems must be populated")
+        .isNotNull()
+        .isNotNegative();
+
+    if (!response.hasMorePages()) {
+      assertThat(response.totalItems())
+          .as("single-page result: totalItems must equal items.size()")
+          .isEqualTo(response.items().size());
+    }
+  }
+
+  // ---------- Pagination defaults and clamping ----------
+
+  @Test
+  void searchApplications_should_default_page_and_pageSize_when_null() {
+    // Null page/pageSize must route through PaginationParams defaults — page=1, pageSize=50
+    // — with no clamp warnings. A change to the default contract would surface here.
+    var response = searchApplicationsTool.searchApplications(null, null, null, null, null);
+
+    assertThat(response.isSuccess()).as("defaults must not fail validation").isTrue();
+    assertThat(response.page()).as("null page must default to 1").isEqualTo(1);
+    assertThat(response.pageSize())
+        .as("null pageSize must default to %d", DEFAULT_PAGE_SIZE)
+        .isEqualTo(DEFAULT_PAGE_SIZE);
+    assertThat(response.warnings())
+        .as("defaults must not produce pagination-clamp warnings")
+        .noneMatch(w -> w.contains("Invalid page"))
+        .noneMatch(w -> w.contains("Invalid pageSize"))
+        .noneMatch(w -> w.contains("exceeds maximum"));
+  }
+
+  @Test
+  void searchApplications_should_clamp_page_below_one() {
+    // PaginationParams treats page < 1 as a soft failure: clamp to 1 and emit a warning.
+    var response = searchApplicationsTool.searchApplications(0, 10, null, null, null);
+
+    assertThat(response.isSuccess()).as("page=0 must soft-fail and continue").isTrue();
+    assertThat(response.page()).as("page=0 must be clamped to 1").isEqualTo(1);
+    assertThat(response.warnings())
+        .as("clamping must emit an 'Invalid page number' warning")
+        .anyMatch(w -> w.contains("Invalid page number 0"));
+  }
+
+  @Test
+  void searchApplications_should_clamp_non_positive_pageSize() {
+    // pageSize < 1 must be replaced with DEFAULT_PAGE_SIZE and a warning emitted.
+    var response = searchApplicationsTool.searchApplications(1, 0, null, null, null);
+
+    assertThat(response.isSuccess()).as("pageSize=0 must soft-fail and continue").isTrue();
+    assertThat(response.pageSize())
+        .as("pageSize=0 must fall back to default %d", DEFAULT_PAGE_SIZE)
+        .isEqualTo(DEFAULT_PAGE_SIZE);
+    assertThat(response.warnings())
+        .as("clamping must emit an 'Invalid pageSize' warning")
+        .anyMatch(w -> w.contains("Invalid pageSize 0"));
+  }
+
+  @Test
+  void searchApplications_should_clamp_oversized_pageSize() {
+    // Tool-specific max is MAX_PAGE_SIZE (100). Requests above must be capped with a
+    // warning that names the cap.
+    int oversized = MAX_PAGE_SIZE * 4;
+    var response = searchApplicationsTool.searchApplications(1, oversized, null, null, null);
+
+    assertThat(response.isSuccess()).as("oversized pageSize must soft-fail and continue").isTrue();
+    assertThat(response.pageSize())
+        .as("pageSize must be capped to MAX_PAGE_SIZE=%d", MAX_PAGE_SIZE)
+        .isEqualTo(MAX_PAGE_SIZE);
+    assertThat(response.warnings())
+        .as("clamping must emit an 'exceeds maximum' warning citing the cap")
+        .anyMatch(w -> w.contains("exceeds maximum") && w.contains(String.valueOf(MAX_PAGE_SIZE)));
+  }
+
+  // ---------- Tag filter ----------
+
+  @Test
+  void searchApplications_should_filter_by_tag() {
+    assertThat(testData.sampleTag)
+        .as(
+            "tag filter test requires at least one app with a non-blank tag — "
+                + "see INTEGRATION_TESTS.md")
+        .isNotBlank();
+
+    var response =
+        searchApplicationsTool.searchApplications(1, MAX_PAGE_SIZE, null, testData.sampleTag, null);
+
+    assertThat(response.isSuccess())
+        .as("tag-filtered query for '%s' must succeed", testData.sampleTag)
+        .isTrue();
+    assertThat(response.items())
+        .as(
+            "tag filter must return at least the seed app that carries tag '%s'",
+            testData.sampleTag)
+        .isNotEmpty()
+        .anyMatch(app -> testData.appIdWithSampleTag.equals(app.appID()));
+
+    // Tag match is exact and case-insensitive per the @Tool docs. Every returned app must
+    // carry the tag (case-insensitively) in its tags list — a silent broadening of the
+    // filter would surface as an app without the tag.
+    assertThat(response.items())
+        .as("every returned app must carry tag '%s' (case-insensitive)", testData.sampleTag)
+        .allSatisfy(
+            app ->
+                assertThat(app.tags())
+                    .as("%s.tags vs filter", app.appID())
+                    .isNotNull()
+                    .anyMatch(t -> t != null && t.equalsIgnoreCase(testData.sampleTag)));
+  }
+
+  // ---------- Metadata filters ----------
+
+  @Test
+  void searchApplications_should_filter_by_metadata() {
+    assertThat(testData.sampleMetadataField)
+        .as(
+            "metadata filter test requires at least one app with populated metadata — "
+                + "see INTEGRATION_TESTS.md")
+        .isNotBlank();
+    assertThat(testData.sampleMetadataValue).isNotBlank();
+
+    var filter =
+        String.format(
+            "{\"%s\":\"%s\"}", testData.sampleMetadataField, testData.sampleMetadataValue);
+
+    var response = searchApplicationsTool.searchApplications(1, MAX_PAGE_SIZE, null, null, filter);
+
+    assertThat(response.errors()).as("valid metadata filter must not produce errors").isEmpty();
+    assertThat(response.isSuccess()).as("metadata-filtered query must succeed").isTrue();
+    assertThat(response.items())
+        .as(
+            "metadata filter {%s=%s} must return at least one app carrying that metadata",
+            testData.sampleMetadataField, testData.sampleMetadataValue)
+        .isNotEmpty();
+  }
+
+  @Test
+  void searchApplications_should_match_metadata_field_name_case_insensitively() {
+    // Field names are resolved case-insensitively on the client side (see
+    // SearchApplicationsTool#buildAppMetadataFieldMapping). Querying with upper-cased and
+    // lower-cased field names must produce identical result counts; otherwise the mapping
+    // regressed to case-sensitive.
+    assertThat(testData.sampleMetadataField)
+        .as("metadata test requires seeded metadata — see INTEGRATION_TESTS.md")
+        .isNotBlank();
+
+    var original =
+        String.format(
+            "{\"%s\":\"%s\"}", testData.sampleMetadataField, testData.sampleMetadataValue);
+    var upperField =
+        String.format(
+            "{\"%s\":\"%s\"}",
+            testData.sampleMetadataField.toUpperCase(Locale.ROOT), testData.sampleMetadataValue);
+
+    var originalResp =
+        searchApplicationsTool.searchApplications(1, MAX_PAGE_SIZE, null, null, original);
+    var upperResp =
+        searchApplicationsTool.searchApplications(1, MAX_PAGE_SIZE, null, null, upperField);
+
+    assertThat(originalResp.isSuccess()).as("original-case query must succeed").isTrue();
+    assertThat(upperResp.isSuccess())
+        .as("upper-case field-name query must succeed (field name is case-insensitive)")
+        .isTrue();
+    assertThat(upperResp.totalItems())
+        .as("upper-case field-name query must match original-case result count")
+        .isEqualTo(originalResp.totalItems());
+  }
+
+  @Test
+  void searchApplications_should_match_metadata_value_case_insensitively() {
+    // Per the @Tool docs, metadata values match case-insensitively. Querying with
+    // upper-cased value must yield the same result count as the original.
+    assertThat(testData.sampleMetadataValue)
+        .as("metadata test requires seeded metadata — see INTEGRATION_TESTS.md")
+        .isNotBlank();
+
+    var original =
+        String.format(
+            "{\"%s\":\"%s\"}", testData.sampleMetadataField, testData.sampleMetadataValue);
+    var upperValue =
+        String.format(
+            "{\"%s\":\"%s\"}",
+            testData.sampleMetadataField, testData.sampleMetadataValue.toUpperCase(Locale.ROOT));
+
+    var originalResp =
+        searchApplicationsTool.searchApplications(1, MAX_PAGE_SIZE, null, null, original);
+    var upperResp =
+        searchApplicationsTool.searchApplications(1, MAX_PAGE_SIZE, null, null, upperValue);
+
+    assertThat(originalResp.isSuccess()).as("original-case value query must succeed").isTrue();
+    assertThat(upperResp.isSuccess())
+        .as("upper-case value query must succeed (value is case-insensitive)")
+        .isTrue();
+    assertThat(upperResp.totalItems())
+        .as("upper-case value query must match original-case result count")
+        .isEqualTo(originalResp.totalItems());
+  }
+
+  @Test
+  void searchApplications_should_apply_or_logic_within_multiple_metadata_values() {
+    // Multiple values for a single field are OR-joined per the @Tool docs. Querying with
+    // [realValue, unlikelyValue] must return the same rows as querying with [realValue]
+    // alone — the unlikely value adds no new matches and OR must not drop matches.
+    assertThat(testData.sampleMetadataField)
+        .as("metadata test requires seeded metadata — see INTEGRATION_TESTS.md")
+        .isNotBlank();
+
+    var singleValue =
+        String.format(
+            "{\"%s\":\"%s\"}", testData.sampleMetadataField, testData.sampleMetadataValue);
+    var orValues =
+        String.format(
+            "{\"%s\":[\"%s\",\"%s\"]}",
+            testData.sampleMetadataField, testData.sampleMetadataValue, UNLIKELY_METADATA_VALUE);
+
+    var singleResp =
+        searchApplicationsTool.searchApplications(1, MAX_PAGE_SIZE, null, null, singleValue);
+    var orResp = searchApplicationsTool.searchApplications(1, MAX_PAGE_SIZE, null, null, orValues);
+
+    assertThat(singleResp.isSuccess()).as("single-value query must succeed").isTrue();
+    assertThat(orResp.isSuccess()).as("OR-values query must succeed").isTrue();
+    assertThat(orResp.totalItems())
+        .as("OR with a no-match value must not drop matches nor introduce spurious rows")
+        .isEqualTo(singleResp.totalItems());
+  }
+
+  @Test
+  void searchApplications_should_narrow_results_with_unmatched_metadata_value() {
+    // Filters must actually narrow: a known field paired with an unlikely value must
+    // return zero rows (not the full unfiltered set). This is the minimum proof that the
+    // filter was forwarded rather than silently dropped.
+    assertThat(testData.sampleMetadataField)
+        .as("metadata test requires seeded metadata — see INTEGRATION_TESTS.md")
+        .isNotBlank();
+
+    var filter =
+        String.format("{\"%s\":\"%s\"}", testData.sampleMetadataField, UNLIKELY_METADATA_VALUE);
+
+    var response = searchApplicationsTool.searchApplications(1, MAX_PAGE_SIZE, null, null, filter);
+
+    assertThat(response.isSuccess()).as("query with no-match value must succeed").isTrue();
+    assertThat(response.items())
+        .as("metadata value '%s' must match no applications", UNLIKELY_METADATA_VALUE)
+        .isEmpty();
+    assertThat(response.totalItems()).as("no-match query must report totalItems=0").isEqualTo(0);
+  }
+
+  // ---------- Metadata validation errors ----------
+
+  @Test
+  void searchApplications_should_reject_unknown_metadata_field() {
+    // A metadata field that does not exist in the org must surface as an actionable error
+    // naming the offending field. Assert the full message shape — a bare substring match
+    // on the field name would coincidentally pass because we passed that name ourselves.
+    var bogusField = "never_a_real_field_zzq_123";
+    var filter = String.format("{\"%s\":\"anything\"}", bogusField);
+
+    var response = searchApplicationsTool.searchApplications(1, 10, null, null, filter);
+
+    assertThat(response.isSuccess()).as("query with unknown metadata field must fail").isFalse();
+    assertThat(response.items()).as("error response must carry no items").isEmpty();
+    assertThat(response.errors())
+        .as("error must name the offending field and describe resolution")
+        .isNotEmpty()
+        .anyMatch(
+            e ->
+                e.contains("Metadata field(s) not found")
+                    && e.contains(bogusField)
+                    && e.contains("Available fields"));
+    assertThat(response.errors())
+        .as("validation error must not be surfaced as a Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
+  }
+
+  @Test
+  void searchApplications_should_reject_empty_metadata_value() {
+    // Empty/whitespace-only values must be rejected up front by the tool with a message
+    // naming the field and describing the empty-value rule.
+    var filter = "{\"freeform\":\"\"}";
+
+    var response = searchApplicationsTool.searchApplications(1, 10, null, null, filter);
+
+    assertThat(response.isSuccess()).as("empty metadata value must fail validation").isFalse();
+    assertThat(response.items()).as("validation failure must carry no items").isEmpty();
+    assertThat(response.errors())
+        .as("error must name the field and cite the non-empty rule")
+        .isNotEmpty()
+        .anyMatch(
+            e -> e.contains("metadataFilters") && e.contains("freeform") && e.contains("empty"));
+    assertThat(response.errors())
+        .as("validation error must not be surfaced as a Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
   }
 
   @Test
   void searchApplications_should_reject_invalid_metadata_json() {
+    // Malformed JSON must be rejected up front with a message that names the offending
+    // parameter and shows the expected format — not a bare "Invalid JSON" substring.
     var response = searchApplicationsTool.searchApplications(1, 10, null, null, "{invalid json}");
 
-    assertThat(response.isSuccess()).isFalse();
-    assertThat(response.errors()).anyMatch(e -> e.contains("Invalid JSON"));
+    assertThat(response.isSuccess()).as("malformed JSON must fail validation").isFalse();
+    assertThat(response.items()).as("validation failure must carry no items").isEmpty();
+    assertThat(response.errors())
+        .as("error must name the offending parameter and show the expected format")
+        .isNotEmpty()
+        .anyMatch(
+            e -> e.contains("Invalid JSON for metadataFilters") && e.contains("Expected format"));
+    assertThat(response.errors())
+        .as("validation error must not be surfaced as a Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
   }
 }

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolIT.java
@@ -110,6 +110,25 @@ class SearchApplicationsToolIT extends AbstractIntegrationTest<SearchApplication
     log.info("Test data: {}", data);
   }
 
+  /**
+   * Captures the seed values needed to exercise every {@code search_applications} filter path:
+   *
+   * <ul>
+   *   <li>{@code totalApplications} — drives the pagination tests (need at least {@link
+   *       #MIN_APPS_FOR_PAGINATION} for cross-page disjointness checks).
+   *   <li>{@code sampleAppName} / {@code sampleAppId} — exercise the name-filter and identity
+   *       round-trip assertions on the first known application.
+   *   <li>{@code sampleTag} + {@code appIdWithSampleTag} — drive the tags-filter test, which
+   *       asserts the tag-matched results contain the discovered app.
+   *   <li>{@code sampleMetadataField} / {@code sampleMetadataValue} — drive the metadata-filter and
+   *       case-insensitivity tests; the field name uses the {@code displayLabel} from the org's
+   *       metadata-fields endpoint so we exercise the real server mapping.
+   * </ul>
+   *
+   * Falls back gracefully when an app lacks tags/metadata — only the precondition values ({@code
+   * totalApplications}, {@code sampleAppId}, {@code sampleAppName}) are required; the tests for
+   * tags/metadata fail loudly with descriptive messages when their seeds are missing.
+   */
   @Override
   protected TestData performDiscovery() throws IOException {
     var data = new TestData();

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolIT.java
@@ -18,11 +18,14 @@ package com.contrast.labs.ai.mcp.contrast.tool.attack;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrast.labs.ai.mcp.contrast.config.IntegrationTestConfig;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.data.Rule;
 import com.contrast.labs.ai.mcp.contrast.util.AbstractIntegrationTest;
 import com.contrast.labs.ai.mcp.contrast.util.TestDataDiscoveryHelper;
 import com.contrast.labs.ai.mcp.contrast.util.TestDataDiscoveryHelper.ApplicationWithProtectRules;
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -43,6 +46,25 @@ import org.springframework.context.annotation.Import;
 class GetProtectRulesToolIT extends AbstractIntegrationTest<GetProtectRulesToolIT.TestData> {
 
   @Autowired private GetProtectRulesTool getProtectRulesTool;
+
+  // Contrast Protect rule mode enumeration as returned by the TeamServer API (uppercase).
+  // If a real response yields a value outside this set, the mode-assertion test below fails
+  // loudly and this constant is updated after confirming the new mode is legitimate.
+  private static final Set<String> KNOWN_PROTECT_MODES =
+      Set.of(
+          "MONITORING",
+          "BLOCKING",
+          "BLOCK_AT_PERIMETER",
+          "OFF",
+          "NO_ACTION",
+          "PERMIT",
+          "MONITOR_BLOCK",
+          "DISABLED");
+
+  // Rule.type values discriminating response shape. Standard Protect rules populate uuid, modes,
+  // and perimeter capability flags; Virtual Patches populate enabledDev/Qa/Prod instead.
+  private static final String TYPE_PROTECT_RULE = "Protect Rule";
+  private static final String TYPE_VIRTUAL_PATCH = "Virtual Patch";
 
   static class TestData {
     String appId;
@@ -92,120 +114,217 @@ class GetProtectRulesToolIT extends AbstractIntegrationTest<GetProtectRulesToolI
 
   @Test
   void testDiscoveredTestDataExists() {
-    log.info("\n=== Integration Test: Validate test data discovery ===");
-
-    assertThat(testData).as("Test data should have been discovered").isNotNull();
-    assertThat(testData.appId).as("Test application ID should be set").isNotNull();
+    assertThat(testData).as("discovery must populate test data").isNotNull();
+    assertThat(testData.appId).as("discovery must resolve a non-blank app ID").isNotBlank();
+    assertThat(testData.appName).as("discovery must resolve a non-blank app name").isNotBlank();
     assertThat(testData.ruleCount)
-        .as("Test application should have at least 1 rule")
-        .isGreaterThan(0);
-
-    log.info("✓ Test data validated:");
-    log.info("  App ID: {}", testData.appId);
-    log.info("  App Name: {}", testData.appName);
-    log.info("  Rule Count: {}", testData.ruleCount);
+        .as("test application must have at least one Protect rule configured")
+        .isPositive();
   }
 
   @Test
   void getProtectRules_should_return_rules_for_valid_appId() {
-    log.info("\n=== Integration Test: get_protect_rules ===");
-
-    assertThat(testData).as("Test data must be discovered before running tests").isNotNull();
-
     var response = getProtectRulesTool.getProtectRules(testData.appId);
 
-    assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.isSuccess()).as("Response should be successful").isTrue();
-    assertThat(response.data()).as("Data should not be null").isNotNull();
-    assertThat(response.data().getRules()).as("Rules should not be null").isNotNull();
-    assertThat(response.data().getRules().size())
-        .as("Should have at least 1 rule")
-        .isGreaterThan(0);
+    assertThat(response).as("response must not be null").isNotNull();
+    assertThat(response.errors()).as("valid appId must not produce errors").isEmpty();
+    assertThat(response.isSuccess()).as("response must be successful").isTrue();
+    assertThat(response.found()).as("response must indicate data was found").isTrue();
+    assertThat(response.data()).as("data must not be null").isNotNull();
 
-    log.info(
-        "✓ Retrieved {} Protect rules for application: {}",
-        response.data().getRules().size(),
-        testData.appName);
+    var rules = response.data().getRules();
+    assertThat(rules)
+        .as("requires seeded Protect rules on app %s — see INTEGRATION_TESTS.md", testData.appName)
+        .isNotEmpty();
 
-    log.info("  Rules configured:");
-    for (var rule : response.data().getRules()) {
-      String mode = Optional.ofNullable(rule.getProduction()).orElse("not set");
-      log.info("    - {} (production mode: {})", rule.getName(), mode);
-    }
-
-    for (var rule : response.data().getRules()) {
-      assertThat(rule.getName()).as("Rule name should not be null").isNotNull();
-    }
+    // Fields every rule type must populate, regardless of whether it's a standard Protect Rule
+    // or a Virtual Patch: human-readable identity plus the canBlock capability flag.
+    assertThat(rules)
+        .as("every rule must populate core identifying fields across rule types")
+        .allSatisfy(
+            rule -> {
+              assertThat(rule.getName()).as("rule (id=%s).name", rule.getId()).isNotBlank();
+              assertThat(rule.getType()).as("rule %s.type", rule.getName()).isNotBlank();
+              assertThat(rule.getDescription())
+                  .as("rule %s.description", rule.getName())
+                  .isNotBlank();
+              assertThat(rule.getId()).as("rule %s.id", rule.getName()).isPositive();
+              assertThat(rule.getCanBlock()).as("rule %s.canBlock", rule.getName()).isNotNull();
+            });
   }
 
   @Test
   void getProtectRules_should_return_error_for_null_appId() {
-    log.info("\n=== Integration Test: Null app ID handling ===");
-
     var response = getProtectRulesTool.getProtectRules(null);
 
-    assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.isSuccess()).as("Should not be successful").isFalse();
-    assertThat(response.errors()).anyMatch(e -> e.contains("appId is required"));
-
-    log.info("✓ Null app ID correctly rejected");
+    assertThat(response).as("response must not be null").isNotNull();
+    assertThat(response.isSuccess()).as("null appId must fail validation").isFalse();
+    assertThat(response.data()).as("null appId must not return data").isNull();
+    assertThat(response.errors())
+        .as("errors must state appId is required with exact shape")
+        .containsExactly("appId is required");
+    assertThat(response.errors())
+        .as("must be a validation error, not a forwarded API error")
+        .noneMatch(e -> e.contains("Contrast API error"))
+        .noneMatch(e -> e.startsWith("Internal"));
   }
 
   @Test
   void getProtectRules_should_return_error_for_empty_appId() {
-    log.info("\n=== Integration Test: Empty app ID handling ===");
-
     var response = getProtectRulesTool.getProtectRules("");
 
-    assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.isSuccess()).as("Should not be successful").isFalse();
-    assertThat(response.errors()).anyMatch(e -> e.contains("appId is required"));
-
-    log.info("✓ Empty app ID correctly rejected");
+    assertThat(response).as("response must not be null").isNotNull();
+    assertThat(response.isSuccess()).as("empty appId must fail validation").isFalse();
+    assertThat(response.data()).as("empty appId must not return data").isNull();
+    assertThat(response.errors())
+        .as("errors must state appId is required with exact shape")
+        .containsExactly("appId is required");
+    assertThat(response.errors())
+        .as("must be a validation error, not a forwarded API error")
+        .noneMatch(e -> e.contains("Contrast API error"))
+        .noneMatch(e -> e.startsWith("Internal"));
   }
 
   @Test
-  void getProtectRules_should_handle_invalid_appId_gracefully() {
-    log.info("\n=== Integration Test: Invalid app ID handling ===");
+  void getProtectRules_should_return_error_for_whitespace_appId() {
+    // GetProtectRulesParams uses StringUtils.hasText() which treats whitespace-only as blank.
+    var response = getProtectRulesTool.getProtectRules("   ");
 
+    assertThat(response).as("response must not be null").isNotNull();
+    assertThat(response.isSuccess()).as("whitespace-only appId must fail validation").isFalse();
+    assertThat(response.data()).as("whitespace-only appId must not return data").isNull();
+    assertThat(response.errors())
+        .as("errors must state appId is required with exact shape")
+        .containsExactly("appId is required");
+    assertThat(response.errors())
+        .as("must be a validation error, not a forwarded API error")
+        .noneMatch(e -> e.contains("Contrast API error"))
+        .noneMatch(e -> e.startsWith("Internal"));
+  }
+
+  @Test
+  void getProtectRules_should_not_return_populated_data_for_invalid_appId() {
+    // Single deterministic expectation: whether the API errors or returns an empty/not-found
+    // payload, the tool must never surface populated Protect data for a bogus app ID.
     var response = getProtectRulesTool.getProtectRules("invalid-app-id-12345");
 
-    assertThat(response).as("Response should not be null").isNotNull();
-
-    // API may return null/empty or throw exception - both are acceptable
-    if (response.isSuccess()) {
-      log.info("✓ API handled invalid app ID gracefully");
-      if (response.data() == null) {
-        log.info("  Response: null (no Protect data for invalid app)");
-      }
-    } else {
-      log.info("✓ API rejected invalid app ID");
-      log.info("  Errors: {}", response.errors());
-    }
+    assertThat(response).as("response must not be null").isNotNull();
+    assertThat(response.data()).as("invalid appId must not return populated Protect data").isNull();
+    assertThat(response.found()).as("invalid appId must not be marked as found").isFalse();
   }
 
   @Test
-  void getProtectRules_should_return_rule_details() {
-    log.info("\n=== Integration Test: Verify rule details ===");
-
-    assertThat(testData).as("Test data must be discovered before running tests").isNotNull();
-
+  void getProtectRules_should_populate_protect_rule_details() {
     var response = getProtectRulesTool.getProtectRules(testData.appId);
+    assertThat(response.isSuccess()).as("response must be successful").isTrue();
 
-    assertThat(response.isSuccess()).isTrue();
-    assertThat(response.data().getRules()).isNotEmpty();
+    var protectRules = rulesOfType(response.data().getRules(), TYPE_PROTECT_RULE);
+    assertThat(protectRules)
+        .as(
+            "requires seeded standard Protect Rules (type='%s') on app %s — see"
+                + " INTEGRATION_TESTS.md",
+            TYPE_PROTECT_RULE, testData.appName)
+        .isNotEmpty();
 
-    log.info("✓ Verifying rule details for {} rules:", response.data().getRules().size());
+    // Standard Protect Rules (e.g., sql-injection, path-traversal) populate the complete shape:
+    // slug uuid, per-environment mode strings, perimeter capability booleans, and parent-rule
+    // linkage (top-level rules self-reference via parentRuleUuid==uuid).
+    assertThat(protectRules)
+        .as("every standard Protect Rule must populate its full field shape")
+        .allSatisfy(
+            rule -> {
+              assertThat(rule.getUuid()).as("%s.uuid", rule.getName()).isNotBlank();
+              assertThat(rule.getProduction()).as("%s.production", rule.getName()).isNotBlank();
+              assertThat(rule.getDevelopment()).as("%s.development", rule.getName()).isNotBlank();
+              assertThat(rule.getQa()).as("%s.qa", rule.getName()).isNotBlank();
+              assertThat(rule.getCanBlockAtPerimeter())
+                  .as("%s.canBlockAtPerimeter", rule.getName())
+                  .isNotNull();
+              assertThat(rule.getIsMonitorAtPerimeter())
+                  .as("%s.isMonitorAtPerimeter", rule.getName())
+                  .isNotNull();
+              assertThat(rule.getParentRuleUuid())
+                  .as("%s.parentRuleUuid", rule.getName())
+                  .isNotBlank();
+              assertThat(rule.getParentRuleName())
+                  .as("%s.parentRuleName", rule.getName())
+                  .isNotBlank();
+            });
+  }
 
-    for (var rule : response.data().getRules()) {
-      log.info("\n  Rule: {}", rule.getName());
-      assertThat(rule.getName()).as("Rule name is required").isNotNull();
-      log.info("    ✓ Name: {}", rule.getName());
-      if (rule.getProduction() != null) {
-        log.info("    ✓ Production Mode: {}", rule.getProduction());
-      }
-    }
+  @Test
+  void getProtectRules_should_return_only_known_protect_modes() {
+    var response = getProtectRulesTool.getProtectRules(testData.appId);
+    var protectRules = rulesOfType(response.data().getRules(), TYPE_PROTECT_RULE);
+    assertThat(protectRules)
+        .as("requires seeded standard Protect Rules on app %s", testData.appName)
+        .isNotEmpty();
 
-    log.info("\n✓ All rules have valid structure and required fields");
+    // Every environment mode must match the known Contrast Protect enumeration. An unknown value
+    // indicates either a newly introduced mode (update KNOWN_PROTECT_MODES) or a deserialization
+    // regression.
+    assertThat(protectRules)
+        .as(
+            "every production/development/qa mode must be in known Protect mode set %s",
+            KNOWN_PROTECT_MODES)
+        .allSatisfy(
+            rule -> {
+              assertThat(rule.getProduction())
+                  .as("%s.production", rule.getName())
+                  .isIn(KNOWN_PROTECT_MODES);
+              assertThat(rule.getDevelopment())
+                  .as("%s.development", rule.getName())
+                  .isIn(KNOWN_PROTECT_MODES);
+              assertThat(rule.getQa()).as("%s.qa", rule.getName()).isIn(KNOWN_PROTECT_MODES);
+            });
+  }
+
+  @Test
+  void getProtectRules_should_populate_virtual_patch_enablement_flags() {
+    var response = getProtectRulesTool.getProtectRules(testData.appId);
+    var virtualPatches = rulesOfType(response.data().getRules(), TYPE_VIRTUAL_PATCH);
+
+    assertThat(virtualPatches)
+        .as(
+            "requires seeded Virtual Patch (type='%s') on app %s to verify enabledDev/Qa/Prod —"
+                + " see INTEGRATION_TESTS.md",
+            TYPE_VIRTUAL_PATCH, testData.appName)
+        .isNotEmpty();
+
+    // Virtual Patches use per-environment Boolean enablement flags instead of mode strings.
+    // Assert all three are populated; a null indicates a deserialization or API-shape regression.
+    assertThat(virtualPatches)
+        .as("every Virtual Patch must populate enabledDev/enabledQa/enabledProd")
+        .allSatisfy(
+            rule -> {
+              assertThat(rule.getEnabledDev()).as("%s.enabledDev", rule.getName()).isNotNull();
+              assertThat(rule.getEnabledQa()).as("%s.enabledQa", rule.getName()).isNotNull();
+              assertThat(rule.getEnabledProd()).as("%s.enabledProd", rule.getName()).isNotNull();
+            });
+  }
+
+  @Test
+  void getProtectRules_should_populate_cves_consistently() {
+    var response = getProtectRulesTool.getProtectRules(testData.appId);
+    var rules = response.data().getRules();
+    assertThat(rules).as("response must contain rules to verify").isNotEmpty();
+
+    // cves is nullable per rule; when populated it must contain non-null Cve entries. This catches
+    // both an accidental empty list (API shape change) and any null pollution in the list.
+    assertThat(rules)
+        .as("cves, when populated, must be a non-empty list with no null entries")
+        .allSatisfy(
+            rule -> {
+              if (rule.getCves() != null) {
+                assertThat(rule.getCves())
+                    .as("%s.cves", rule.getName())
+                    .isNotEmpty()
+                    .doesNotContainNull();
+              }
+            });
+  }
+
+  private static List<Rule> rulesOfType(List<Rule> rules, String type) {
+    return rules.stream().filter(r -> type.equals(r.getType())).toList();
   }
 }

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolIT.java
@@ -88,6 +88,13 @@ class GetProtectRulesToolIT extends AbstractIntegrationTest<GetProtectRulesToolI
     return TestData.class;
   }
 
+  /**
+   * Locates an application that has at least one Protect rule configured (standard rule or Virtual
+   * Patch). The tests need a non-zero rule count to exercise {@code get_protect_rules}'s rule-shape
+   * assertions ({@code allSatisfy} over {@code name}/{@code type}/{@code description}/{@code id}/
+   * {@code canBlock}); a zero-rule app would silently pass the assertion. The discovered {@code
+   * appId} also drives the happy-path retrieval test.
+   */
   @Override
   protected TestData performDiscovery() throws IOException {
     Optional<ApplicationWithProtectRules> protectCandidate =

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksToolIT.java
@@ -18,6 +18,11 @@ package com.contrast.labs.ai.mcp.contrast.tool.attack;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrast.labs.ai.mcp.contrast.config.IntegrationTestConfig;
+import com.contrast.labs.ai.mcp.contrast.result.AttackSummary;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -43,8 +48,6 @@ class SearchAttacksToolIT {
 
   @Test
   void searchAttacks_should_return_response_with_no_filters() {
-    log.info("\n=== Integration Test: search_attacks (no filters) ===");
-
     var response =
         searchAttacksTool.searchAttacks(1, 10, null, null, null, null, null, null, null, null);
 
@@ -53,18 +56,8 @@ class SearchAttacksToolIT {
     assertThat(response.page()).as("Page should be 1").isEqualTo(1);
     assertThat(response.pageSize()).as("Page size should be 10").isEqualTo(10);
 
-    log.info("✓ Retrieved {} attacks", response.items().size());
-    log.info("  Total items: {}", response.totalItems());
-    log.info("  Has more pages: {}", response.hasMorePages());
-
     if (!response.items().isEmpty()) {
       var firstAttack = response.items().get(0);
-      log.info("  Sample attack:");
-      log.info("    Attack ID: {}", firstAttack.attackId());
-      log.info("    Status: {}", firstAttack.status());
-      log.info("    Source: {}", firstAttack.source());
-      log.info("    Rules: {}", firstAttack.rules());
-
       assertThat(firstAttack.attackId()).as("Attack ID should not be null").isNotNull();
       assertThat(firstAttack.status()).as("Status should not be null").isNotNull();
     }
@@ -72,59 +65,80 @@ class SearchAttacksToolIT {
 
   @Test
   void searchAttacks_should_filter_by_quickFilter() {
-    log.info("\n=== Integration Test: search_attacks (quickFilter=EFFECTIVE) ===");
-
     var response =
         searchAttacksTool.searchAttacks(
-            1, 10, "EFFECTIVE", null, null, null, null, null, null, null);
+            1, 50, "EFFECTIVE", null, null, null, null, null, null, null);
 
     assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.items()).as("Items should not be null").isNotNull();
+    assertThat(response.errors()).as("Should have no errors").isEmpty();
+    assertThat(response.items())
+        .as("requires seeded EFFECTIVE attacks in test org — see INTEGRATION_TESTS.md")
+        .isNotEmpty();
 
-    log.info("✓ Retrieved {} EFFECTIVE attacks", response.items().size());
+    // EFFECTIVE excludes probed attacks per SearchAttacksTool description (line 89).
+    assertThat(response.items())
+        .as("EFFECTIVE filter must exclude PROBED attacks")
+        .allSatisfy(
+            attack ->
+                assertThat(attack.status())
+                    .as("attack %s status", attack.attackId())
+                    .isNotEqualTo("PROBED"));
   }
 
   @Test
   void searchAttacks_should_filter_by_statusFilter() {
-    log.info("\n=== Integration Test: search_attacks (statusFilter=EXPLOITED) ===");
-
     var response =
         searchAttacksTool.searchAttacks(
-            1, 10, null, "EXPLOITED", null, null, null, null, null, null);
+            1, 50, null, "EXPLOITED", null, null, null, null, null, null);
 
     assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.items()).as("Items should not be null").isNotNull();
-
-    log.info("✓ Retrieved {} EXPLOITED attacks", response.items().size());
+    assertThat(response.errors()).as("Should have no errors").isEmpty();
+    assertThat(response.items())
+        .as("requires seeded EXPLOITED attacks in test org — see INTEGRATION_TESTS.md")
+        .isNotEmpty();
+    assertThat(response.items())
+        .as("statusFilter=EXPLOITED must return only EXPLOITED attacks")
+        .allSatisfy(
+            attack ->
+                assertThat(attack.status())
+                    .as("attack %s status", attack.attackId())
+                    .isEqualTo("EXPLOITED"));
   }
 
   @Test
   void searchAttacks_should_filter_by_keyword() {
-    log.info("\n=== Integration Test: search_attacks (keyword=sql) ===");
-
     var response =
-        searchAttacksTool.searchAttacks(1, 10, null, null, "sql", null, null, null, null, null);
+        searchAttacksTool.searchAttacks(1, 50, null, null, "sql", null, null, null, null, null);
 
     assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.items()).as("Items should not be null").isNotNull();
+    assertThat(response.errors()).as("Should have no errors").isEmpty();
+    assertThat(response.items())
+        .as("requires seeded attacks matching keyword 'sql' — see INTEGRATION_TESTS.md")
+        .isNotEmpty();
 
-    log.info("✓ Retrieved {} attacks matching keyword 'sql'", response.items().size());
+    // Keyword performs substring match across source IP, server name, application name, rule name,
+    // attack UUID, forwarded IP/path, and attack tags (OR logic). Of those, only source IP,
+    // application name, rule name, and attack UUID are exposed on AttackSummary. A match on a
+    // non-exposed field (server name, forwarded path, tags) would fail this assertion — the
+    // production-seeded SQL-injection data is expected to include at least one visible-field match
+    // (typically rule names like "sql-injection").
+    assertThat(response.items())
+        .as("keyword 'sql' must appear in at least one visible searchable field per result")
+        .allSatisfy(
+            attack ->
+                assertThat(visibleSearchableStrings(attack))
+                    .as("attack %s searchable fields", attack.attackId())
+                    .anyMatch(s -> s.toLowerCase().contains("sql")));
   }
 
   @Test
   void searchAttacks_should_handle_pagination() {
-    log.info("\n=== Integration Test: search_attacks (pagination) ===");
-
     var page1 =
         searchAttacksTool.searchAttacks(1, 5, null, null, null, null, null, null, null, null);
 
     assertThat(page1).as("Page 1 response should not be null").isNotNull();
     assertThat(page1.page()).as("Should be page 1").isEqualTo(1);
     assertThat(page1.pageSize()).as("Page size should be 5").isEqualTo(5);
-
-    log.info("✓ Page 1: {} attacks", page1.items().size());
-    log.info("  Total items: {}", page1.totalItems());
-    log.info("  Has more pages: {}", page1.hasMorePages());
 
     if (page1.hasMorePages()) {
       var page2 =
@@ -133,34 +147,32 @@ class SearchAttacksToolIT {
       assertThat(page2).as("Page 2 response should not be null").isNotNull();
       assertThat(page2.page()).as("Should be page 2").isEqualTo(2);
 
-      log.info("✓ Page 2: {} attacks", page2.items().size());
-
-      if (!page1.items().isEmpty() && !page2.items().isEmpty()) {
-        assertThat(page1.items().get(0).attackId())
-            .as("Page 1 and Page 2 should have different attacks")
-            .isNotEqualTo(page2.items().get(0).attackId());
-      }
+      var page1Ids = page1.items().stream().map(AttackSummary::attackId).toList();
+      var page2Ids = page2.items().stream().map(AttackSummary::attackId).toList();
+      assertThat(page2Ids)
+          .as("Page 2 items should be disjoint from page 1 items")
+          .doesNotContainAnyElementsOf(page1Ids);
     }
   }
 
   @Test
   void searchAttacks_should_handle_sort() {
-    log.info("\n=== Integration Test: search_attacks (sort=-startTime) ===");
-
     var response =
         searchAttacksTool.searchAttacks(
             1, 10, null, null, null, null, null, null, "-startTime", null);
 
     assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.items()).as("Items should not be null").isNotNull();
-
-    log.info("✓ Retrieved {} attacks sorted by -startTime", response.items().size());
+    assertThat(response.errors()).as("Should have no errors").isEmpty();
+    assertThat(response.items())
+        .as("requires seeded attacks to verify sort order — see INTEGRATION_TESTS.md")
+        .isNotEmpty();
+    assertThat(response.items())
+        .as("sort=-startTime must return items ordered by startTimeMs descending")
+        .isSortedAccordingTo(Comparator.comparingLong(AttackSummary::startTimeMs).reversed());
   }
 
   @Test
   void searchAttacks_should_return_error_for_invalid_quickFilter() {
-    log.info("\n=== Integration Test: search_attacks (invalid quickFilter) ===");
-
     var response =
         searchAttacksTool.searchAttacks(1, 10, "INVALID", null, null, null, null, null, null, null);
 
@@ -169,15 +181,10 @@ class SearchAttacksToolIT {
     assertThat(response.errors())
         .as("Should explain invalid filter")
         .anyMatch(e -> e.contains("Invalid quickFilter"));
-
-    log.info("✓ Invalid filter correctly rejected");
-    log.info("  Errors: {}", response.errors());
   }
 
   @Test
   void searchAttacks_should_return_error_for_invalid_statusFilter() {
-    log.info("\n=== Integration Test: search_attacks (invalid statusFilter) ===");
-
     var response =
         searchAttacksTool.searchAttacks(1, 10, null, "INVALID", null, null, null, null, null, null);
 
@@ -186,45 +193,61 @@ class SearchAttacksToolIT {
     assertThat(response.errors())
         .as("Should explain invalid filter")
         .anyMatch(e -> e.contains("Invalid statusFilter"));
-
-    log.info("✓ Invalid status filter correctly rejected");
-    log.info("  Errors: {}", response.errors());
   }
 
   @Test
   void searchAttacks_should_handle_boolean_filters() {
-    log.info("\n=== Integration Test: search_attacks (boolean filters) ===");
+    // Compare with and without suppressed attacks to verify includeSuppressed takes effect.
+    // AttackSummary does not expose the `suppressed` field, so we can only assert the count
+    // relationship: including suppressed must return at least as many results as excluding them.
+    var withSuppressed =
+        searchAttacksTool.searchAttacks(1, 100, null, null, null, true, null, null, null, null);
+    var withoutSuppressed =
+        searchAttacksTool.searchAttacks(1, 100, null, null, null, false, null, null, null, null);
 
-    var response =
-        searchAttacksTool.searchAttacks(1, 10, null, null, null, true, null, null, null, null);
+    assertThat(withSuppressed.errors())
+        .as("includeSuppressed=true should have no errors")
+        .isEmpty();
+    assertThat(withoutSuppressed.errors())
+        .as("includeSuppressed=false should have no errors")
+        .isEmpty();
 
-    assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.items()).as("Items should not be null").isNotNull();
-
-    log.info("✓ Retrieved {} attacks with includeSuppressed=true", response.items().size());
+    assertThat(totalOrZero(withSuppressed.totalItems()))
+        .as("includeSuppressed=true must return >= total items than includeSuppressed=false")
+        .isGreaterThanOrEqualTo(totalOrZero(withoutSuppressed.totalItems()));
   }
 
   @Test
   void searchAttacks_should_handle_combined_filters() {
-    log.info("\n=== Integration Test: search_attacks (combined filters) ===");
-
     var response =
         searchAttacksTool.searchAttacks(
-            1, 10, "EFFECTIVE", "EXPLOITED", null, false, null, null, null, null);
+            1, 50, "EFFECTIVE", "EXPLOITED", null, false, null, null, null, null);
 
     assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.items()).as("Items should not be null").isNotNull();
+    assertThat(response.errors()).as("Should have no errors").isEmpty();
+    assertThat(response.items())
+        .as("requires seeded EFFECTIVE+EXPLOITED attacks — see INTEGRATION_TESTS.md")
+        .isNotEmpty();
 
-    log.info("✓ Retrieved {} attacks with combined filters", response.items().size());
-    log.info("  Filters: quickFilter=EFFECTIVE, statusFilter=EXPLOITED");
+    // Intersection of EFFECTIVE (excludes PROBED) and statusFilter=EXPLOITED must hold per result.
+    // includeSuppressed=false cannot be verified from AttackSummary (field not exposed).
+    assertThat(response.items())
+        .as("every result must satisfy both quickFilter=EFFECTIVE and statusFilter=EXPLOITED")
+        .allSatisfy(
+            attack -> {
+              assertThat(attack.status())
+                  .as("attack %s status must be EXPLOITED (statusFilter)", attack.attackId())
+                  .isEqualTo("EXPLOITED");
+              assertThat(attack.status())
+                  .as("attack %s status must not be PROBED (EFFECTIVE)", attack.attackId())
+                  .isNotEqualTo("PROBED");
+            });
   }
 
   // ========== Sort Field Validation Tests (Bug Fix: AIML-345) ==========
 
   @Test
   void searchAttacks_should_return_validation_error_for_invalid_sort_field() {
-    log.info("\n=== Integration Test: search_attacks (invalid sort field - BUG FIX) ===");
-
     // This test verifies the bug fix: invalid sort fields should return a helpful
     // validation error listing valid options, NOT a generic "Contrast API error"
     var response =
@@ -242,33 +265,23 @@ class SearchAttacksToolIT {
     assertThat(response.errors())
         .as("Error message should NOT be generic API error")
         .noneMatch(e -> e.contains("Contrast API error"));
-
-    log.info("✓ Invalid sort field correctly rejected with helpful error");
-    log.info("  Errors: {}", response.errors());
   }
 
   @ParameterizedTest(name = "valid sort field: {0}")
   @ValueSource(strings = {"sourceIP", "status", "startTime", "endTime", "type"})
   void searchAttacks_should_accept_all_valid_sort_fields(String sortField) {
-    log.info("\n=== Integration Test: search_attacks (sort={}) ===", sortField);
-
     var response =
         searchAttacksTool.searchAttacks(1, 10, null, null, null, null, null, null, sortField, null);
 
     assertThat(response).as("Response should not be null").isNotNull();
     assertThat(response.errors()).as("Should have no errors for sort: " + sortField).isEmpty();
     assertThat(response.items()).as("Items should not be null").isNotNull();
-
-    log.info("✓ Sort field '{}' accepted", sortField);
-    log.info("  Results: {} attacks found", response.items().size());
   }
 
   @ParameterizedTest(name = "valid sort field descending: -{0}")
   @ValueSource(strings = {"sourceIP", "status", "startTime", "endTime", "type"})
   void searchAttacks_should_accept_all_valid_sort_fields_with_descending_prefix(String sortField) {
     String descending = "-" + sortField;
-    log.info("\n=== Integration Test: search_attacks (sort={}) ===", descending);
-
     var response =
         searchAttacksTool.searchAttacks(
             1, 10, null, null, null, null, null, null, descending, null);
@@ -276,16 +289,11 @@ class SearchAttacksToolIT {
     assertThat(response).as("Response should not be null").isNotNull();
     assertThat(response.errors()).as("Should have no errors for sort: " + descending).isEmpty();
     assertThat(response.items()).as("Items should not be null").isNotNull();
-
-    log.info("✓ Sort field '{}' accepted", descending);
-    log.info("  Results: {} attacks found", response.items().size());
   }
 
   @ParameterizedTest(name = "invalid sort field: {0}")
   @ValueSource(strings = {"severity", "probes", "NEWEST", "OLDEST", "invalidField"})
   void searchAttacks_should_reject_invalid_sort_fields(String sortField) {
-    log.info("\n=== Integration Test: search_attacks (invalid sort={}) ===", sortField);
-
     var response =
         searchAttacksTool.searchAttacks(1, 10, null, null, null, null, null, null, sortField, null);
 
@@ -296,33 +304,29 @@ class SearchAttacksToolIT {
     assertThat(response.errors())
         .as("Should be validation error not API error")
         .anyMatch(e -> e.contains("Invalid sort field"));
-
-    log.info("✓ Invalid sort field '{}' correctly rejected", sortField);
-    log.info("  Errors: {}", response.errors());
   }
 
   // ========== Keyword and Rules Parameter Tests (Bug Fix: AIML-385) ==========
 
   @Test
-  void searchAttacks_should_find_results_with_keyword_SQL_Injection() {
-    log.info("\n=== Integration Test: search_attacks (keyword='SQL Injection') ===");
-
+  void searchAttacks_should_accept_keyword_with_spaces_without_error() {
+    // Narrow contract: multi-word keywords must be URL-encoded safely and accepted by the API.
+    // We do NOT assert results are non-empty because the seeded test org may not contain attacks
+    // whose visible fields match "SQL Injection" as a literal substring — keyword also matches
+    // rule display names which aren't exposed on AttackSummary.
     var response =
         searchAttacksTool.searchAttacks(
             1, 10, null, null, "SQL Injection", null, null, null, null, null);
 
     assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.errors()).as("Should have no errors").isEmpty();
-
-    log.info(
-        "✓ Retrieved {} attacks using keyword 'SQL Injection' (display name search)",
-        response.items().size());
+    assertThat(response.errors())
+        .as("keyword with spaces must be URL-encoded and accepted without error")
+        .isEmpty();
+    assertThat(response.items()).as("Items should not be null").isNotNull();
   }
 
   @Test
   void searchAttacks_should_find_results_with_rules_filter() {
-    log.info("\n=== Integration Test: search_attacks (rules='sql-injection') ===");
-
     var response =
         searchAttacksTool.searchAttacks(
             1, 10, null, null, null, null, null, null, null, "sql-injection");
@@ -337,24 +341,32 @@ class SearchAttacksToolIT {
               attack ->
                   assertThat(attack.rules()).anyMatch(rule -> rule.toLowerCase().contains("sql")));
     }
-
-    log.info(
-        "✓ Retrieved {} attacks using rules='sql-injection' (exact rule ID filter)",
-        response.items().size());
   }
 
   @Test
   void searchAttacks_should_find_results_with_multiple_rules() {
-    log.info("\n=== Integration Test: search_attacks (rules='sql-injection,xss-reflected') ===");
-
     var response =
         searchAttacksTool.searchAttacks(
-            1, 10, null, null, null, null, null, null, null, "sql-injection,xss-reflected");
+            1, 50, null, null, null, null, null, null, null, "sql-injection,xss-reflected");
 
     assertThat(response).as("Response should not be null").isNotNull();
     assertThat(response.errors()).as("Should have no errors").isEmpty();
+    assertThat(response.items())
+        .as("requires seeded attacks matching sql-injection or xss-reflected rules")
+        .isNotEmpty();
 
-    log.info("✓ Retrieved {} attacks using multiple rules filter", response.items().size());
+    // Every attack must have at least one rule matching one of the two requested rule families.
+    assertThat(response.items())
+        .as("every result must match at least one of the requested rules (sql or xss)")
+        .allSatisfy(
+            attack ->
+                assertThat(attack.rules())
+                    .as("attack %s rules", attack.attackId())
+                    .anyMatch(
+                        rule -> {
+                          var lower = rule.toLowerCase();
+                          return lower.contains("sql") || lower.contains("xss");
+                        }));
   }
 
   // ========== Special Character Keyword Tests (Test Cases 3.5 and 13.4) ==========
@@ -373,16 +385,38 @@ class SearchAttacksToolIT {
         "%00null-byte" // Null byte pattern (tests double-encoding of %)
       })
   void searchAttacks_should_handle_specialCharacterKeywords(String keyword) {
-    log.info("\n=== Integration Test: search_attacks (keyword='{}') ===", keyword);
-
+    // Narrow contract: keyword is URL-encoded safely without triggering API-side attack
+    // detection. Result content is irrelevant — seeded test data is not expected to match these
+    // adversarial keywords. We only assert the request round-trips without error.
     var response =
         searchAttacksTool.searchAttacks(1, 10, null, null, keyword, null, null, null, null, null);
 
     assertThat(response).as("Response should not be null").isNotNull();
     assertThat(response.errors()).as("Should have no errors for keyword: " + keyword).isEmpty();
     assertThat(response.items()).as("Items should not be null").isNotNull();
+  }
 
-    log.info("✓ Special character keyword handled correctly: {}", keyword);
-    log.info("  Results: {} attacks found", response.items().size());
+  /**
+   * Collects all string fields on an {@link AttackSummary} that participate in keyword substring
+   * matching and are exposed on the summary. Server name, forwarded IP/path, and attack tags are
+   * also keyword-searchable on the server side but are not exposed on AttackSummary.
+   */
+  private static List<String> visibleSearchableStrings(AttackSummary attack) {
+    var appStrings =
+        Optional.ofNullable(attack.applications()).orElse(List.of()).stream()
+            .flatMap(
+                app ->
+                    Stream.of(app.applicationName(), app.applicationId())
+                        .filter(s -> s != null && !s.isBlank()));
+    var ruleStrings =
+        Optional.ofNullable(attack.rules()).orElse(List.of()).stream()
+            .filter(s -> s != null && !s.isBlank());
+    var topLevel =
+        Stream.of(attack.source(), attack.attackId()).filter(s -> s != null && !s.isBlank());
+    return Stream.concat(Stream.concat(topLevel, ruleStrings), appStrings).toList();
+  }
+
+  private static int totalOrZero(Integer totalItems) {
+    return totalItems != null ? totalItems : 0;
   }
 }

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolIT.java
@@ -18,12 +18,12 @@ package com.contrast.labs.ai.mcp.contrast.tool.coverage;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrast.labs.ai.mcp.contrast.config.IntegrationTestConfig;
-import com.contrast.labs.ai.mcp.contrast.result.RouteLight;
 import com.contrast.labs.ai.mcp.contrast.util.AbstractIntegrationTest;
 import com.contrast.labs.ai.mcp.contrast.util.TestDataDiscoveryHelper;
 import com.contrast.labs.ai.mcp.contrast.util.TestDataDiscoveryHelper.RouteCoverageTestData;
 import java.io.IOException;
 import java.util.Optional;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -32,25 +32,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 
 /**
- * Integration test for GetRouteCoverageTool that validates route coverage data from real
- * TeamServer.
+ * Integration tests for {@link GetRouteCoverageTool} verifying the contract across the SDK/Route
+ * Coverage API boundary. Cited in {@code CLAUDE.md} → Integration Test Standards as a canonical
+ * example for pagination + filter + edge cases; assertions here must remain mutation-resistant.
  *
  * <p>This test automatically discovers suitable test data by querying the Contrast API. It looks
  * for applications with route coverage, sessions, and session metadata.
  *
- * <p>This test only runs if CONTRAST_HOST_NAME environment variable is set.
- *
- * <p>Required environment variables:
- *
- * <ul>
- *   <li>CONTRAST_HOST_NAME (e.g., app.contrastsecurity.com)
- *   <li>CONTRAST_API_KEY
- *   <li>CONTRAST_SERVICE_KEY
- *   <li>CONTRAST_USERNAME
- *   <li>CONTRAST_ORG_ID
- * </ul>
- *
- * <p>Run locally: source .env.integration-test && mvn verify
+ * <p>Run locally: {@code source .env.integration-test && mvn verify}
  */
 @Slf4j
 @SpringBootTest
@@ -60,6 +49,42 @@ public class GetRouteCoverageToolIT
     extends AbstractIntegrationTest<GetRouteCoverageToolIT.TestData> {
 
   @Autowired private GetRouteCoverageTool getRouteCoverageTool;
+
+  // SingleTool's 5xx mapping — validation errors must never look like this.
+  private static final String CONTRAST_API_ERROR = "Contrast API error";
+
+  // Exact validation messages produced by RouteCoverageParams. Asserting full message shape (not a
+  // parameter-name substring) prevents a false-positive match against any unrelated error.
+  private static final String APP_ID_REQUIRED_ERROR = "appId is required";
+  private static final String METADATA_VALUE_REQUIRED_ERROR =
+      "sessionMetadataValue is required when sessionMetadataName is provided";
+  private static final String METADATA_NAME_REQUIRED_ERROR =
+      "sessionMetadataName is required when sessionMetadataValue is provided";
+
+  // Mutually-exclusive-filter warning emitted by RouteCoverageParams when both useLatestSession and
+  // session metadata filters are supplied together. The tool's contract documents that
+  // useLatestSession takes precedence — this test verifies the user is told.
+  private static final String MUTUALLY_EXCLUSIVE_FILTERS_WARNING =
+      "Both useLatestSession and sessionMetadataName provided - "
+          + "useLatestSession takes precedence and sessionMetadata filter will be ignored";
+
+  // Route status enumeration — see RouteLight javadoc and RouteMapper#toResponseLight, which
+  // partitions routes into exercised/discovered counts using these labels (case-insensitive).
+  private static final Set<String> KNOWN_ROUTE_STATUSES = Set.of("DISCOVERED", "EXERCISED");
+
+  // Environment enumeration — see RouteLight javadoc: "Distinct environments where route has been
+  // observed (DEVELOPMENT, QA, PRODUCTION)". An unknown value indicates either a new environment
+  // (update this set) or an upstream regression.
+  private static final Set<String> KNOWN_ENVIRONMENTS = Set.of("DEVELOPMENT", "QA", "PRODUCTION");
+
+  // App ID values used by error-path tests. The "invalid" value should pass parameter validation
+  // (non-blank) but fail to resolve to any real application; the "malformed metadata" values
+  // exercise robustness against unusual but well-formed strings.
+  private static final String INVALID_APP_ID = "invalid-app-id-12345";
+  private static final String NONEXISTENT_METADATA_NAME = "nonexistent-metadata-name-zzz999";
+  private static final String NONEXISTENT_METADATA_VALUE = "nonexistent-value-zzz999";
+  private static final String MALFORMED_METADATA_NAME = "name with spaces and !@#$%^&*";
+  private static final String MALFORMED_METADATA_VALUE = "value\nwith\tcontrol\rchars";
 
   /** Container for discovered test data. */
   static class TestData {
@@ -141,7 +166,7 @@ public class GetRouteCoverageToolIT
   private void warnIfNoSessionMetadata(TestData data) {
     if (!data.hasSessionMetadata) {
       log.warn("\n⚠️  WARNING: Application has route coverage but NO SESSION METADATA");
-      log.warn("   Some metadata-dependent assertions may be skipped.");
+      log.warn("   Metadata-dependent tests will fail loudly with a clear precondition message.");
     }
   }
 
@@ -167,281 +192,431 @@ public class GetRouteCoverageToolIT
   // ========== Validation tests ==========
 
   @Test
-  void getRouteCoverage_should_return_validation_error_for_missing_appId() {
-    var result = getRouteCoverageTool.getRouteCoverage(null, null, null, null);
+  void getRouteCoverage_should_return_validation_error_for_null_appId() {
+    var response = getRouteCoverageTool.getRouteCoverage(null, null, null, null);
 
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("appId") && e.contains("required"));
+    assertThat(response).as("response must not be null").isNotNull();
+    assertThat(response.isSuccess()).as("null appId must fail validation").isFalse();
+    assertThat(response.data()).as("validation failure must not carry data").isNull();
+    assertThat(response.found()).as("validation failure must not report found").isFalse();
+    assertThat(response.errors())
+        .as("errors must state appId is required with exact shape")
+        .containsExactly(APP_ID_REQUIRED_ERROR);
+    assertThat(response.errors())
+        .as("must be a validation error, not a forwarded API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR))
+        .noneMatch(e -> e.startsWith("Internal"));
+  }
+
+  @Test
+  void getRouteCoverage_should_return_validation_error_for_empty_appId() {
+    var response = getRouteCoverageTool.getRouteCoverage("", null, null, null);
+
+    assertThat(response).as("response must not be null").isNotNull();
+    assertThat(response.isSuccess()).as("empty appId must fail validation").isFalse();
+    assertThat(response.data()).as("validation failure must not carry data").isNull();
+    assertThat(response.errors())
+        .as("errors must state appId is required with exact shape")
+        .containsExactly(APP_ID_REQUIRED_ERROR);
+    assertThat(response.errors())
+        .as("must be a validation error, not a forwarded API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
+  }
+
+  @Test
+  void getRouteCoverage_should_return_validation_error_for_whitespace_appId() {
+    // ToolValidationContext#require uses StringUtils.hasText, which rejects whitespace as well as
+    // null/empty. Without this test a regression that switched to isEmpty() would silently allow
+    // whitespace strings to reach the SDK and surface as opaque API errors.
+    var response = getRouteCoverageTool.getRouteCoverage("   ", null, null, null);
+
+    assertThat(response).as("response must not be null").isNotNull();
+    assertThat(response.isSuccess()).as("whitespace-only appId must fail validation").isFalse();
+    assertThat(response.data()).as("validation failure must not carry data").isNull();
+    assertThat(response.errors())
+        .as("errors must state appId is required with exact shape")
+        .containsExactly(APP_ID_REQUIRED_ERROR);
+    assertThat(response.errors())
+        .as("must be a validation error, not a forwarded API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
   }
 
   @Test
   void getRouteCoverage_should_return_validation_error_for_unpaired_metadata_name() {
-    var result = getRouteCoverageTool.getRouteCoverage(testData.appId, "branch", null, null);
+    var response = getRouteCoverageTool.getRouteCoverage(testData.appId, "branch", null, null);
 
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors())
-        .anyMatch(e -> e.contains("sessionMetadataValue") && e.contains("required"));
+    assertThat(response.isSuccess()).as("unpaired metadata name must fail validation").isFalse();
+    assertThat(response.data()).as("validation failure must not carry data").isNull();
+    assertThat(response.errors())
+        .as("errors must state sessionMetadataValue is required with exact shape")
+        .containsExactly(METADATA_VALUE_REQUIRED_ERROR);
+    assertThat(response.errors())
+        .as("must be a validation error, not a forwarded API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
   }
 
   @Test
   void getRouteCoverage_should_return_validation_error_for_unpaired_metadata_value() {
-    var result = getRouteCoverageTool.getRouteCoverage(testData.appId, null, "main", null);
+    var response = getRouteCoverageTool.getRouteCoverage(testData.appId, null, "main", null);
 
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors())
-        .anyMatch(e -> e.contains("sessionMetadataName") && e.contains("required"));
+    assertThat(response.isSuccess()).as("unpaired metadata value must fail validation").isFalse();
+    assertThat(response.data()).as("validation failure must not carry data").isNull();
+    assertThat(response.errors())
+        .as("errors must state sessionMetadataName is required with exact shape")
+        .containsExactly(METADATA_NAME_REQUIRED_ERROR);
+    assertThat(response.errors())
+        .as("must be a validation error, not a forwarded API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
   }
 
-  // ========== Unfiltered query tests ==========
+  @Test
+  void getRouteCoverage_should_emit_warning_when_both_filters_provided() {
+    // Tool contract: useLatestSession takes precedence over session metadata. The tool must
+    // surface this precedence to the caller via a warning so silent filter loss is impossible.
+    assertThat(testData.hasSessionMetadata)
+        .as("requires seeded session metadata on app %s — see INTEGRATION_TESTS.md", testData.appId)
+        .isTrue();
+
+    var response =
+        getRouteCoverageTool.getRouteCoverage(
+            testData.appId, testData.sessionMetadataName, testData.sessionMetadataValue, true);
+
+    assertThat(response.isSuccess())
+        .as("query should succeed — useLatestSession path takes precedence")
+        .isTrue();
+    assertThat(response.warnings())
+        .as("must warn that the metadata filter is silently superseded by useLatestSession")
+        .contains(MUTUALLY_EXCLUSIVE_FILTERS_WARNING);
+  }
+
+  // ========== Successful query tests ==========
 
   @Test
   void getRouteCoverage_should_retrieve_routes_unfiltered() {
-    log.info("\n=== Integration Test: get_route_coverage (unfiltered) ===");
+    assertThat(testData.routeCount)
+        .as("requires seeded route coverage on app %s — see INTEGRATION_TESTS.md", testData.appId)
+        .isPositive();
 
-    var result = getRouteCoverageTool.getRouteCoverage(testData.appId, null, null, null);
+    var response = getRouteCoverageTool.getRouteCoverage(testData.appId, null, null, null);
 
-    assertThat(result).as("Response should not be null").isNotNull();
-    assertThat(result.isSuccess()).as("Response should indicate success").isTrue();
-    assertThat(result.found()).as("Should find routes").isTrue();
-    assertThat(result.data()).as("Data should not be null").isNotNull();
-    assertThat(result.data().routes()).as("Routes should not be null").isNotNull();
-    assertThat(result.data().routes().size() > 0).as("Should have at least 1 route").isTrue();
+    assertThat(response).as("response must not be null").isNotNull();
+    assertThat(response.isSuccess()).as("unfiltered query must succeed").isTrue();
+    assertThat(response.found()).as("seeded app must be reported as found").isTrue();
+    assertThat(response.data()).as("successful response must carry data").isNotNull();
+    assertThat(response.data().routes()).as("routes must be populated").isNotEmpty();
 
-    log.info(
-        "✓ Retrieved {} routes for application: {}",
-        result.data().routes().size(),
-        testData.appName);
-
-    // Light response includes aggregate statistics
-    log.info("  Exercised routes: {}", result.data().exercisedCount());
-    log.info("  Discovered routes: {}", result.data().discoveredCount());
-    log.info("  Coverage percent: {}%", result.data().coveragePercent());
-
-    // Verify all routes have essential fields in light format
-    for (RouteLight route : result.data().routes()) {
-      assertThat(route.signature()).as("Route signature should not be null").isNotNull();
-      assertThat(route.routeHash()).as("Route hash should not be null").isNotNull();
-    }
+    // Aggregate statistics are computed by RouteMapper from per-route status — assert the invariant
+    // that every route is partitioned into exactly one of (exercised, discovered).
+    assertThat(response.data().totalRoutes())
+        .as("totalRoutes must equal exercisedCount + discoveredCount")
+        .isEqualTo(response.data().exercisedCount() + response.data().discoveredCount());
+    assertThat(response.data().totalRoutes())
+        .as("totalRoutes must equal routes.size()")
+        .isEqualTo(response.data().routes().size());
   }
-
-  // ========== Session metadata filter tests ==========
 
   @Test
   void getRouteCoverage_should_filter_by_session_metadata() {
-    log.info("\n=== Integration Test: get_route_coverage (session metadata filter) ===");
+    // Replaces the previous silent-skip anti-pattern (`if (!hasSessionMetadata) return`). Failing
+    // loudly here surfaces config drift / data rot in CI instead of producing a green-but-empty
+    // test report.
+    assertThat(testData.hasSessionMetadata)
+        .as(
+            "requires seeded app with session metadata on app %s — see INTEGRATION_TESTS.md",
+            testData.appId)
+        .isTrue();
 
-    if (!testData.hasSessionMetadata) {
-      log.warn("Skipping test - no session metadata available");
-      return;
-    }
-
-    var result =
+    var response =
         getRouteCoverageTool.getRouteCoverage(
             testData.appId, testData.sessionMetadataName, testData.sessionMetadataValue, null);
 
-    assertThat(result).as("Response should not be null").isNotNull();
-    assertThat(result.isSuccess()).as("Response should indicate success").isTrue();
-    assertThat(result.data()).as("Data should not be null").isNotNull();
-    assertThat(result.data().routes()).as("Routes should not be null").isNotNull();
+    assertThat(response).as("response must not be null").isNotNull();
+    assertThat(response.isSuccess()).as("metadata-filtered query must succeed").isTrue();
+    assertThat(response.data()).as("successful response must carry data").isNotNull();
+    assertThat(response.data().routes()).as("filtered routes must not be null").isNotNull();
 
-    log.info(
-        "✓ Retrieved {} routes for application: {}",
-        result.data().routes().size(),
-        testData.appName);
-    log.info(
-        "  Filtered by session metadata: {}={}",
-        testData.sessionMetadataName,
-        testData.sessionMetadataValue);
-
-    // Verify routes have essential fields in light format
-    for (RouteLight route : result.data().routes()) {
-      assertThat(route.signature())
-          .as("Route signature should be present for filtered routes")
-          .isNotNull();
-    }
+    // Filter assertion: every returned route must carry the essential identifiers populated by
+    // RouteMapper. An empty signature here would indicate a downstream serialization regression
+    // even if the count is non-zero.
+    assertThat(response.data().routes())
+        .as("every metadata-filtered route must populate signature and routeHash")
+        .allSatisfy(
+            route -> {
+              assertThat(route.signature()).as("route.signature").isNotBlank();
+              assertThat(route.routeHash()).as("route.routeHash").isNotBlank();
+            });
   }
-
-  // ========== Latest session filter tests ==========
 
   @Test
   void getRouteCoverage_should_filter_by_latest_session() {
-    log.info("\n=== Integration Test: get_route_coverage (latest session) ===");
-
-    if (!testData.hasSessionMetadata) {
-      log.warn("Skipping test - no session metadata available (required for latest session)");
-      return;
-    }
-
-    var result = getRouteCoverageTool.getRouteCoverage(testData.appId, null, null, true);
-
-    assertThat(result).as("Response should not be null").isNotNull();
-    assertThat(result.isSuccess())
-        .as("Response should indicate success. Application should have session metadata.")
+    // Replaces the previous silent-skip anti-pattern. Latest-session filter requires the app to
+    // have at least one recorded agent session — without that there is nothing to assert against.
+    assertThat(testData.hasSessionMetadata)
+        .as(
+            "requires seeded app with session metadata on app %s — see INTEGRATION_TESTS.md",
+            testData.appId)
         .isTrue();
-    assertThat(result.data()).as("Data should not be null").isNotNull();
-    assertThat(result.data().routes())
-        .as("Routes should not be null when success is true")
-        .isNotNull();
 
-    log.info("✓ Retrieved {} routes from latest session", result.data().routes().size());
-    log.info("  Application: {}", testData.appName);
+    var response = getRouteCoverageTool.getRouteCoverage(testData.appId, null, null, true);
 
-    // Light response includes aggregate statistics
-    log.info("  Exercised: {}", result.data().exercisedCount());
-    log.info("  Discovered: {}", result.data().discoveredCount());
-
-    // Verify all routes have essential fields in light format
-    for (RouteLight route : result.data().routes()) {
-      assertThat(route.signature())
-          .as("Route signature should be present for latest session")
-          .isNotNull();
-    }
+    assertThat(response).as("response must not be null").isNotNull();
+    assertThat(response.isSuccess())
+        .as("latest-session query must succeed — app has session metadata")
+        .isTrue();
+    assertThat(response.found()).as("seeded app with sessions must be reported as found").isTrue();
+    assertThat(response.data()).as("successful response must carry data").isNotNull();
+    assertThat(response.data().routes()).as("latest-session routes must not be null").isNotNull();
+    assertThat(response.data().routes())
+        .as("every latest-session route must populate signature")
+        .allSatisfy(route -> assertThat(route.signature()).isNotBlank());
   }
 
   // ========== Empty string handling (MCP-OU8 bug fix) ==========
 
   @Test
-  void getRouteCoverage_should_treat_empty_strings_as_null() {
-    log.info("\n=== Integration Test: Empty string parameters (MCP-OU8 bug fix) ===");
+  void getRouteCoverage_should_treat_empty_strings_as_unfiltered() {
+    // Replaces the previous dual-path test (`if (hasRouteCoverage)` conditional). RouteCoverage
+    // params normalize empty strings to null, so passing "" for both metadata params must produce
+    // exactly the same response shape as a true unfiltered query.
+    assertThat(testData.routeCount)
+        .as("requires seeded route coverage on app %s — see INTEGRATION_TESTS.md", testData.appId)
+        .isPositive();
 
-    // Empty strings should be treated as null and trigger unfiltered query
-    var result = getRouteCoverageTool.getRouteCoverage(testData.appId, "", "", false);
+    var emptyStringResponse = getRouteCoverageTool.getRouteCoverage(testData.appId, "", "", false);
+    var unfilteredResponse =
+        getRouteCoverageTool.getRouteCoverage(testData.appId, null, null, null);
 
-    assertThat(result).as("Response should not be null").isNotNull();
-    assertThat(result.isSuccess()).as("Response should be successful").isTrue();
-
-    log.info("✓ Response successful: {}", result.isSuccess());
-    log.info("✓ Routes returned: {}", result.data().routes().size());
-
-    // Should return routes (assuming the app has route coverage)
-    if (testData.hasRouteCoverage) {
-      assertThat(result.data().routes().size() > 0)
-          .as(
-              "Empty strings should return all routes (unfiltered query) when app has route"
-                  + " coverage")
-          .isTrue();
-      log.info("✓ Routes found via unfiltered query (empty strings treated as null)");
-    }
+    assertThat(emptyStringResponse.isSuccess()).as("empty-string query must succeed").isTrue();
+    assertThat(emptyStringResponse.errors())
+        .as("empty strings must not produce paired-metadata validation errors")
+        .isEmpty();
+    assertThat(emptyStringResponse.data().routes())
+        .as("empty-string query must return at least the same routes as unfiltered")
+        .isNotEmpty();
+    assertThat(emptyStringResponse.data().totalRoutes())
+        .as("empty-string query must return identical totalRoutes to a true unfiltered query")
+        .isEqualTo(unfilteredResponse.data().totalRoutes());
   }
 
   // ========== Error handling tests ==========
 
   @Test
-  void getRouteCoverage_should_handle_invalid_appId_gracefully() {
-    log.info("\n=== Integration Test: Invalid app ID handling ===");
+  void getRouteCoverage_should_not_return_populated_data_for_invalid_appId() {
+    // Single deterministic expectation: whether the API errors, returns an empty body, or maps to
+    // a not-found response, the tool must never surface populated route data for a bogus app ID.
+    // Replaces the previous try/catch anti-pattern that swallowed all exceptions silently.
+    var response = getRouteCoverageTool.getRouteCoverage(INVALID_APP_ID, null, null, null);
 
-    try {
-      var result = getRouteCoverageTool.getRouteCoverage("invalid-app-id-12345", null, null, null);
-
-      // Either not found or error is acceptable
-      log.info("✓ API handled invalid app ID gracefully");
-      log.info("  Success: {}, Found: {}", result.isSuccess(), result.found());
-
-    } catch (Exception e) {
-      log.info("✓ API rejected invalid app ID with error: {}", e.getClass().getSimpleName());
-    }
+    assertThat(response).as("response must not be null").isNotNull();
+    assertThat(response.found()).as("invalid appId must not be marked as found").isFalse();
+    assertThat(response.data()).as("invalid appId must not return populated route data").isNull();
   }
 
   @Test
-  void getRouteCoverage_should_handle_nonexistent_metadata_gracefully() {
-    log.info("\n=== Integration Test: Non-existent session metadata ===");
+  void getRouteCoverage_should_return_zero_routes_for_nonexistent_metadata() {
+    // Replaces the previous test that passed if the tool returned empty routes regardless of
+    // whether the metadata filter actually applied. Comparing nonexistent-filter vs unfiltered
+    // proves the filter ran AND that the seeded app actually has routes (so a false-negative
+    // empty-routes pass is impossible).
+    assertThat(testData.routeCount)
+        .as("requires seeded route coverage on app %s — see INTEGRATION_TESTS.md", testData.appId)
+        .isPositive();
 
-    // Use metadata name/value that definitely doesn't exist
-    var result =
+    var unfiltered = getRouteCoverageTool.getRouteCoverage(testData.appId, null, null, null);
+    var nonexistent =
         getRouteCoverageTool.getRouteCoverage(
-            testData.appId, "nonexistent-metadata-name-12345", "nonexistent-value-67890", null);
+            testData.appId, NONEXISTENT_METADATA_NAME, NONEXISTENT_METADATA_VALUE, null);
 
-    assertThat(result).as("Response should not be null").isNotNull();
-    assertThat(result.isSuccess())
-        .as("Response should indicate success even with no matching sessions")
+    assertThat(unfiltered.isSuccess()).as("unfiltered baseline must succeed").isTrue();
+    assertThat(unfiltered.data().routes())
+        .as("unfiltered baseline must return at least one route to make the comparison meaningful")
+        .isNotEmpty();
+    assertThat(nonexistent.isSuccess())
+        .as("nonexistent-metadata query must succeed (empty result, not error)")
         .isTrue();
+    assertThat(nonexistent.data().routes())
+        .as("nonexistent metadata must filter every route out")
+        .isEmpty();
+    assertThat(nonexistent.data().totalRoutes())
+        .as("nonexistent-metadata totalRoutes must be 0 to match the empty routes list")
+        .isZero();
+  }
 
-    log.info("✓ API handled non-existent metadata gracefully");
-    log.info(
-        "  Routes returned: {} (expected 0 for non-existent metadata)",
-        result.data().routes().size());
+  @Test
+  void getRouteCoverage_should_return_zero_routes_for_malformed_metadata() {
+    // Distinct from the nonexistent-metadata test: this exercises robustness against unusual but
+    // well-formed strings (whitespace, control chars, special characters) that the API receives,
+    // serializes through JSON, and matches against. Tool must never throw or return populated data
+    // for such input.
+    assertThat(testData.routeCount)
+        .as("requires seeded route coverage on app %s — see INTEGRATION_TESTS.md", testData.appId)
+        .isPositive();
 
-    // With non-existent metadata, we expect 0 routes
-    assertThat(result.data().routes().size())
-        .as("Non-existent metadata should return 0 routes")
-        .isEqualTo(0);
+    var response =
+        getRouteCoverageTool.getRouteCoverage(
+            testData.appId, MALFORMED_METADATA_NAME, MALFORMED_METADATA_VALUE, null);
+
+    assertThat(response).as("response must not be null").isNotNull();
+    assertThat(response.isSuccess())
+        .as("malformed metadata must not propagate as a Contrast API error")
+        .isTrue();
+    assertThat(response.data().routes())
+        .as("malformed metadata must filter every route out")
+        .isEmpty();
   }
 
   // ========== Route structure validation ==========
 
   @Test
-  void getRouteCoverage_should_populate_route_fields_for_all_routes() {
-    log.info("\n=== Integration Test: Route light structure validation ===");
+  void getRouteCoverage_should_populate_all_route_fields_for_all_routes() {
+    // RouteLight has 11 fields. Asserting every field guards against (a) a regression in
+    // RouteMapper that drops a field, (b) an SDK shape change that returns null where a primitive
+    // would silently default to 0, and (c) a Gson deserialization regression that drops nested
+    // observation lists.
+    assertThat(testData.routeCount)
+        .as("requires seeded route coverage on app %s — see INTEGRATION_TESTS.md", testData.appId)
+        .isPositive();
 
-    var result = getRouteCoverageTool.getRouteCoverage(testData.appId, null, null, null);
+    var response = getRouteCoverageTool.getRouteCoverage(testData.appId, null, null, null);
 
-    assertThat(result).as("Response should not be null").isNotNull();
-    assertThat(result.isSuccess()).as("Response should indicate success").isTrue();
-    assertThat(result.data().routes().size() > 0)
-        .as("Should have at least 1 route to validate")
-        .isTrue();
+    assertThat(response.isSuccess()).as("unfiltered query must succeed").isTrue();
+    assertThat(response.data().routes()).as("must have at least 1 route to validate").isNotEmpty();
 
-    log.info("✓ Validating structure of {} routes", result.data().routes().size());
+    assertThat(response.data().routes())
+        .as("every route must populate the full RouteLight shape")
+        .allSatisfy(
+            route -> {
+              // Strings — "Populate ≠ non-null": isNotBlank rejects an empty signature.
+              assertThat(route.signature()).as("%s.signature", route.routeHash()).isNotBlank();
+              assertThat(route.routeHash()).as("route.routeHash").isNotBlank();
+              assertThat(route.status())
+                  .as("%s.status must be a known route status", route.routeHash())
+                  .isIn(KNOWN_ROUTE_STATUSES);
 
-    // Validate structure of each route in light format
-    for (RouteLight route : result.data().routes()) {
-      // Route itself should have key fields
-      assertThat(route.signature())
-          .as("Route signature should be present")
-          .isNotNull()
-          .isNotEmpty();
-      assertThat(route.routeHash()).as("Route hash should be present").isNotNull().isNotEmpty();
+              // Collections — Compact constructor guarantees observations is non-null; assert that
+              // explicit contract here so a future change cannot silently regress to null.
+              assertThat(route.environments())
+                  .as("%s.environments must not be null (List<String>)", route.routeHash())
+                  .isNotNull();
+              assertThat(route.observations())
+                  .as("%s.observations must not be null (compact constructor)", route.routeHash())
+                  .isNotNull();
 
-      // status field should be set
-      assertThat(route.status()).as("Route status should be present").isNotNull();
-    }
+              // Numeric counts — every route must report non-negative counts. criticalVulns is a
+              // subset of vulns so the relationship must hold for every route.
+              assertThat(route.vulnerabilities())
+                  .as("%s.vulnerabilities", route.routeHash())
+                  .isNotNegative();
+              assertThat(route.criticalVulnerabilities())
+                  .as("%s.criticalVulnerabilities", route.routeHash())
+                  .isNotNegative()
+                  .isLessThanOrEqualTo(route.vulnerabilities());
+              assertThat(route.serversTotal())
+                  .as("%s.serversTotal", route.routeHash())
+                  .isNotNegative();
 
-    // Verify aggregate statistics are computed
-    assertThat(result.data().totalRoutes()).as("Total routes should be set").isGreaterThan(0);
-    assertThat(result.data().exercisedCount() + result.data().discoveredCount())
-        .as("Exercised + discovered should equal total")
-        .isEqualTo(result.data().totalRoutes());
+              // Timestamps — discovered is "Timestamp when route was first discovered (immutable)";
+              // exercised is "0 if never". Both must be non-negative epoch ms.
+              assertThat(route.discovered())
+                  .as("%s.discovered (epoch ms)", route.routeHash())
+                  .isNotNegative();
+              assertThat(route.exercised())
+                  .as("%s.exercised (epoch ms, 0 if never)", route.routeHash())
+                  .isNotNegative();
 
-    log.info("✓ All {} routes have valid light structure", result.data().routes().size());
+              // totalObservations is Long (boxed) — assert non-null + non-negative. A null here
+              // means the API shape changed or the mapper failed to copy the field.
+              assertThat(route.totalObservations())
+                  .as("%s.totalObservations", route.routeHash())
+                  .isNotNull()
+                  .isNotNegative();
+            });
+  }
+
+  @Test
+  void getRouteCoverage_should_only_use_known_environment_values() {
+    // RouteLight.environments is documented as a closed set: {DEVELOPMENT, QA, PRODUCTION}. An
+    // unknown value indicates either a newly introduced environment (update KNOWN_ENVIRONMENTS) or
+    // a deserialization regression. Skipping this assertion would let a typo'd or unmapped enum
+    // value silently propagate to AI agents.
+    assertThat(testData.routeCount)
+        .as("requires seeded route coverage on app %s — see INTEGRATION_TESTS.md", testData.appId)
+        .isPositive();
+
+    var response = getRouteCoverageTool.getRouteCoverage(testData.appId, null, null, null);
+    assertThat(response.isSuccess()).as("unfiltered query must succeed").isTrue();
+
+    assertThat(response.data().routes())
+        .as("every route's environments must contain only known values %s", KNOWN_ENVIRONMENTS)
+        .allSatisfy(
+            route ->
+                assertThat(route.environments())
+                    .as("%s.environments", route.routeHash())
+                    .allSatisfy(env -> assertThat(env).isIn(KNOWN_ENVIRONMENTS)));
+  }
+
+  @Test
+  void getRouteCoverage_should_have_consistent_observation_counts() {
+    // Per RouteLight contract: observations is the inline list (deduplicated by verb+url) and
+    // totalObservations is the raw count. The list size cannot exceed the total count. A violation
+    // here would indicate either truncation of totalObservations or duplication in observations.
+    assertThat(testData.routeCount)
+        .as("requires seeded route coverage on app %s — see INTEGRATION_TESTS.md", testData.appId)
+        .isPositive();
+
+    var response = getRouteCoverageTool.getRouteCoverage(testData.appId, null, null, null);
+    assertThat(response.isSuccess()).as("unfiltered query must succeed").isTrue();
+
+    assertThat(response.data().routes())
+        .as("observations.size() must never exceed totalObservations for any route")
+        .allSatisfy(
+            route ->
+                assertThat((long) route.observations().size())
+                    .as(
+                        "%s observations.size()=%d vs totalObservations=%d",
+                        route.routeHash(), route.observations().size(), route.totalObservations())
+                    .isLessThanOrEqualTo(route.totalObservations()));
   }
 
   // ========== Comparison test ==========
 
   @Test
-  void getRouteCoverage_should_return_same_or_more_routes_unfiltered_vs_filtered() {
-    log.info("\n=== Integration Test: Compare different filter types ===");
+  void getRouteCoverage_unfiltered_should_return_at_least_as_many_routes_as_either_filter() {
+    // The previous version asserted unfiltered ≥ metadata-filtered but forgot the latest-session
+    // case. Filters can only narrow the result, never broaden it — this invariant must hold for
+    // both filter modes.
+    assertThat(testData.hasSessionMetadata)
+        .as(
+            "requires seeded app with session metadata on app %s — see INTEGRATION_TESTS.md",
+            testData.appId)
+        .isTrue();
+    assertThat(testData.routeCount)
+        .as("requires seeded route coverage on app %s — see INTEGRATION_TESTS.md", testData.appId)
+        .isPositive();
 
-    if (!testData.hasSessionMetadata) {
-      log.warn("Skipping test - no session metadata available");
-      return;
-    }
-
-    // Get route coverage using different filters
-    var unfilteredResult = getRouteCoverageTool.getRouteCoverage(testData.appId, null, null, null);
-
-    var sessionMetadataResult =
+    var unfiltered = getRouteCoverageTool.getRouteCoverage(testData.appId, null, null, null);
+    var sessionMetadata =
         getRouteCoverageTool.getRouteCoverage(
             testData.appId, testData.sessionMetadataName, testData.sessionMetadataValue, null);
+    var latestSession = getRouteCoverageTool.getRouteCoverage(testData.appId, null, null, true);
 
-    var latestSessionResult =
-        getRouteCoverageTool.getRouteCoverage(testData.appId, null, null, true);
+    assertThat(unfiltered.isSuccess()).as("unfiltered query must succeed").isTrue();
+    assertThat(sessionMetadata.isSuccess()).as("session-metadata query must succeed").isTrue();
+    assertThat(latestSession.isSuccess()).as("latest-session query must succeed").isTrue();
 
-    // Assert all methods returned data
-    assertThat(unfilteredResult.isSuccess()).as("Unfiltered query should succeed").isTrue();
-    assertThat(sessionMetadataResult.isSuccess())
-        .as("Session metadata query should succeed")
-        .isTrue();
-    assertThat(latestSessionResult.isSuccess()).as("Latest session query should succeed").isTrue();
+    int unfilteredCount = unfiltered.data().routes().size();
+    int sessionMetadataCount = sessionMetadata.data().routes().size();
+    int latestSessionCount = latestSession.data().routes().size();
 
-    log.info("✓ All filter types work correctly:");
-    log.info("  Unfiltered routes:        {}", unfilteredResult.data().routes().size());
-    log.info("  Session metadata routes:  {}", sessionMetadataResult.data().routes().size());
-    log.info("  Latest session routes:    {}", latestSessionResult.data().routes().size());
-
-    // Verify unfiltered should have >= filtered results
-    assertThat(
-            unfilteredResult.data().routes().size() >= sessionMetadataResult.data().routes().size())
-        .as("Unfiltered query should return same or more routes than filtered query")
-        .isTrue();
+    assertThat(unfilteredCount)
+        .as(
+            "unfiltered (%d) must return at least as many routes as metadata filter (%d)",
+            unfilteredCount, sessionMetadataCount)
+        .isGreaterThanOrEqualTo(sessionMetadataCount);
+    assertThat(unfilteredCount)
+        .as(
+            "unfiltered (%d) must return at least as many routes as latest-session filter (%d)",
+            unfilteredCount, latestSessionCount)
+        .isGreaterThanOrEqualTo(latestSessionCount);
   }
 }

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolIT.java
@@ -127,6 +127,16 @@ public class GetRouteCoverageToolIT
     log.info("\n🔍 Fast discovery: using cached route coverage helper...");
   }
 
+  /**
+   * Locates an application that has discovered/exercised route coverage and, when possible, also
+   * carries session metadata. {@code appId} + {@code routeCount} drive the happy-path retrieval and
+   * pagination tests; {@code sessionMetadataName} / {@code sessionMetadataValue} drive the metadata
+   * filter test, which would pass vacuously if the test app had no metadata at all.
+   *
+   * <p>Session metadata is best-effort: when missing, {@code afterCacheHit}/{@code afterDiscovery}
+   * surface a clear warning and the metadata-dependent test fails loudly with a precondition
+   * message rather than silently skipping.
+   */
   @Override
   protected TestData performDiscovery() throws IOException {
     Optional<RouteCoverageTestData> routeCandidate =

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolIT.java
@@ -18,9 +18,12 @@ package com.contrast.labs.ai.mcp.contrast.tool.library;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrast.labs.ai.mcp.contrast.config.IntegrationTestConfig;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.data.LibraryExtended;
 import com.contrast.labs.ai.mcp.contrast.util.AbstractIntegrationTest;
 import com.contrast.labs.ai.mcp.contrast.util.TestDataDiscoveryHelper;
+import com.contrastsecurity.http.RuleSeverity;
 import java.io.IOException;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -41,6 +44,16 @@ class ListApplicationLibrariesToolIT
     extends AbstractIntegrationTest<ListApplicationLibrariesToolIT.TestData> {
 
   @Autowired private ListApplicationLibrariesTool tool;
+
+  // Contrast library security grades are single letters A, B, C, D, F (no E).
+  private static final Set<String> VALID_GRADES = Set.of("A", "B", "C", "D", "F");
+
+  // Contrast tool-specific and shared pagination constants — keep in sync with
+  // ValidationConstants.DEFAULT_PAGE_SIZE and API_MAX_PAGE_SIZE.
+  private static final int DEFAULT_PAGE_SIZE = 50;
+  private static final int API_MAX_PAGE_SIZE = 50;
+  private static final int PAGINATION_PROBE_SIZE = 5;
+  private static final int MIN_LIBS_FOR_PAGINATION = PAGINATION_PROBE_SIZE + 1;
 
   static class TestData {
     String appId;
@@ -89,175 +102,418 @@ class ListApplicationLibrariesToolIT
 
   @Test
   void testDiscoveredTestDataExists() {
-    log.info("\n=== Integration Test: Validate test data discovery ===");
-
-    assertThat(testData).as("Test data should have been discovered").isNotNull();
-    assertThat(testData.appId).as("App ID should be set").isNotNull();
-    assertThat(testData.expectedLibraryCount).as("Should have libraries").isGreaterThan(0);
+    assertThat(testData).as("discovery must populate test data").isNotNull();
+    assertThat(testData.appId).as("discovery must resolve a non-blank app ID").isNotBlank();
+    assertThat(testData.appName).as("discovery must resolve a non-blank app name").isNotBlank();
+    assertThat(testData.expectedLibraryCount)
+        .as("test application must have at least one library")
+        .isPositive();
   }
 
   @Test
   void listApplicationLibraries_should_return_libraries() {
-    log.info("\n=== Integration Test: list_application_libraries ===");
-
     var result = tool.listApplicationLibraries(null, null, testData.appId);
 
-    assertThat(result.isSuccess()).isTrue();
-    assertThat(result.items()).isNotEmpty();
-    assertThat(result.errors()).isEmpty();
+    assertThat(result.errors()).as("valid appId must not produce errors").isEmpty();
+    assertThat(result.isSuccess()).as("response must be successful").isTrue();
+    assertThat(result.items())
+        .as("requires seeded libraries on app %s — see INTEGRATION_TESTS.md", testData.appName)
+        .isNotEmpty();
 
-    log.info("Retrieved {} libraries for application: {}", result.items().size(), testData.appName);
+    // Every library must populate the core identity fields and satisfy vulnerability-count
+    // arithmetic: the severity breakdown cannot exceed the total, and each count must be
+    // non-negative. Empty strings are rejected via isNotBlank.
+    assertThat(result.items())
+        .as("every library must populate core identity and vulnerability-count fields")
+        .allSatisfy(
+            lib -> {
+              assertThat(lib.getFilename()).as("%s.filename", lib.getHash()).isNotBlank();
+              assertThat(lib.getHash()).as("%s.hash", lib.getFilename()).isNotBlank();
+              assertThat(lib.getVersion()).as("%s.version", lib.getFilename()).isNotBlank();
+              assertThat(lib.getClassCount())
+                  .as("%s.classCount", lib.getFilename())
+                  .isNotNegative();
+              assertThat(lib.getClassesUsed())
+                  .as("%s.classesUsed", lib.getFilename())
+                  .isNotNegative();
+              assertThat(lib.getCriticalVulnerabilities())
+                  .as("%s.criticalVulnerabilities", lib.getFilename())
+                  .isNotNegative();
+              assertThat(lib.getHighVulnerabilities())
+                  .as("%s.highVulnerabilities", lib.getFilename())
+                  .isNotNegative();
+              assertThat(lib.getMediumVulnerabilities())
+                  .as("%s.mediumVulnerabilities", lib.getFilename())
+                  .isNotNegative();
+              assertThat(lib.getLowVulnerabilities())
+                  .as("%s.lowVulnerabilities", lib.getFilename())
+                  .isNotNegative();
+              assertThat(lib.getNoteVulnerabilities())
+                  .as("%s.noteVulnerabilities", lib.getFilename())
+                  .isNotNegative();
+              // Each severity bucket alone cannot exceed the total. Full arithmetic consistency
+              // (sum == total) is asserted in the dedicated severity-counts test against the
+              // vulnerabilities array, which avoids mixing API-provided and array-derived sources.
+              int total = lib.getTotalVulnerabilities();
+              assertThat(lib.getCriticalVulnerabilities())
+                  .as("%s.critical must not exceed total", lib.getFilename())
+                  .isLessThanOrEqualTo(total);
+              assertThat(lib.getHighVulnerabilities())
+                  .as("%s.high must not exceed total", lib.getFilename())
+                  .isLessThanOrEqualTo(total);
+              assertThat(lib.getMediumVulnerabilities())
+                  .as("%s.medium must not exceed total", lib.getFilename())
+                  .isLessThanOrEqualTo(total);
+              assertThat(lib.getLowVulnerabilities())
+                  .as("%s.low must not exceed total", lib.getFilename())
+                  .isLessThanOrEqualTo(total);
+              assertThat(lib.getNoteVulnerabilities())
+                  .as("%s.note must not exceed total", lib.getFilename())
+                  .isLessThanOrEqualTo(total);
+            });
+  }
 
-    // Verify library structure
-    var firstLib = result.items().get(0);
-    assertThat(firstLib.getFilename()).as("Library filename should not be null").isNotNull();
-    assertThat(firstLib.getHash()).as("Library hash should not be null").isNotNull();
-    assertThat(firstLib.getClassCount()).as("Class count should be non-negative").isNotNegative();
+  @Test
+  void listApplicationLibraries_should_default_page_and_pageSize_when_null() {
+    // Null page/pageSize must route through PaginationParams defaults — page=1, pageSize=50 —
+    // with no pagination warnings. A change to the default contract would surface here.
+    var result = tool.listApplicationLibraries(null, null, testData.appId);
 
-    // Validate new severity count fields
-    log.info(
-        "First library severity counts — medium: {}, low: {}, note: {}",
-        firstLib.getMediumVulnerabilities(),
-        firstLib.getLowVulnerabilities(),
-        firstLib.getNoteVulnerabilities());
-
-    // Counts must be non-negative
-    assertThat(firstLib.getMediumVulnerabilities())
-        .as("mediumVulnerabilities should be non-negative")
-        .isNotNegative();
-    assertThat(firstLib.getLowVulnerabilities())
-        .as("lowVulnerabilities should be non-negative")
-        .isNotNegative();
-    assertThat(firstLib.getNoteVulnerabilities())
-        .as("noteVulnerabilities should be non-negative")
-        .isNotNegative();
+    assertThat(result.isSuccess()).as("defaults must not fail validation").isTrue();
+    assertThat(result.page()).as("null page must default to 1").isEqualTo(1);
+    assertThat(result.pageSize())
+        .as("null pageSize must default to %d", DEFAULT_PAGE_SIZE)
+        .isEqualTo(DEFAULT_PAGE_SIZE);
+    assertThat(result.warnings())
+        .as("defaults must not produce pagination-clamp warnings")
+        .noneMatch(w -> w.contains("Invalid page"))
+        .noneMatch(w -> w.contains("Invalid pageSize"))
+        .noneMatch(w -> w.contains("exceeds maximum"));
   }
 
   @Test
   void listApplicationLibraries_should_handle_invalid_app_id() {
-    log.info("\n=== Integration Test: Invalid app ID handling ===");
-
+    // A bogus app ID must never surface populated library data. Whether the API rejects
+    // with an error or returns an empty success payload is implementation-dependent; the
+    // invariant the tool must hold is "no populated items for a nonexistent app".
     var result = tool.listApplicationLibraries(null, null, "invalid-app-id-12345");
 
-    // API should handle gracefully - either empty list or API error
-    if (result.isSuccess()) {
-      log.info("API handled invalid app ID gracefully - returned empty or data");
-    } else {
-      log.info("API rejected invalid app ID with error: {}", result.errors());
-    }
+    assertThat(result).as("response must not be null").isNotNull();
+    assertThat(result.items())
+        .as("invalid appId must never return populated library data")
+        .isEmpty();
   }
 
   @Test
   void listApplicationLibraries_should_include_class_usage_data() {
-    log.info("\n=== Integration Test: Class usage statistics ===");
-
     var result = tool.listApplicationLibraries(null, null, testData.appId);
 
-    assertThat(result.isSuccess()).isTrue();
-    assertThat(result.items()).isNotEmpty();
+    assertThat(result.isSuccess()).as("response must be successful").isTrue();
+    assertThat(result.items())
+        .as("requires seeded libraries on app %s — see INTEGRATION_TESTS.md", testData.appName)
+        .isNotEmpty();
 
-    // Check class usage is populated
-    var libraries = result.items();
-    long activeLibs = libraries.stream().filter(lib -> lib.getClassesUsed() > 0).count();
-    long unusedLibs = libraries.stream().filter(lib -> lib.getClassesUsed() == 0).count();
-
-    log.info("Active libraries (classes used > 0): {}", activeLibs);
-    log.info("Unused libraries (classes used = 0): {}", unusedLibs);
-
-    // Verify class usage consistency
-    for (var lib : libraries) {
-      assertThat(lib.getClassesUsed())
-          .as("Classes used should not exceed class count for " + lib.getFilename())
-          .isLessThanOrEqualTo(lib.getClassCount());
-    }
+    // classesUsed ∈ [0, classCount] for every library. A value above classCount would indicate
+    // either a deserialization mix-up between the two fields or an API contract regression.
+    assertThat(result.items())
+        .as("every library must report classesUsed within [0, classCount]")
+        .allSatisfy(
+            lib -> {
+              assertThat(lib.getClassCount())
+                  .as("%s.classCount", lib.getFilename())
+                  .isNotNegative();
+              assertThat(lib.getClassesUsed())
+                  .as("%s.classesUsed", lib.getFilename())
+                  .isNotNegative();
+              assertThat(lib.getClassesUsed())
+                  .as("%s.classesUsed must not exceed classCount", lib.getFilename())
+                  .isLessThanOrEqualTo(lib.getClassCount());
+            });
   }
 
   @Test
   void listApplicationLibraries_should_paginate_with_small_page_size() {
-    log.info("\n=== Integration Test: Pagination ===");
-
-    // First get total count
+    // Fail fast if seeded data is too small to exercise multi-page behavior.
     var fullResult = tool.listApplicationLibraries(null, null, testData.appId);
-    assertThat(fullResult.isSuccess()).isTrue();
+    assertThat(fullResult.isSuccess()).as("baseline fetch must succeed").isTrue();
     int totalLibraries = fullResult.totalItems();
+    assertThat(totalLibraries)
+        .as(
+            "pagination test requires app %s to have > %d libraries — see INTEGRATION_TESTS.md",
+            testData.appName, PAGINATION_PROBE_SIZE)
+        .isGreaterThanOrEqualTo(MIN_LIBS_FOR_PAGINATION);
 
-    if (totalLibraries <= 5) {
-      log.info("Skipping pagination test - only {} libraries available", totalLibraries);
-      return;
-    }
+    var page1 = tool.listApplicationLibraries(1, PAGINATION_PROBE_SIZE, testData.appId);
+    assertThat(page1.isSuccess()).as("page 1 must succeed").isTrue();
+    assertThat(page1.items())
+        .as("page 1 must contain exactly %d items", PAGINATION_PROBE_SIZE)
+        .hasSize(PAGINATION_PROBE_SIZE);
+    assertThat(page1.page()).as("page 1 page number").isEqualTo(1);
+    assertThat(page1.pageSize()).as("page 1 size echo").isEqualTo(PAGINATION_PROBE_SIZE);
+    assertThat(page1.totalItems()).as("page 1 totalItems echo").isEqualTo(totalLibraries);
+    assertThat(page1.hasMorePages()).as("page 1 hasMorePages").isTrue();
 
-    // Request first page with small page size
-    var page1 = tool.listApplicationLibraries(1, 5, testData.appId);
-    assertThat(page1.isSuccess()).isTrue();
-    assertThat(page1.items()).hasSize(5);
-    assertThat(page1.page()).isEqualTo(1);
-    assertThat(page1.pageSize()).isEqualTo(5);
-    assertThat(page1.totalItems()).isEqualTo(totalLibraries);
-    assertThat(page1.hasMorePages()).isTrue();
+    var page2 = tool.listApplicationLibraries(2, PAGINATION_PROBE_SIZE, testData.appId);
+    assertThat(page2.isSuccess()).as("page 2 must succeed").isTrue();
+    assertThat(page2.page()).as("page 2 page number").isEqualTo(2);
 
-    // Request second page
-    var page2 = tool.listApplicationLibraries(2, 5, testData.appId);
-    assertThat(page2.isSuccess()).isTrue();
-    assertThat(page2.page()).isEqualTo(2);
+    int expectedPage2Size = Math.min(PAGINATION_PROBE_SIZE, totalLibraries - PAGINATION_PROBE_SIZE);
+    assertThat(page2.items())
+        .as("page 2 must contain min(pageSize, remaining) = %d items", expectedPage2Size)
+        .hasSize(expectedPage2Size);
 
-    log.info(
-        "Page 1: {} items, Page 2: {} items, Total: {}",
-        page1.items().size(),
-        page2.items().size(),
-        totalLibraries);
+    // Library hash is a stable per-library identifier; disjointness by hash proves the offset
+    // advanced rather than being ignored.
+    var page1Hashes = page1.items().stream().map(LibraryExtended::getHash).toList();
+    var page2Hashes = page2.items().stream().map(LibraryExtended::getHash).toList();
+    assertThat(page2Hashes)
+        .as("page 2 hashes must be disjoint from page 1 hashes")
+        .doesNotContainAnyElementsOf(page1Hashes);
   }
 
   @Test
   void listApplicationLibraries_should_have_consistent_severity_counts() {
-    log.info("\n=== Integration Test: Severity count consistency ===");
-
     var result = tool.listApplicationLibraries(null, null, testData.appId);
-    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.isSuccess()).as("response must be successful").isTrue();
 
-    // Find a library with vulnerabilities to validate the severityToUse format assumption
-    var vulnLib =
+    // The arithmetic-consistency contract only applies to libraries whose vulnerabilities array
+    // is populated — that's the source of truth for medium/low/note counts in LibraryExtended.
+    // Fail fast if no such library is seeded so data rot becomes visible, rather than silently
+    // passing.
+    var vulnerableLibs =
         result.items().stream()
             .filter(lib -> lib.getVulnerabilities() != null && !lib.getVulnerabilities().isEmpty())
-            .findFirst();
-
-    if (vulnLib.isEmpty()) {
-      log.info("No libraries with vulnerabilities found — skipping severity format validation");
-      return;
-    }
-
-    var lib = vulnLib.get();
-    // Compare array-computed counts only — avoids mixing API-provided critical/high fields
-    // with array-computed medium/low/note, which would cause spurious failures.
-    int arraySize = lib.getVulnerabilities().size();
-    int sumFromArray =
-        lib.getMediumVulnerabilities()
-            + lib.getLowVulnerabilities()
-            + lib.getNoteVulnerabilities()
-            + (int)
-                lib.getVulnerabilities().stream()
-                    .filter(v -> "CRITICAL".equalsIgnoreCase(v.getSeverityCode()))
-                    .count()
-            + (int)
-                lib.getVulnerabilities().stream()
-                    .filter(v -> "HIGH".equalsIgnoreCase(v.getSeverityCode()))
-                    .count();
-
-    log.info(
-        "Library: {}, vulns array size: {}, sum of severity counts: {}, "
-            + "medium: {}, low: {}, note: {}",
-        lib.getFilename(),
-        arraySize,
-        sumFromArray,
-        lib.getMediumVulnerabilities(),
-        lib.getLowVulnerabilities(),
-        lib.getNoteVulnerabilities());
-
-    assertThat(sumFromArray)
+            .toList();
+    assertThat(vulnerableLibs)
         .as(
-            "Sum of all severity counts should equal vulnerabilities array size for %s. "
-                + "If medium/low/note are 0 when vulns exist, severityToUse format may differ "
-                + "from expected — check log output for actual values.",
-            lib.getFilename())
-        .isEqualTo(arraySize);
+            "requires at least one seeded library with a populated vulnerabilities array on app"
+                + " %s — see INTEGRATION_TESTS.md",
+            testData.appName)
+        .isNotEmpty();
+
+    // For every vulnerable library, the sum of array-computed severity counts (across all five
+    // buckets) must equal the vulnerabilities array size. Mixing array-computed medium/low/note
+    // with API-provided critical/high would produce spurious failures under TS-41988, so we
+    // compute critical/high from the array as well.
+    assertThat(vulnerableLibs)
+        .as(
+            "every vulnerable library's severity breakdown must sum to its vulnerabilities array"
+                + " size")
+        .allSatisfy(
+            lib -> {
+              int arraySize = lib.getVulnerabilities().size();
+              int criticalFromArray = countBySeverity(lib, RuleSeverity.CRITICAL);
+              int highFromArray = countBySeverity(lib, RuleSeverity.HIGH);
+              int sum =
+                  criticalFromArray
+                      + highFromArray
+                      + lib.getMediumVulnerabilities()
+                      + lib.getLowVulnerabilities()
+                      + lib.getNoteVulnerabilities();
+              assertThat(sum)
+                  .as(
+                      "%s severity sum (critical=%d, high=%d, medium=%d, low=%d, note=%d) must"
+                          + " equal vulns array size (%d) — unknown severityToUse value would"
+                          + " cause mismatch",
+                      lib.getFilename(),
+                      criticalFromArray,
+                      highFromArray,
+                      lib.getMediumVulnerabilities(),
+                      lib.getLowVulnerabilities(),
+                      lib.getNoteVulnerabilities(),
+                      arraySize)
+                  .isEqualTo(arraySize);
+            });
+  }
+
+  @Test
+  void listApplicationLibraries_should_clamp_page_below_one() {
+    // PaginationParams treats page < 1 as a soft failure: clamp to 1 and emit a warning.
+    var result = tool.listApplicationLibraries(0, PAGINATION_PROBE_SIZE, testData.appId);
+
+    assertThat(result.isSuccess()).as("page=0 must soft-fail and continue").isTrue();
+    assertThat(result.page()).as("page=0 must be clamped to 1").isEqualTo(1);
+    assertThat(result.warnings())
+        .as("clamping must emit an 'Invalid page number' warning")
+        .anyMatch(w -> w.contains("Invalid page number 0"));
+  }
+
+  @Test
+  void listApplicationLibraries_should_clamp_oversized_pageSize() {
+    // Tool-specific max is API_MAX_PAGE_SIZE (50). Requests above must be capped with a warning.
+    int oversized = API_MAX_PAGE_SIZE * 4;
+    var result = tool.listApplicationLibraries(1, oversized, testData.appId);
+
+    assertThat(result.isSuccess()).as("oversized pageSize must soft-fail and continue").isTrue();
+    assertThat(result.pageSize())
+        .as("pageSize must be capped to API_MAX_PAGE_SIZE=%d", API_MAX_PAGE_SIZE)
+        .isEqualTo(API_MAX_PAGE_SIZE);
+    assertThat(result.warnings())
+        .as("clamping must emit an 'exceeds maximum' warning citing the cap")
+        .anyMatch(
+            w -> w.contains("exceeds maximum") && w.contains(String.valueOf(API_MAX_PAGE_SIZE)));
+  }
+
+  @Test
+  void listApplicationLibraries_should_clamp_non_positive_pageSize() {
+    // pageSize < 1 must be replaced with DEFAULT_PAGE_SIZE and a warning emitted.
+    var result = tool.listApplicationLibraries(1, 0, testData.appId);
+
+    assertThat(result.isSuccess()).as("pageSize=0 must soft-fail and continue").isTrue();
+    assertThat(result.pageSize())
+        .as("pageSize=0 must fall back to default %d", DEFAULT_PAGE_SIZE)
+        .isEqualTo(DEFAULT_PAGE_SIZE);
+    assertThat(result.warnings())
+        .as("clamping must emit an 'Invalid pageSize' warning")
+        .anyMatch(w -> w.contains("Invalid pageSize 0"));
+  }
+
+  @Test
+  void listApplicationLibraries_should_return_empty_for_page_beyond_range() {
+    // Total is known from page 1. Requesting a page far beyond that must succeed with an empty
+    // items list (no error, no spurious data) and correctly report hasMorePages=false.
+    var baseline = tool.listApplicationLibraries(1, PAGINATION_PROBE_SIZE, testData.appId);
+    assertThat(baseline.isSuccess()).as("baseline fetch must succeed").isTrue();
+    int total = baseline.totalItems();
+    assertThat(total).as("baseline must report totalItems").isPositive();
+
+    int beyond = (total / PAGINATION_PROBE_SIZE) + 10;
+    var result = tool.listApplicationLibraries(beyond, PAGINATION_PROBE_SIZE, testData.appId);
+
+    assertThat(result.isSuccess()).as("out-of-range page must not error").isTrue();
+    assertThat(result.items()).as("out-of-range page must yield no items").isEmpty();
+    assertThat(result.hasMorePages())
+        .as("out-of-range page must report hasMorePages=false")
+        .isFalse();
+    assertThat(result.totalItems())
+        .as("out-of-range page must still echo total count")
+        .isEqualTo(total);
+  }
+
+  @Test
+  void listApplicationLibraries_should_populate_grade_with_valid_letter() {
+    var result = tool.listApplicationLibraries(null, null, testData.appId);
+    assertThat(result.isSuccess()).as("response must be successful").isTrue();
+
+    // Contrast only scores open-source dependencies; custom libs (e.g., the app's own jar) return
+    // sentinel "?" for grade. Filter them out so the assertion targets the documented A-F domain.
+    var scorableLibs = result.items().stream().filter(lib -> !lib.isCustom()).toList();
+    assertThat(scorableLibs)
+        .as("requires at least one non-custom library on app %s", testData.appName)
+        .isNotEmpty();
+
+    assertThat(scorableLibs)
+        .as("every non-custom library's grade must be one of %s", VALID_GRADES)
+        .allSatisfy(
+            lib -> assertThat(lib.getGrade()).as("%s.grade", lib.getFilename()).isIn(VALID_GRADES));
+  }
+
+  @Test
+  void listApplicationLibraries_should_populate_vulnerability_details_when_present() {
+    var result = tool.listApplicationLibraries(null, null, testData.appId);
+    assertThat(result.isSuccess()).as("response must be successful").isTrue();
+
+    var vulnerableLibs =
+        result.items().stream()
+            .filter(lib -> lib.getVulnerabilities() != null && !lib.getVulnerabilities().isEmpty())
+            .toList();
+    assertThat(vulnerableLibs)
+        .as(
+            "requires at least one seeded library with a populated vulnerabilities array on app"
+                + " %s — see INTEGRATION_TESTS.md",
+            testData.appName)
+        .isNotEmpty();
+
+    // Every vulnerability on every vulnerable library must surface its identifying name and a
+    // severity code drawn from the Contrast RuleSeverity enum — a regression in either field
+    // would surface a deserialization or contract issue.
+    var validSeverityCodes =
+        Set.of(
+            RuleSeverity.CRITICAL.name(),
+            RuleSeverity.HIGH.name(),
+            RuleSeverity.MEDIUM.name(),
+            RuleSeverity.LOW.name(),
+            RuleSeverity.NOTE.name());
+
+    assertThat(vulnerableLibs)
+        .as("every vulnerability must populate name and a known severity code")
+        .allSatisfy(
+            lib ->
+                assertThat(lib.getVulnerabilities())
+                    .as("%s.vulnerabilities", lib.getFilename())
+                    .doesNotContainNull()
+                    .allSatisfy(
+                        vuln -> {
+                          assertThat(vuln.getName())
+                              .as("%s vulnerability name", lib.getFilename())
+                              .isNotBlank();
+                          assertThat(vuln.getSeverityCode())
+                              .as(
+                                  "%s vulnerability %s severityCode",
+                                  lib.getFilename(), vuln.getName())
+                              .isNotBlank();
+                          assertThat(vuln.getSeverityCode().toUpperCase())
+                              .as(
+                                  "%s vulnerability %s severityCode must be a known RuleSeverity",
+                                  lib.getFilename(), vuln.getName())
+                              .isIn(validSeverityCodes);
+                        }));
+  }
+
+  @Test
+  void listApplicationLibraries_should_populate_version_and_staleness_fields() {
+    var result = tool.listApplicationLibraries(null, null, testData.appId);
+    assertThat(result.isSuccess()).as("response must be successful").isTrue();
+
+    // Custom libs return sentinel "?" for version and -1 for monthsOutdated. Staleness metrics
+    // only apply to open-source dependencies, so filter custom out to keep the assertion targeted.
+    var scorableLibs = result.items().stream().filter(lib -> !lib.isCustom()).toList();
+    assertThat(scorableLibs)
+        .as("requires at least one non-custom library on app %s", testData.appName)
+        .isNotEmpty();
+
+    assertThat(scorableLibs)
+        .as("every non-custom library must populate version and report non-negative staleness")
+        .allSatisfy(
+            lib -> {
+              assertThat(lib.getVersion()).as("%s.version", lib.getFilename()).isNotBlank();
+              assertThat(lib.getLibScore()).as("%s.libScore", lib.getFilename()).isNotNegative();
+              assertThat(lib.getMonthsOutdated())
+                  .as("%s.monthsOutdated", lib.getFilename())
+                  .isNotNegative();
+              assertThat(lib.getReleaseDate())
+                  .as("%s.releaseDate (epoch ms)", lib.getFilename())
+                  .isNotNegative();
+            });
+  }
+
+  @Test
+  void listApplicationLibraries_should_expose_filtered_app_id_on_library_rows() {
+    var result = tool.listApplicationLibraries(null, null, testData.appId);
+    assertThat(result.isSuccess()).as("response must be successful").isTrue();
+    assertThat(result.items())
+        .as("requires seeded libraries on app %s", testData.appName)
+        .isNotEmpty();
+
+    // Because the tool filters by appId, every returned library's app_id (if populated) must
+    // match the filter. An empty appId on the row is acceptable — some API shapes omit the
+    // reverse reference — but a mismatch indicates cross-app leakage.
+    assertThat(result.items())
+        .as("library rows that carry an appId must match the filter %s", testData.appId)
+        .allSatisfy(
+            lib -> {
+              if (lib.getAppId() != null && !lib.getAppId().isBlank()) {
+                assertThat(lib.getAppId())
+                    .as("%s.appId must match filter", lib.getFilename())
+                    .isEqualTo(testData.appId);
+              }
+            });
+  }
+
+  private static int countBySeverity(LibraryExtended lib, RuleSeverity severity) {
+    return (int)
+        lib.getVulnerabilities().stream()
+            .filter(v -> severity.name().equalsIgnoreCase(v.getSeverityCode()))
+            .count();
   }
 }

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolIT.java
@@ -78,6 +78,12 @@ class ListApplicationLibrariesToolIT
     return TestData.class;
   }
 
+  /**
+   * Locates an application that has at least one library attached. The {@code appId} drives the
+   * happy-path call to {@code list_application_libraries}; a library count of zero would let the
+   * core {@code allSatisfy} library-shape assertions vacuously pass, so the test depends on a
+   * positive count. {@code expectedLibraryCount} is captured for the discovery precondition test.
+   */
   @Override
   protected TestData performDiscovery() throws IOException {
     var appWithLibraries =

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolIT.java
@@ -120,56 +120,37 @@ class ListApplicationLibrariesToolIT
         .as("requires seeded libraries on app %s — see INTEGRATION_TESTS.md", testData.appName)
         .isNotEmpty();
 
-    // Every library must populate the core identity fields and satisfy vulnerability-count
-    // arithmetic: the severity breakdown cannot exceed the total, and each count must be
-    // non-negative. Empty strings are rejected via isNotBlank.
+    // Every library must populate the core identity fields, and each per-severity bucket must
+    // lie within [0, totalVulnerabilities] — a negative count would indicate a sentinel leaking
+    // through, and a count exceeding total would indicate a deserialization mix-up. Full
+    // arithmetic consistency (sum == total) is asserted in the dedicated severity-counts test
+    // against the vulnerabilities array, which avoids mixing API-provided and array-derived
+    // sources. classCount/classesUsed arithmetic is covered in the class-usage test.
     assertThat(result.items())
-        .as("every library must populate core identity and vulnerability-count fields")
+        .as("every library must populate core identity and in-range vulnerability-count fields")
         .allSatisfy(
             lib -> {
               assertThat(lib.getFilename()).as("%s.filename", lib.getHash()).isNotBlank();
               assertThat(lib.getHash()).as("%s.hash", lib.getFilename()).isNotBlank();
               assertThat(lib.getVersion()).as("%s.version", lib.getFilename()).isNotBlank();
-              assertThat(lib.getClassCount())
-                  .as("%s.classCount", lib.getFilename())
-                  .isNotNegative();
-              assertThat(lib.getClassesUsed())
-                  .as("%s.classesUsed", lib.getFilename())
-                  .isNotNegative();
-              assertThat(lib.getCriticalVulnerabilities())
-                  .as("%s.criticalVulnerabilities", lib.getFilename())
-                  .isNotNegative();
-              assertThat(lib.getHighVulnerabilities())
-                  .as("%s.highVulnerabilities", lib.getFilename())
-                  .isNotNegative();
-              assertThat(lib.getMediumVulnerabilities())
-                  .as("%s.mediumVulnerabilities", lib.getFilename())
-                  .isNotNegative();
-              assertThat(lib.getLowVulnerabilities())
-                  .as("%s.lowVulnerabilities", lib.getFilename())
-                  .isNotNegative();
-              assertThat(lib.getNoteVulnerabilities())
-                  .as("%s.noteVulnerabilities", lib.getFilename())
-                  .isNotNegative();
-              // Each severity bucket alone cannot exceed the total. Full arithmetic consistency
-              // (sum == total) is asserted in the dedicated severity-counts test against the
-              // vulnerabilities array, which avoids mixing API-provided and array-derived sources.
               int total = lib.getTotalVulnerabilities();
               assertThat(lib.getCriticalVulnerabilities())
-                  .as("%s.critical must not exceed total", lib.getFilename())
-                  .isLessThanOrEqualTo(total);
+                  .as(
+                      "%s.criticalVulnerabilities must be in [0, total=%d]",
+                      lib.getFilename(), total)
+                  .isBetween(0, total);
               assertThat(lib.getHighVulnerabilities())
-                  .as("%s.high must not exceed total", lib.getFilename())
-                  .isLessThanOrEqualTo(total);
+                  .as("%s.highVulnerabilities must be in [0, total=%d]", lib.getFilename(), total)
+                  .isBetween(0, total);
               assertThat(lib.getMediumVulnerabilities())
-                  .as("%s.medium must not exceed total", lib.getFilename())
-                  .isLessThanOrEqualTo(total);
+                  .as("%s.mediumVulnerabilities must be in [0, total=%d]", lib.getFilename(), total)
+                  .isBetween(0, total);
               assertThat(lib.getLowVulnerabilities())
-                  .as("%s.low must not exceed total", lib.getFilename())
-                  .isLessThanOrEqualTo(total);
+                  .as("%s.lowVulnerabilities must be in [0, total=%d]", lib.getFilename(), total)
+                  .isBetween(0, total);
               assertThat(lib.getNoteVulnerabilities())
-                  .as("%s.note must not exceed total", lib.getFilename())
-                  .isLessThanOrEqualTo(total);
+                  .as("%s.noteVulnerabilities must be in [0, total=%d]", lib.getFilename(), total)
+                  .isBetween(0, total);
             });
   }
 
@@ -192,16 +173,25 @@ class ListApplicationLibrariesToolIT
   }
 
   @Test
-  void listApplicationLibraries_should_handle_invalid_app_id() {
-    // A bogus app ID must never surface populated library data. Whether the API rejects
-    // with an error or returns an empty success payload is implementation-dependent; the
-    // invariant the tool must hold is "no populated items for a nonexistent app".
+  void listApplicationLibraries_should_surface_error_response_for_invalid_app_id() {
+    // A bogus app ID must surface as a deterministic error response, not a silent empty-success
+    // payload. The specific HTTP status (403 vs 404) and mapped message are environment-dependent
+    // (TeamServer deliberately conflates "unknown" with "forbidden" for enumeration defence), so
+    // we assert the tool-contract shape: errors present, no items, no total, no more pages, and
+    // no warnings mixed in with the error.
     var result = tool.listApplicationLibraries(null, null, "invalid-app-id-12345");
 
-    assertThat(result).as("response must not be null").isNotNull();
-    assertThat(result.items())
-        .as("invalid appId must never return populated library data")
-        .isEmpty();
+    assertThat(result.isSuccess())
+        .as("invalid appId must surface as an error, not a silent empty success")
+        .isFalse();
+    assertThat(result.errors())
+        .as("error response must carry at least one non-blank error message")
+        .isNotEmpty()
+        .allSatisfy(msg -> assertThat(msg).isNotBlank());
+    assertThat(result.items()).as("error response must carry no items").isEmpty();
+    assertThat(result.totalItems()).as("error response must report zero total").isZero();
+    assertThat(result.hasMorePages()).as("error response must not claim more pages").isFalse();
+    assertThat(result.warnings()).as("error response must not mix in warnings").isEmpty();
   }
 
   @Test

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolIT.java
@@ -78,6 +78,13 @@ class ListApplicationsByCveToolIT
     return TestData.class;
   }
 
+  /**
+   * Locates an application with libraries and, when possible, captures a real CVE ID exposed by one
+   * of those libraries. The CVE ID is the only input that exercises the happy path of {@code
+   * list_applications_by_cve}; without it the CVE-driven tests fail loudly with a precondition
+   * message rather than masking the missing seed data. {@code hasVulnerableLibrary} drives the
+   * {@code afterCacheHit}/{@code afterDiscovery} warning so the cause is visible in test logs.
+   */
   @Override
   protected TestData performDiscovery() throws IOException {
     var appWithLibraries =

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolIT.java
@@ -43,6 +43,17 @@ class ListApplicationsByCveToolIT
 
   @Autowired private ListApplicationsByCveTool tool;
 
+  // CVSS v3 scores range from 0.0 to 10.0 inclusive.
+  private static final double MIN_CVSS_SCORE = 0.0;
+  private static final double MAX_CVSS_SCORE = 10.0;
+
+  // Percentage fields in ImpactStats are reported on a 0–100 scale.
+  private static final double MIN_PERCENTAGE = 0.0;
+  private static final double MAX_PERCENTAGE = 100.0;
+
+  // Shared substring for SingleTool's 5xx mapping — validation errors must never look like this.
+  private static final String CONTRAST_API_ERROR = "Contrast API error";
+
   static class TestData {
     String appId;
     String appName;
@@ -103,101 +114,284 @@ class ListApplicationsByCveToolIT
   private void warnIfNoVulnerableLibraries(TestData data) {
     if (!data.hasVulnerableLibrary) {
       log.warn("\n⚠️  WARNING: Application has libraries but NO VULNERABLE LIBRARIES");
-      log.warn("   CVE-related tests will be skipped.");
+      log.warn("   CVE-related tests will fail loudly to surface missing seeded data.");
       log.warn("   To enable full testing, use an application with vulnerable dependencies.");
     }
   }
 
   @Test
   void testDiscoveredTestDataExists() {
-    log.info("\n=== Integration Test: Validate test data discovery ===");
-
-    assertThat(testData).as("Test data should have been discovered").isNotNull();
-    assertThat(testData.appId).as("App ID should be set").isNotNull();
-
+    assertThat(testData).as("discovery must populate test data").isNotNull();
+    assertThat(testData.appId).as("discovery must resolve a non-blank app ID").isNotBlank();
+    assertThat(testData.appName).as("discovery must resolve a non-blank app name").isNotBlank();
     if (testData.hasVulnerableLibrary) {
-      assertThat(testData.vulnerableCveId).as("CVE ID should be set").isNotNull();
+      assertThat(testData.vulnerableCveId)
+          .as("hasVulnerableLibrary=true must yield a non-blank CVE ID")
+          .isNotBlank();
     }
   }
 
   @Test
   void listApplicationsByCve_should_return_cve_data() {
-    log.info("\n=== Integration Test: list_applications_by_cve ===");
+    assertThat(testData.vulnerableCveId)
+        .as(
+            "requires seeded app with at least one vulnerable library exposing a CVE — "
+                + "see INTEGRATION_TESTS.md")
+        .isNotBlank();
 
-    if (testData.vulnerableCveId == null) {
-      log.info("⚠️  SKIPPED: No vulnerable libraries with CVEs found in test data");
-      return;
-    }
+    var result = tool.listApplicationsByCve(testData.vulnerableCveId);
+
+    assertThat(result.errors()).as("valid CVE must not produce errors").isEmpty();
+    assertThat(result.isSuccess()).as("response must be successful").isTrue();
+    assertThat(result.found()).as("known CVE must be found").isTrue();
+    assertThat(result.data()).as("data must be populated on success").isNotNull();
+    assertThat(result.data().getApps())
+        .as("known-vulnerable CVE must return at least one impacted app")
+        .isNotEmpty();
+    assertThat(result.data().getLibraries())
+        .as("known-vulnerable CVE must return at least one vulnerable library")
+        .isNotEmpty();
+    assertThat(result.data().getCve()).as("response must carry the queried CVE record").isNotNull();
+    assertThat(result.data().getCve().getName())
+        .as("response CVE name must echo the queried CVE")
+        .isEqualTo(testData.vulnerableCveId);
+  }
+
+  @Test
+  void listApplicationsByCve_should_populate_cve_metadata() {
+    assertThat(testData.vulnerableCveId)
+        .as("requires seeded app with vulnerable CVE — see INTEGRATION_TESTS.md")
+        .isNotBlank();
 
     var result = tool.listApplicationsByCve(testData.vulnerableCveId);
 
     assertThat(result.isSuccess()).isTrue();
-    assertThat(result.found()).isTrue();
     assertThat(result.data()).isNotNull();
-    assertThat(result.data().getApps()).as("Apps list should not be null").isNotNull();
-    assertThat(result.data().getLibraries()).as("Libraries list should not be null").isNotNull();
-    assertThat(result.errors()).isEmpty();
 
-    log.info("CVE {} affects:", testData.vulnerableCveId);
-    log.info("  Applications: {}", result.data().getApps().size());
-    log.info("  Vulnerable libraries: {}", result.data().getLibraries().size());
+    var cve = result.data().getCve();
+    assertThat(cve).as("cve metadata must be populated").isNotNull();
+    assertThat(cve.getName()).as("cve.name must echo the queried CVE").isNotBlank();
+    assertThat(cve.getDescription())
+        .as("cve.description must be populated for a known CVE")
+        .isNotBlank();
+    assertThat(cve.getScore())
+        .as("cve.score must be within CVSS range [%s, %s]", MIN_CVSS_SCORE, MAX_CVSS_SCORE)
+        .isBetween(MIN_CVSS_SCORE, MAX_CVSS_SCORE);
+  }
+
+  @Test
+  void listApplicationsByCve_should_populate_impact_stats() {
+    assertThat(testData.vulnerableCveId)
+        .as("requires seeded app with vulnerable CVE — see INTEGRATION_TESTS.md")
+        .isNotBlank();
+
+    var result = tool.listApplicationsByCve(testData.vulnerableCveId);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.data()).isNotNull();
+
+    var stats = result.data().getImpactStats();
+    assertThat(stats).as("impactStats must be populated").isNotNull();
+    assertThat(stats.getImpactedAppCount())
+        .as("impactedAppCount must be non-negative")
+        .isNotNegative();
+    assertThat(stats.getTotalAppCount()).as("totalAppCount must be non-negative").isNotNegative();
+    assertThat(stats.getImpactedServerCount())
+        .as("impactedServerCount must be non-negative")
+        .isNotNegative();
+    assertThat(stats.getTotalServerCount())
+        .as("totalServerCount must be non-negative")
+        .isNotNegative();
+    assertThat(stats.getImpactedAppCount())
+        .as("impactedAppCount cannot exceed totalAppCount")
+        .isLessThanOrEqualTo(stats.getTotalAppCount());
+    assertThat(stats.getImpactedServerCount())
+        .as("impactedServerCount cannot exceed totalServerCount")
+        .isLessThanOrEqualTo(stats.getTotalServerCount());
+    assertThat(stats.getAppPercentage())
+        .as("appPercentage must be in [%s, %s]", MIN_PERCENTAGE, MAX_PERCENTAGE)
+        .isBetween(MIN_PERCENTAGE, MAX_PERCENTAGE);
+    assertThat(stats.getServerPercentage())
+        .as("serverPercentage must be in [%s, %s]", MIN_PERCENTAGE, MAX_PERCENTAGE)
+        .isBetween(MIN_PERCENTAGE, MAX_PERCENTAGE);
+  }
+
+  @Test
+  void listApplicationsByCve_should_expose_server_list() {
+    assertThat(testData.vulnerableCveId)
+        .as("requires seeded app with vulnerable CVE — see INTEGRATION_TESTS.md")
+        .isNotBlank();
+
+    var result = tool.listApplicationsByCve(testData.vulnerableCveId);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.data()).isNotNull();
+
+    // The servers list is a documented response field — it must be present even if some
+    // environments legitimately have no impacted servers. A null list would indicate a
+    // deserialization or contract regression.
+    assertThat(result.data().getServers())
+        .as("servers list must be non-null (may be empty in minimal environments)")
+        .isNotNull();
+  }
+
+  @Test
+  void listApplicationsByCve_should_populate_app_fields() {
+    assertThat(testData.vulnerableCveId)
+        .as("requires seeded app with vulnerable CVE — see INTEGRATION_TESTS.md")
+        .isNotBlank();
+
+    var result = tool.listApplicationsByCve(testData.vulnerableCveId);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.data()).isNotNull();
+    assertThat(result.data().getApps())
+        .as("known-vulnerable CVE must return at least one impacted app")
+        .isNotEmpty();
+
+    // Every returned App must populate identity plus non-negative seen-timestamps. Enrichment
+    // counters are validated separately in the class-usage test.
+    //
+    // lastSeen==0 is a documented sentinel for "app has never been observed running" (common
+    // for SCA-only apps that are catalogued but have no runtime activity). Only enforce
+    // lastSeen >= firstSeen when lastSeen is populated.
+    assertThat(result.data().getApps())
+        .as("every impacted app must populate identity and timestamp fields")
+        .allSatisfy(
+            app -> {
+              assertThat(app.getAppId()).as("app.appId").isNotBlank();
+              assertThat(app.getName()).as("app.name").isNotBlank();
+              assertThat(app.getFirstSeen())
+                  .as("%s.firstSeen must be non-negative", app.getAppId())
+                  .isNotNegative();
+              assertThat(app.getLastSeen())
+                  .as("%s.lastSeen must be non-negative", app.getAppId())
+                  .isNotNegative();
+              if (app.getLastSeen() > 0) {
+                assertThat(app.getLastSeen())
+                    .as("%s.lastSeen must not precede firstSeen when populated", app.getAppId())
+                    .isGreaterThanOrEqualTo(app.getFirstSeen());
+              }
+            });
+
+    // Identity must actually be populated for every app — a real test of the payload, not just
+    // shape. At least one app's firstSeen must be populated (non-zero) to prove the timestamp
+    // field decodes end-to-end, not just defaults to 0.
+    assertThat(result.data().getApps())
+        .as("at least one impacted app must carry a populated firstSeen timestamp")
+        .anyMatch(app -> app.getFirstSeen() > 0);
   }
 
   @Test
   void listApplicationsByCve_should_populate_class_usage() {
-    log.info("\n=== Integration Test: CVE class usage population ===");
-
-    if (testData.vulnerableCveId == null) {
-      log.info("⚠️  SKIPPED: No vulnerable libraries with CVEs found in test data");
-      return;
-    }
+    assertThat(testData.vulnerableCveId)
+        .as("requires seeded app with vulnerable CVE — see INTEGRATION_TESTS.md")
+        .isNotBlank();
 
     var result = tool.listApplicationsByCve(testData.vulnerableCveId);
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.data()).isNotNull();
-    assertThat(result.data().getApps()).isNotEmpty();
+    assertThat(result.data().getApps())
+        .as("known-vulnerable CVE must return at least one impacted app")
+        .isNotEmpty();
 
-    // Log class usage for each app
-    for (var app : result.data().getApps()) {
-      log.info(
-          "App: {} (class count: {}, class usage: {})",
-          app.getName(),
-          app.getClassCount(),
-          app.getClassUsage());
+    // The enrichment step only sets classCount/classUsage when the app's library matches the
+    // vulnerable library hash AND classesUsed > 0 — see ListApplicationsByCveTool#enrichApps.
+    // Invariants that must hold for EVERY app regardless of whether enrichment fired:
+    //   0 <= classUsage <= classCount
+    assertThat(result.data().getApps())
+        .as("every app must report classUsage within [0, classCount]")
+        .allSatisfy(
+            app -> {
+              assertThat(app.getClassCount()).as("%s.classCount", app.getAppId()).isNotNegative();
+              assertThat(app.getClassUsage()).as("%s.classUsage", app.getAppId()).isNotNegative();
+              assertThat(app.getClassUsage())
+                  .as("%s.classUsage must not exceed classCount", app.getAppId())
+                  .isLessThanOrEqualTo(app.getClassCount());
+            });
 
-      assertThat(app.getClassCount())
-          .as("Class count should be non-negative for app: " + app.getName())
-          .isGreaterThanOrEqualTo(0);
-    }
+    // Enrichment observability: at least one app must have populated class usage, proving the
+    // SDKHelper.getLibsForID lookup and hash-matching loop executed end-to-end against real
+    // Contrast data. If this fails, the test org is missing apps that actively load any
+    // vulnerable library's classes — see INTEGRATION_TESTS.md.
+    assertThat(result.data().getApps())
+        .as(
+            "requires seeded app actively using the vulnerable library's classes so enrichment "
+                + "fires — see INTEGRATION_TESTS.md")
+        .anyMatch(app -> app.getClassCount() > 0 && app.getClassUsage() > 0);
   }
 
   @Test
   void listApplicationsByCve_should_handle_nonexistent_cve() {
-    log.info("\n=== Integration Test: Non-existent CVE handling ===");
-
+    // Well-formatted but unknown CVE: the Contrast API returns an empty body, so Gson
+    // deserializes to null CveData. ListApplicationsByCveTool#doExecute returns null for a
+    // null payload, which SingleTool's pipeline converts to the canonical notFound response
+    // (isSuccess=true, found=false, data=null, errors empty). Deterministic single-path
+    // contract — no dual-path log-and-pass.
     var result = tool.listApplicationsByCve("CVE-9999-99999");
 
-    // Should either return not found or an error - both are acceptable
-    if (result.isSuccess()) {
-      // If success, it should indicate not found
-      assertThat(result.found()).isFalse();
-      log.info("API returned not found for non-existent CVE");
-    } else {
-      // If error, it should have an appropriate error message
-      assertThat(result.errors()).isNotEmpty();
-      log.info("API rejected non-existent CVE with error: {}", result.errors());
-    }
+    assertThat(result.errors())
+        .as("unknown CVE must not surface as an error (notFound path, not error path)")
+        .isEmpty();
+    assertThat(result.isSuccess())
+        .as("notFound is a successful response: no errors produced")
+        .isTrue();
+    assertThat(result.found()).as("unknown CVE must not be found").isFalse();
+    assertThat(result.data()).as("notFound response must not carry data").isNull();
+    assertThat(result.errors())
+        .as("unknown CVE must not surface as a generic 5xx API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
   }
 
   @Test
   void listApplicationsByCve_should_reject_invalid_cve_format() {
-    log.info("\n=== Integration Test: Invalid CVE format handling ===");
+    var invalidCve = "not-a-cve";
 
-    var result = tool.listApplicationsByCve("not-a-cve");
+    var result = tool.listApplicationsByCve(invalidCve);
 
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("cveId") && e.contains("CVE format"));
-    log.info("Correctly rejected invalid CVE format");
+    assertThat(result.isSuccess()).as("invalid CVE format must fail validation").isFalse();
+    assertThat(result.found()).as("validation failure must not report found").isFalse();
+    assertThat(result.data()).as("validation failure must not carry data").isNull();
+    // Assert the full validation message shape, including the example and format spec. A bare
+    // substring match on "cveId" would coincidentally pass because that's the parameter name.
+    assertThat(result.errors())
+        .as("validation error must describe required CVE format")
+        .containsExactly(
+            "cveId must be in CVE format (e.g., CVE-2021-44228). "
+                + "Format: CVE-YYYY-NNNNN where YYYY is the year and NNNNN is a sequence number.");
+    assertThat(result.errors())
+        .as("validation error must not surface as a Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
+  }
+
+  @Test
+  void listApplicationsByCve_should_reject_null_cve_id() {
+    var result = tool.listApplicationsByCve(null);
+
+    assertThat(result.isSuccess()).as("null CVE must fail validation").isFalse();
+    assertThat(result.found()).as("validation failure must not report found").isFalse();
+    assertThat(result.data()).as("validation failure must not carry data").isNull();
+    assertThat(result.errors())
+        .as("validation error must state cveId is required")
+        .containsExactly("cveId is required");
+    assertThat(result.errors())
+        .as("validation error must not surface as a Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
+  }
+
+  @Test
+  void listApplicationsByCve_should_reject_empty_cve_id() {
+    var result = tool.listApplicationsByCve("");
+
+    assertThat(result.isSuccess()).as("empty CVE must fail validation").isFalse();
+    assertThat(result.found()).as("validation failure must not report found").isFalse();
+    assertThat(result.data()).as("validation failure must not carry data").isNull();
+    assertThat(result.errors())
+        .as("validation error must state cveId is required")
+        .containsExactly("cveId is required");
+    assertThat(result.errors())
+        .as("validation error must not surface as a Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
   }
 }

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectToolIT.java
@@ -16,8 +16,8 @@
 package com.contrast.labs.ai.mcp.contrast.tool.sast;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -28,10 +28,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
 /**
- * Integration tests for GetSastProjectTool.
+ * Integration tests for {@link GetSastProjectTool} verifying the contract across the SDK/Scan API
+ * boundary. Cited in {@code CLAUDE.md} → Integration Test Standards as a canonical example for
+ * field-mapping coverage; assertions here must remain mutation-resistant.
  *
- * <p>These tests require Contrast credentials to be set in environment variables and a valid SAST
- * project name configured. Run: source .env.integration-test && mvn verify
+ * <p>Run: {@code source .env.integration-test && mvn verify}
  */
 @SpringBootTest
 @TestPropertySource(locations = "classpath:application-integration-test.properties")
@@ -41,118 +42,267 @@ class GetSastProjectToolIT {
 
   @Autowired private GetSastProjectTool getSastProjectTool;
 
-  @Value("${contrast.host-name:${CONTRAST_HOST_NAME:}}")
-  private String hostName;
-
   @Value("${test.scan.project-name:}")
   private String testProjectName;
 
+  // SingleTool's 5xx mapping — validation errors must never look like this.
+  private static final String CONTRAST_API_ERROR = "Contrast API error";
+
+  // Exact validation message produced by ToolValidationContext#require for the projectName param.
+  // Asserting the full shape (not just a "projectName" substring) prevents a false-positive match
+  // against any unrelated message that happens to mention the parameter name.
+  private static final String PROJECT_NAME_REQUIRED_ERROR = "projectName is required";
+
+  // Warning emitted by SingleTool when doExecute returns null (project not found).
+  private static final String RESOURCE_NOT_FOUND_WARNING = "Resource not found";
+
   @BeforeEach
-  void setUp() {
-    assumeTrue(
-        hostName != null && !hostName.isEmpty(),
-        "Integration tests require CONTRAST_HOST_NAME to be configured");
-    assumeTrue(
-        testProjectName != null && !testProjectName.isEmpty(),
-        "Integration tests require test.scan.project-name to be configured in"
-            + " application-integration-test.properties");
+  void requireSeededProjectName() {
+    // Fail loudly (not silently skip) when the property is missing — surfaces config drift in CI
+    // instead of producing a green-but-empty test report. Replaces the previous Assumptions
+    // .assumeTrue anti-pattern.
+    assertThat(testProjectName)
+        .as(
+            "requires test.scan.project-name in application-integration-test.properties — see"
+                + " INTEGRATION_TESTS.md")
+        .isNotBlank();
   }
+
+  // ---------- Successful retrieval ----------
 
   @Test
   void getScanProject_should_return_project_for_valid_name() {
     var response = getSastProjectTool.getScanProject(testProjectName);
 
-    assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.isSuccess()).as("Response should be successful").isTrue();
-    assertThat(response.data()).as("Project data should not be null").isNotNull();
-    assertThat(response.data().name()).as("Project name should match").isEqualTo(testProjectName);
-    assertThat(response.data().id()).as("Project ID should be set").isNotNull();
+    assertThat(response).as("response must not be null").isNotNull();
+    assertThat(response.isSuccess())
+        .as("seeded project must produce a successful response")
+        .isTrue();
+    assertThat(response.errors()).as("successful query must have no errors").isEmpty();
+    assertThat(response.found()).as("seeded project must be reported as found").isTrue();
+    assertThat(response.data()).as("successful response must carry data").isNotNull();
+    assertThat(response.data().name())
+        .as("project.name must echo the seeded name exactly")
+        .isEqualTo(testProjectName);
+    // "Populate ≠ non-null": id is a String — isNotNull would pass for an empty UUID.
+    assertThat(response.data().id()).as("project.id must be populated").isNotBlank();
   }
 
+  // ---------- Validation errors ----------
+
   @Test
-  void getScanProject_should_return_error_for_null_projectName() {
+  void getScanProject_should_return_validation_error_for_null_projectName() {
     var response = getSastProjectTool.getScanProject(null);
 
-    assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.isSuccess()).as("Should not be successful").isFalse();
-    assertThat(response.errors()).anyMatch(e -> e.contains("projectName is required"));
+    assertThat(response.isSuccess()).as("null projectName must fail validation").isFalse();
+    assertThat(response.found()).as("validation failure must not report found").isFalse();
+    assertThat(response.data()).as("validation failure must not carry data").isNull();
+    assertThat(response.errors())
+        .as("validation error must state projectName is required")
+        .containsExactly(PROJECT_NAME_REQUIRED_ERROR);
+    assertThat(response.errors())
+        .as("validation error must not surface as a Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
   }
 
   @Test
-  void getScanProject_should_return_error_for_empty_projectName() {
+  void getScanProject_should_return_validation_error_for_empty_projectName() {
     var response = getSastProjectTool.getScanProject("");
 
-    assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.isSuccess()).as("Should not be successful").isFalse();
-    assertThat(response.errors()).anyMatch(e -> e.contains("projectName is required"));
+    assertThat(response.isSuccess()).as("empty projectName must fail validation").isFalse();
+    assertThat(response.found()).as("validation failure must not report found").isFalse();
+    assertThat(response.data()).as("validation failure must not carry data").isNull();
+    assertThat(response.errors())
+        .as("validation error must state projectName is required")
+        .containsExactly(PROJECT_NAME_REQUIRED_ERROR);
+    assertThat(response.errors())
+        .as("validation error must not surface as a Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
   }
+
+  @Test
+  void getScanProject_should_return_validation_error_for_whitespace_projectName() {
+    // ToolValidationContext#require uses StringUtils.hasText, which rejects whitespace as well as
+    // null/empty. Without this test a regression that switched to isEmpty() would silently allow
+    // whitespace strings to reach the SDK.
+    var response = getSastProjectTool.getScanProject("   ");
+
+    assertThat(response.isSuccess())
+        .as("whitespace-only projectName must fail validation")
+        .isFalse();
+    assertThat(response.found()).as("validation failure must not report found").isFalse();
+    assertThat(response.data()).as("validation failure must not carry data").isNull();
+    assertThat(response.errors())
+        .as("validation error must state projectName is required")
+        .containsExactly(PROJECT_NAME_REQUIRED_ERROR);
+    assertThat(response.errors())
+        .as("validation error must not surface as a Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
+  }
+
+  // ---------- Not-found path ----------
 
   @Test
   void getScanProject_should_return_notFound_for_nonexistent_project() {
     var nonExistentProject = "nonexistent-project-" + System.currentTimeMillis();
+
     var response = getSastProjectTool.getScanProject(nonExistentProject);
 
-    assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.found()).as("Should not find non-existent project").isFalse();
-    assertThat(response.data()).as("Data should be null").isNull();
+    assertThat(response).as("response must not be null").isNotNull();
+    // notFound is distinct from error: isSuccess (no errors) but found=false.
+    assertThat(response.isSuccess()).as("notFound must not surface as an error").isTrue();
+    assertThat(response.errors()).as("notFound must produce no errors").isEmpty();
+    assertThat(response.found()).as("nonexistent project must not be reported as found").isFalse();
+    assertThat(response.data()).as("notFound response must not carry data").isNull();
+    assertThat(response.warnings())
+        .as("notFound path must surface the documented warning")
+        .contains(RESOURCE_NOT_FOUND_WARNING);
   }
 
   @Test
-  void getScanProject_should_verify_project_has_required_fields() {
+  void getScanProject_should_match_project_name_case_insensitively() {
+    // The TeamServer Scan API matches project names case-insensitively (the SDK's findByName
+    // delegates the comparison to the server). The tool's @Tool description reflects this. A
+    // regression that switched to client-side case-sensitive filtering would surface as
+    // found=false here. The returned project name must echo the canonical (seeded) casing so
+    // downstream tools see a stable identifier regardless of how the user typed the query.
+    var mutatedName = caseFlip(testProjectName);
+    assertThat(mutatedName)
+        .as(
+            "seeded project name must contain at least one case-flippable character to exercise"
+                + " case-insensitive matching")
+        .isNotEqualTo(testProjectName);
+
+    var response = getSastProjectTool.getScanProject(mutatedName);
+
+    assertThat(response.isSuccess())
+        .as("case-mutated lookup must produce a successful response")
+        .isTrue();
+    assertThat(response.errors()).as("case-mutated lookup must produce no errors").isEmpty();
+    assertThat(response.found())
+        .as(
+            "case-mutated name '%s' must match seeded project '%s' (case-insensitive matching)",
+            mutatedName, testProjectName)
+        .isTrue();
+    assertThat(response.data()).as("case-insensitive match must carry project data").isNotNull();
+    assertThat(response.data().name())
+        .as(
+            "response must echo the canonical seeded name '%s', not the case-mutated query input"
+                + " '%s'",
+            testProjectName, mutatedName)
+        .isEqualTo(testProjectName);
+  }
+
+  // ---------- Field-mapping regression coverage ----------
+
+  /**
+   * Regression test for AIML-343: {@code get_scan_project} returned {@code {"data":{}}} despite
+   * {@code found:true}. Root cause was Jackson failing to serialize the SDK Project interface's
+   * method-style accessors. Fix introduced the {@link
+   * com.contrast.labs.ai.mcp.contrast.result.ScanProject} record.
+   *
+   * <p>Asserts every field of ScanProject. A regression that drops a field from the {@code from()}
+   * mapper, or a future Jackson-related break that re-empties the payload, must surface here.
+   */
+  @Test
+  void getScanProject_should_populate_every_field_of_ScanProject_record() {
     var response = getSastProjectTool.getScanProject(testProjectName);
 
-    assertThat(response.isSuccess()).isTrue();
-    assertThat(response.data()).isNotNull();
+    assertThat(response.isSuccess()).as("seeded query must succeed").isTrue();
+    assertThat(response.found()).as("seeded project must be found").isTrue();
+    assertThat(response.data()).as("successful response must carry data").isNotNull();
 
-    // Verify required fields are present
-    assertThat(response.data().id()).as("Project ID is required").isNotNull();
-    assertThat(response.data().name()).as("Project name is required").isNotNull();
-    assertThat(response.data().language()).as("Language is required").isNotNull();
+    var project = response.data();
+
+    // Identity fields — all Strings, all required by the SDK contract. isNotBlank prevents the
+    // AIML-343 empty-payload regression: an empty string would pass isNotNull but fail isNotBlank.
+    assertThat(project.id()).as("ScanProject.id must be populated").isNotBlank();
+    assertThat(project.name())
+        .as("ScanProject.name must echo the seeded name")
+        .isEqualTo(testProjectName);
+    assertThat(project.organizationId())
+        .as("ScanProject.organizationId must be populated")
+        .isNotBlank();
+    assertThat(project.language())
+        .as("ScanProject.language must be populated (Java, JavaScript, etc.)")
+        .isNotBlank();
+
+    // Severity counts — primitive int, asserting >= 0 confirms SDK mapping returned a real
+    // numeric value rather than 0 from a default. Cannot be < 0.
+    assertThat(project.critical())
+        .as("ScanProject.critical must be a non-negative count")
+        .isGreaterThanOrEqualTo(0);
+    assertThat(project.high())
+        .as("ScanProject.high must be a non-negative count")
+        .isGreaterThanOrEqualTo(0);
+    assertThat(project.medium())
+        .as("ScanProject.medium must be a non-negative count")
+        .isGreaterThanOrEqualTo(0);
+    assertThat(project.low())
+        .as("ScanProject.low must be a non-negative count")
+        .isGreaterThanOrEqualTo(0);
+    assertThat(project.note())
+        .as("ScanProject.note must be a non-negative count")
+        .isGreaterThanOrEqualTo(0);
+
+    // Scan history — completedScans is the population precondition for lastScanId/lastScanTime
+    // being populated. The seeded test project is expected to have at least one completed scan;
+    // failing this means the seed is stale.
+    assertThat(project.completedScans())
+        .as(
+            "ScanProject.completedScans must be >= 1 for the seeded project '%s' — a value of 0"
+                + " indicates the seed has been wiped or the project has never been scanned",
+            testProjectName)
+        .isGreaterThanOrEqualTo(1);
+
+    // Once we know a scan has completed, lastScanId and lastScanTime must be populated. These
+    // were the two fields the bead identified as missing from the prior "all fields" assertion —
+    // a regression that drops them from ScanProject#from would silently break the response.
+    assertThat(project.lastScanId())
+        .as("ScanProject.lastScanId must be populated when completedScans >= 1")
+        .isNotBlank();
+    assertThat(project.lastScanTime())
+        .as("ScanProject.lastScanTime must be populated when completedScans >= 1")
+        .isNotNull();
+    assertThat(project.lastScanTime())
+        .as("ScanProject.lastScanTime must be in the past (a real scan timestamp)")
+        .isBefore(Instant.now().plusSeconds(60));
+
+    // Namespace filters are user-configured: a project may legitimately have empty filter lists.
+    // Assert non-null only — ScanProject.from defends against a null SDK return by substituting
+    // List.of(), so a regression that re-introduces nulls would surface here.
+    assertThat(project.includeNamespaceFilters())
+        .as("ScanProject.includeNamespaceFilters must never be null (use empty list instead)")
+        .isNotNull();
+    assertThat(project.excludeNamespaceFilters())
+        .as("ScanProject.excludeNamespaceFilters must never be null (use empty list instead)")
+        .isNotNull();
+
+    // archived is a primitive boolean — no null check is meaningful. We assert that the value is
+    // consistent with the seeded project being actively used (not archived). A regression that
+    // mis-mapped the field would surface as the seeded project appearing archived.
+    assertThat(project.archived())
+        .as("ScanProject.archived must be false for the active seeded project")
+        .isFalse();
   }
 
   /**
-   * Regression test for bug AIML-343: get_scan_project returned {"data":{}} despite found:true.
-   *
-   * <p>The bug was caused by Jackson inability to serialize the SDK Project interface (which uses
-   * method-style accessors like id() instead of getId()). The fix creates a ScanProject record that
-   * Jackson can serialize properly.
+   * Returns the input string with its first ASCII letter case-flipped. Returns the input unchanged
+   * if no flippable letter exists; the calling test asserts inequality to detect that case.
    */
-  @Test
-  void getScanProject_regression_all_fields_should_be_populated() {
-    var response = getSastProjectTool.getScanProject(testProjectName);
-
-    assertThat(response.found()).as("Project should be found").isTrue();
-    assertThat(response.data()).as("Data should not be null").isNotNull();
-
-    // THE BUG: data was serialized as {} (empty object)
-    // AFTER FIX: all fields should be populated
-    var project = response.data();
-
-    // Core identity fields (never null)
-    assertThat(project.id()).as("id field must be populated").isNotBlank();
-    assertThat(project.name()).as("name field must be populated").isNotBlank();
-    assertThat(project.organizationId()).as("organizationId field must be populated").isNotBlank();
-    assertThat(project.language()).as("language field must be populated").isNotBlank();
-
-    // Boolean field
-    assertThat(project.archived()).as("archived field accessible").isNotNull();
-
-    // Vulnerability counts (valid integers, may be zero)
-    assertThat(project.critical()).as("critical count accessible").isGreaterThanOrEqualTo(0);
-    assertThat(project.high()).as("high count accessible").isGreaterThanOrEqualTo(0);
-    assertThat(project.medium()).as("medium count accessible").isGreaterThanOrEqualTo(0);
-    assertThat(project.low()).as("low count accessible").isGreaterThanOrEqualTo(0);
-    assertThat(project.note()).as("note count accessible").isGreaterThanOrEqualTo(0);
-
-    // Scan counts
-    assertThat(project.completedScans()).as("completedScans accessible").isGreaterThanOrEqualTo(0);
-
-    // Namespace filters should be lists (possibly empty, never null)
-    assertThat(project.includeNamespaceFilters())
-        .as("includeNamespaceFilters should be a list")
-        .isNotNull();
-    assertThat(project.excludeNamespaceFilters())
-        .as("excludeNamespaceFilters should be a list")
-        .isNotNull();
+  private static String caseFlip(String input) {
+    var chars = input.toCharArray();
+    for (var i = 0; i < chars.length; i++) {
+      var c = chars[i];
+      if (Character.isUpperCase(c)) {
+        chars[i] = Character.toLowerCase(c);
+        return new String(chars);
+      }
+      if (Character.isLowerCase(c)) {
+        chars[i] = Character.toUpperCase(c);
+        return new String(chars);
+      }
+    }
+    return input;
   }
 }

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastResultsToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastResultsToolIT.java
@@ -16,12 +16,14 @@
 package com.contrast.labs.ai.mcp.contrast.tool.sast;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,157 +31,234 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
 /**
- * Integration tests for GetSastResultsTool.
+ * Integration tests for {@link GetSastResultsTool}.
  *
- * <p>These tests require Contrast credentials to be set in environment variables and a valid SAST
- * project with completed scans configured. Run: source .env.integration-test && mvn verify
+ * <p>Requires Contrast credentials and a seeded SAST project with at least one completed scan.
+ * Configure via {@code application-integration-test.properties} ({@code test.scan.project-name})
+ * and run via {@code source .env.integration-test && mvn verify}. See INTEGRATION_TESTS.md.
+ *
+ * <p>The "no completed scans" and "scan id not found" warning paths are covered by {@link
+ * GetSastResultsToolTest} (mocked) — they are not reproducible against a live organisation without
+ * dedicated, brittle fixtures.
  */
 @Slf4j
 @SpringBootTest
 @TestPropertySource(locations = "classpath:application-integration-test.properties")
 @Tag("integration")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @EnabledIfEnvironmentVariable(named = "CONTRAST_HOST_NAME", matches = ".+")
 class GetSastResultsToolIT {
 
   @Autowired private GetSastResultsTool getSastResultsTool;
 
-  @Value("${contrast.host-name:${CONTRAST_HOST_NAME:}}")
-  private String hostName;
-
   @Value("${test.scan.project-name:}")
   private String testProjectName;
 
-  @BeforeEach
-  void setUp() {
-    assumeTrue(
-        hostName != null && !hostName.isEmpty(),
-        "Integration tests require CONTRAST_HOST_NAME to be configured");
-    assumeTrue(
-        testProjectName != null && !testProjectName.isEmpty(),
-        "Integration tests require test.scan.project-name to be configured in"
-            + " application-integration-test.properties");
+  // Verbatim deprecation warning emitted by GetSastResultsTool#doExecute. Pinning to the full
+  // message catches regressions where the wording drifts (and AI consumers' downstream parsing
+  // breaks) far better than a "DEPRECATED" substring match.
+  private static final String DEPRECATION_WARNING =
+      "DEPRECATED: This tool returns raw SARIF which may be very large. "
+          + "Consider using future paginated SAST search tools for better AI-friendly access.";
+
+  // Validation message format from ToolValidationContext#require — see SingleTool#executePipeline.
+  private static final String PROJECT_NAME_REQUIRED = "projectName is required";
+
+  // 5xx mapping in BaseTool#mapHttpErrorCode. Validation paths and resource-not-found paths must
+  // never surface as this — guard against regressions that catch validation failures with the
+  // generic 5xx handler.
+  private static final String CONTRAST_API_ERROR_FRAGMENT = "Contrast API error";
+
+  // SARIF v2.1.0 — the only spec version Contrast Scan emits. See @Tool description.
+  private static final String SARIF_VERSION = "2.1.0";
+
+  // Driver name promised by GetSastResultsTool's @Tool description ("Tool information (Contrast
+  // Scan)"). A regression that swapped the SARIF source would surface here.
+  private static final String CONTRAST_SCAN_DRIVER_NAME = "Contrast Scan";
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @BeforeAll
+  void verifyConfiguration() {
+    // Replaces the previous Assumptions.assumeTrue, which silently skipped the entire class when
+    // configuration was missing. Failing loudly surfaces config drift in CI rather than allowing
+    // a green build with zero coverage.
+    assertThat(testProjectName)
+        .as(
+            "requires test.scan.project-name in application-integration-test.properties — "
+                + "see INTEGRATION_TESTS.md")
+        .isNotBlank();
   }
 
-  @Test
-  void getScanResults_should_return_sarif_for_valid_project() {
-    log.info("\n=== Integration Test: get_scan_results ===");
+  // ---------- Successful retrieval ----------
 
+  @Test
+  void getScanResults_should_return_parseable_sarif_2_1_0() throws Exception {
     var response = getSastResultsTool.getScanResults(testProjectName);
 
-    assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.isSuccess()).as("Response should be successful").isTrue();
-    assertThat(response.data()).as("SARIF data should not be null").isNotNull();
-    assertThat(response.data()).as("Should be valid SARIF").isNotEmpty();
+    assertThat(response).isNotNull();
+    assertThat(response.isSuccess())
+        .as("seeded SAST project '%s' must produce a successful response", testProjectName)
+        .isTrue();
+    assertThat(response.errors()).as("successful query must surface no errors").isEmpty();
+    assertThat(response.data())
+        .as("SARIF data must be populated for a project with completed scans")
+        .isNotBlank();
 
-    // Verify SARIF structure
-    assertThat(response.data()).contains("\"version\":");
-    assertThat(response.data()).contains("2.1.0");
-    assertThat(response.data()).contains("\"runs\":");
-
-    log.info(
-        "✓ Retrieved SARIF data for project: {} ({} characters)",
-        testProjectName,
-        response.data().length());
+    // Parse as JSON so a malformed body (e.g., truncated stream, gzipped payload, HTML error
+    // page returned with 200) fails here rather than passing a substring check.
+    var root = OBJECT_MAPPER.readTree(response.data());
+    assertThat(root.isObject()).as("SARIF root must be a JSON object").isTrue();
+    assertThat(root.has("$schema"))
+        .as("SARIF root must declare $schema (mandatory in 2.1.0)")
+        .isTrue();
+    assertThat(root.path("$schema").asText()).as("$schema must be a non-blank string").isNotBlank();
+    assertThat(root.path("version").asText())
+        .as("Contrast Scan emits SARIF %s", SARIF_VERSION)
+        .isEqualTo(SARIF_VERSION);
+    assertThat(root.path("runs").isArray()).as("SARIF runs must be a JSON array").isTrue();
   }
 
   @Test
-  void getScanResults_should_include_deprecation_warning() {
-    log.info("\n=== Integration Test: Deprecation warning ===");
-
+  void getScanResults_should_expose_contrast_scan_tool_info() throws Exception {
     var response = getSastResultsTool.getScanResults(testProjectName);
 
-    assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.isSuccess()).as("Response should be successful").isTrue();
-    assertThat(response.warnings()).anyMatch(w -> w.contains("DEPRECATED"));
+    assertThat(response.isSuccess()).as("seeded query must succeed").isTrue();
 
-    log.info("✓ Deprecation warning present in response");
-    log.info("  Warnings: {}", response.warnings());
+    var root = OBJECT_MAPPER.readTree(response.data());
+    var runs = root.path("runs");
+    assertThat(runs.isArray()).as("runs must be a JSON array").isTrue();
+    // Seeded project has at least one completed scan, which always produces one run. An empty
+    // runs array against a project with completedScans>0 indicates a serializer regression.
+    assertThat(runs)
+        .as("seeded project '%s' must surface at least one SARIF run", testProjectName)
+        .isNotEmpty();
+
+    JsonNode firstRun = runs.get(0);
+    var driver = firstRun.path("tool").path("driver");
+    assertThat(driver.isObject())
+        .as("runs[0].tool.driver must be a JSON object per SARIF 2.1.0")
+        .isTrue();
+    assertThat(driver.path("name").asText())
+        .as("runs[0].tool.driver.name must identify Contrast Scan")
+        .isEqualTo(CONTRAST_SCAN_DRIVER_NAME);
+    assertThat(driver.path("rules").isArray())
+        .as("runs[0].tool.driver.rules must be a JSON array (may be empty)")
+        .isTrue();
+    assertThat(firstRun.path("results").isArray())
+        .as("runs[0].results must be a JSON array (may be empty)")
+        .isTrue();
   }
 
   @Test
-  void getScanResults_should_return_error_for_null_projectName() {
-    log.info("\n=== Integration Test: Null project name handling ===");
+  void getScanResults_should_emit_full_deprecation_warning() {
+    var response = getSastResultsTool.getScanResults(testProjectName);
 
+    assertThat(response.isSuccess())
+        .as("query must succeed before warnings are inspected (single deterministic outcome)")
+        .isTrue();
+    // Assert the verbatim message — substring "DEPRECATED" matches any rewording, including
+    // garbage text that happens to contain the token, which would not actually warn AI consumers.
+    assertThat(response.warnings())
+        .as("response must contain the verbatim deprecation warning")
+        .contains(DEPRECATION_WARNING);
+  }
+
+  // ---------- Validation errors ----------
+
+  @Test
+  void getScanResults_should_return_validation_error_for_null_projectName() {
     var response = getSastResultsTool.getScanResults(null);
 
-    assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.isSuccess()).as("Should not be successful").isFalse();
-    assertThat(response.errors()).anyMatch(e -> e.contains("projectName is required"));
-
-    log.info("✓ Null project name correctly rejected");
+    assertThat(response.isSuccess()).as("null projectName must fail validation").isFalse();
+    assertThat(response.found()).as("validation failure must not report found").isFalse();
+    assertThat(response.data()).as("validation failure must not carry data").isNull();
+    // Assert exact message — a bare contains("projectName") match would coincidentally succeed
+    // on any error mentioning the parameter name (e.g., a 5xx wrapping the field).
+    assertThat(response.errors())
+        .as("validation must produce the documented projectName-required message")
+        .containsExactly(PROJECT_NAME_REQUIRED);
+    assertThat(response.errors())
+        .as("validation error must not be surfaced as a 5xx Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR_FRAGMENT));
   }
 
   @Test
-  void getScanResults_should_return_error_for_empty_projectName() {
-    log.info("\n=== Integration Test: Empty project name handling ===");
-
+  void getScanResults_should_return_validation_error_for_empty_projectName() {
     var response = getSastResultsTool.getScanResults("");
 
-    assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.isSuccess()).as("Should not be successful").isFalse();
-    assertThat(response.errors()).anyMatch(e -> e.contains("projectName is required"));
-
-    log.info("✓ Empty project name correctly rejected");
+    assertThat(response.isSuccess()).as("empty projectName must fail validation").isFalse();
+    assertThat(response.errors()).containsExactly(PROJECT_NAME_REQUIRED);
+    assertThat(response.errors()).noneMatch(e -> e.contains(CONTRAST_API_ERROR_FRAGMENT));
   }
+
+  @Test
+  void getScanResults_should_return_validation_error_for_blank_projectName() {
+    // Whitespace-only must be rejected by ToolValidationContext#require (StringUtils.hasText) —
+    // not silently passed to the SDK where it would surface as a generic notFound.
+    var response = getSastResultsTool.getScanResults("   ");
+
+    assertThat(response.isSuccess())
+        .as("whitespace-only projectName must fail validation")
+        .isFalse();
+    assertThat(response.errors()).containsExactly(PROJECT_NAME_REQUIRED);
+    assertThat(response.errors()).noneMatch(e -> e.contains(CONTRAST_API_ERROR_FRAGMENT));
+  }
+
+  // ---------- Project lookup edge cases ----------
 
   @Test
   void getScanResults_should_return_notFound_for_nonexistent_project() {
-    log.info("\n=== Integration Test: Non-existent project handling ===");
+    var nonExistent = "nonexistent-project-" + System.currentTimeMillis();
+    var response = getSastResultsTool.getScanResults(nonExistent);
 
-    var nonExistentProject = "nonexistent-project-" + System.currentTimeMillis();
-    var response = getSastResultsTool.getScanResults(nonExistentProject);
-
-    assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.found()).as("Should not find non-existent project").isFalse();
-    assertThat(response.data()).as("Data should be null").isNull();
-
-    log.info("✓ Non-existent project correctly returned not found");
+    // SingleTool maps doExecute() returning null to a notFound response: errors=[], found=false,
+    // data=null. isSuccess() is true because errors is empty — explicitly assert this contract
+    // so a regression that flipped it to an error path would surface.
+    assertThat(response.isSuccess()).as("notFound is not an error").isTrue();
+    assertThat(response.found()).as("missing project must report found=false").isFalse();
+    assertThat(response.data()).as("notFound must not carry data").isNull();
+    assertThat(response.errors()).as("notFound must not surface as an error").isEmpty();
+    // Deprecation warning is added before the project lookup, so it must still be emitted on
+    // the notFound path. A regression that short-circuited warnings on null doExecute would
+    // surface here.
+    assertThat(response.warnings())
+        .as("deprecation warning must still be emitted for missing projects")
+        .contains(DEPRECATION_WARNING);
   }
 
   @Test
-  void getScanResults_should_return_valid_sarif_structure() {
-    log.info("\n=== Integration Test: Verify SARIF structure ===");
+  void getScanResults_should_treat_project_name_as_case_sensitive() {
+    // Per the @Tool description: "Project names are case-sensitive and must match exactly."
+    // Inverting the case of a known-good name must yield notFound — never silently match a
+    // differently-cased project. Guard the precondition so a numeric/symbolic seed name (no-op
+    // case inversion) fails loudly rather than passing on coincidence.
+    var inverted = invertCase(testProjectName);
+    assertThat(inverted)
+        .as(
+            "test.scan.project-name='%s' must contain at least one alphabetic character to "
+                + "exercise case-sensitivity",
+            testProjectName)
+        .isNotEqualTo(testProjectName);
 
-    var response = getSastResultsTool.getScanResults(testProjectName);
+    var response = getSastResultsTool.getScanResults(inverted);
 
-    assertThat(response.isSuccess()).isTrue();
-    assertThat(response.data()).isNotNull();
-
-    // Verify SARIF 2.1.0 structure
-    assertThat(response.data()).contains("\"$schema\":");
-    assertThat(response.data()).contains("\"version\":\"2.1.0\"");
-    assertThat(response.data()).contains("\"runs\":");
-
-    log.info("✓ SARIF structure validated:");
-    log.info("  - Contains $schema");
-    log.info("  - Contains version 2.1.0");
-    log.info("  - Contains runs array");
+    assertThat(response.found())
+        .as("case-inverted name '%s' must not match seeded project '%s'", inverted, testProjectName)
+        .isFalse();
+    assertThat(response.data()).isNull();
   }
 
-  @Test
-  void end_to_end_workflow_should_demonstrate_deprecation() {
-    log.info("\n=== Integration Test: End-to-end workflow with deprecation notice ===");
-
-    var response = getSastResultsTool.getScanResults(testProjectName);
-
-    if (response.isSuccess()) {
-      log.info("✓ SARIF retrieved successfully ({} chars)", response.data().length());
-
-      if (!response.warnings().isEmpty()) {
-        log.warn("⚠️ Tool returned warnings:");
-        for (var warning : response.warnings()) {
-          log.warn("  - {}", warning);
-        }
+  private static String invertCase(String input) {
+    var chars = input.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      var c = chars[i];
+      if (Character.isUpperCase(c)) {
+        chars[i] = Character.toLowerCase(c);
+      } else if (Character.isLowerCase(c)) {
+        chars[i] = Character.toUpperCase(c);
       }
-
-      // Verify the deprecation warning is present
-      assertThat(response.warnings())
-          .as("Should include deprecation warning")
-          .anyMatch(w -> w.contains("DEPRECATED"));
-
-      log.info("\n💡 Note: This tool is deprecated. Consider using future paginated SAST tools.");
-    } else {
-      log.info("✗ SARIF retrieval failed: {}", response.errors());
     }
+    return new String(chars);
   }
 }

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java
@@ -125,6 +125,22 @@ public class GetVulnerabilityToolIT
     log.info("Test data: {}", data);
   }
 
+  /**
+   * Captures two vulnerability samples from the first page of org-wide search results:
+   *
+   * <ul>
+   *   <li><b>Primary sample</b> — the first vuln carrying a non-blank {@code vulnID}, plus its
+   *       {@code appID}, {@code appName}, title, type, severity, and status. Drives the happy-path
+   *       retrieval test plus every field-shape assertion in {@code testDiscoveredTestDataExists}.
+   *   <li><b>Environment sample</b> — the first vuln whose {@code environments} list is populated.
+   *       The {@code _populate_environments_} test asserts {@code isNotEmpty} on the returned
+   *       environments list, so it cannot use the primary sample if that sample has no
+   *       environments. Reused if the primary sample already carries them.
+   * </ul>
+   *
+   * Both samples come from the default-status search (not {@code ALL_STATUSES}) — the populated
+   * vulnerabilities most likely to drive the retrieval contract.
+   */
   @Override
   protected TestData performDiscovery() throws IOException {
     var response =

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java
@@ -28,25 +28,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 
 /**
- * Integration test for GetVulnerabilityTool that validates single vulnerability retrieval against
- * real TeamServer.
+ * Integration tests for {@link GetVulnerabilityTool} verifying the contract across the SDK/Assess
+ * API boundary. Cited in {@code CLAUDE.md} → Integration Test Standards as a canonical example for
+ * comprehensive field verification; assertions here must remain mutation-resistant.
  *
- * <p>This test validates that the refactored tool produces identical results to the original
- * AssessService.getVulnerabilityById() method.
- *
- * <p>This test only runs if CONTRAST_HOST_NAME environment variable is set.
- *
- * <p>Required environment variables:
- *
- * <ul>
- *   <li>CONTRAST_HOST_NAME (e.g., app.contrastsecurity.com)
- *   <li>CONTRAST_API_KEY
- *   <li>CONTRAST_SERVICE_KEY
- *   <li>CONTRAST_USERNAME
- *   <li>CONTRAST_ORG_ID
- * </ul>
- *
- * <p>Run locally: source .env.integration-test && mvn verify
+ * <p>Run: {@code source .env.integration-test && mvn verify}
  */
 @Slf4j
 @SpringBootTest
@@ -58,16 +44,69 @@ public class GetVulnerabilityToolIT
   @Autowired private GetVulnerabilityTool getVulnerabilityTool;
   @Autowired private SearchVulnerabilitiesTool searchVulnerabilitiesTool;
 
-  /** Container for discovered test data - stores a vulnerability to retrieve. */
+  // Discovery sample size — broad enough to find a vulnerability that has environments populated
+  // (required for the populate-environments test) without pulling the entire org corpus.
+  private static final int DISCOVERY_PAGE_SIZE = 100;
+
+  // Exact validation messages produced by ToolValidationContext#require for each parameter.
+  // Asserting the full shape (not just a parameter-name substring) prevents a false-positive match
+  // against any unrelated message that happens to mention the parameter name.
+  private static final String VULN_ID_REQUIRED_ERROR = "vulnId is required";
+  private static final String APP_ID_REQUIRED_ERROR = "appId is required";
+
+  // SingleTool's 5xx mapping — validation errors must never look like this.
+  private static final String CONTRAST_API_ERROR = "Contrast API error";
+
+  // UUID-formatted ID that will not match any real resource. The Contrast API treats lookups for
+  // nonexistent vuln/app IDs as 401/403 rather than 404 (a deliberate security choice — the API
+  // does not differentiate "no permission" from "doesn't exist", to avoid leaking resource
+  // existence). SingleTool maps that to its UnauthorizedException handler with this exact
+  // user-facing message.
+  private static final String NONEXISTENT_UUID = "00000000-0000-0000-0000-000000000000";
+  private static final String UNKNOWN_RESOURCE_ERROR =
+      "Authentication failed or resource not found."
+          + " Verify credentials and that the resource ID is correct.";
+
+  /**
+   * Container for discovered test data. Populated once per class by {@link #performDiscovery()}.
+   *
+   * <p>Carries two samples:
+   *
+   * <ul>
+   *   <li><b>primary</b> — first vulnerability returned by the org-wide search; backs the main
+   *       retrieval, validation-error, and not-found tests.
+   *   <li><b>env-populated</b> — first vulnerability with non-empty {@code environments}; backs the
+   *       {@code _should_populate_environments_*} test. May coincide with the primary sample.
+   * </ul>
+   */
   static class TestData {
     String vulnId;
     String appId;
     String vulnTitle;
+    String vulnType;
+    String severity;
+    String status;
+    String appName;
+
+    String envSampleVulnId;
+    String envSampleAppId;
+    String envSampleEnvironment;
 
     @Override
     public String toString() {
       return String.format(
-          "TestData{vulnId='%s', appId='%s', title='%s'}", vulnId, appId, vulnTitle);
+          "TestData{vulnId='%s', appId='%s', appName='%s', title='%s', type='%s', severity='%s',"
+              + " status='%s', envVulnId='%s', envAppId='%s', envSample='%s'}",
+          vulnId,
+          appId,
+          appName,
+          vulnTitle,
+          vulnType,
+          severity,
+          status,
+          envSampleVulnId,
+          envSampleAppId,
+          envSampleEnvironment);
     }
   }
 
@@ -83,171 +122,357 @@ public class GetVulnerabilityToolIT
 
   @Override
   protected void logTestDataDetails(TestData data) {
-    log.info("Test data: vulnId={}, appId={}, title={}", data.vulnId, data.appId, data.vulnTitle);
+    log.info("Test data: {}", data);
   }
 
   @Override
   protected TestData performDiscovery() throws IOException {
-    // Find a vulnerability to use for testing
     var response =
         searchVulnerabilitiesTool.searchVulnerabilities(
-            1, 1, null, null, null, null, null, null, null);
+            1, DISCOVERY_PAGE_SIZE, null, null, null, null, null, null, null);
 
-    if (!response.isSuccess() || response.items().isEmpty()) {
+    if (!response.isSuccess()) {
       throw new NoTestDataException(
-          "No vulnerabilities found in organization. "
-              + "GetVulnerabilityTool integration tests require at least one vulnerability.");
+          "GetVulnerabilityToolIT discovery failed — errors: " + response.errors());
+    }
+    if (response.items().isEmpty()) {
+      throw new NoTestDataException(
+          "GetVulnerabilityToolIT requires at least one vulnerability in the organization — "
+              + "see INTEGRATION_TESTS.md");
     }
 
-    var vuln = response.items().get(0);
-    var testData = new TestData();
-    testData.vulnId = vuln.vulnID();
-    testData.appId = vuln.appID();
-    testData.vulnTitle = vuln.title();
+    var data = new TestData();
 
-    log.info("Discovery: found vulnerability {} in app {}", testData.vulnId, testData.appId);
+    // Primary sample — first vuln carrying a non-blank vulnID.
+    for (var vuln : response.items()) {
+      if (vuln.vulnID() == null || vuln.vulnID().isBlank()) {
+        continue;
+      }
+      data.vulnId = vuln.vulnID();
+      data.appId = vuln.appID();
+      data.appName = vuln.appName();
+      data.vulnTitle = vuln.title();
+      data.vulnType = vuln.type();
+      data.severity = vuln.severity();
+      data.status = vuln.status();
+      break;
+    }
 
-    return testData;
+    // Environment-populated sample — first vuln with non-empty environments. Used by the
+    // populate-environments test, which must assert isNotEmpty rather than isNotNull. If the
+    // primary sample already has environments, reuse it; otherwise scan further into the page.
+    for (var vuln : response.items()) {
+      if (vuln.environments() == null || vuln.environments().isEmpty()) {
+        continue;
+      }
+      var firstEnv = vuln.environments().get(0);
+      if (firstEnv == null || firstEnv.isBlank()) {
+        continue;
+      }
+      data.envSampleVulnId = vuln.vulnID();
+      data.envSampleAppId = vuln.appID();
+      data.envSampleEnvironment = firstEnv;
+      break;
+    }
+
+    return data;
+  }
+
+  // ---------- Discovery precondition ----------
+
+  @Test
+  void testDiscoveredTestDataExists() {
+    assertThat(testData).as("discovery must populate test data").isNotNull();
+    assertThat(testData.vulnId).as("primary sample vulnID must be non-blank").isNotBlank();
+    assertThat(testData.appId)
+        .as("primary sample appID must be non-blank — APPLICATION expand should populate it")
+        .isNotBlank();
+    assertThat(testData.appName).as("primary sample appName must be non-blank").isNotBlank();
+    assertThat(testData.vulnTitle).as("primary sample title must be non-blank").isNotBlank();
+    assertThat(testData.vulnType).as("primary sample type must be non-blank").isNotBlank();
+    assertThat(testData.severity).as("primary sample severity must be non-blank").isNotBlank();
+    assertThat(testData.status).as("primary sample status must be non-blank").isNotBlank();
+  }
+
+  // ---------- Validation errors ----------
+
+  @Test
+  void getVulnerability_should_return_validation_error_for_null_vulnId() {
+    var response = getVulnerabilityTool.getVulnerability(null, testData.appId);
+
+    assertThat(response.isSuccess()).as("null vulnId must fail validation").isFalse();
+    assertThat(response.found()).as("validation failure must not report found").isFalse();
+    assertThat(response.data()).as("validation failure must not carry data").isNull();
+    assertThat(response.errors())
+        .as("validation error must state vulnId is required")
+        .containsExactly(VULN_ID_REQUIRED_ERROR);
+    assertThat(response.errors())
+        .as("validation error must not surface as a Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
   }
 
   @Test
-  void getVulnerability_should_return_validation_error_for_missing_vulnId() {
-    var result = getVulnerabilityTool.getVulnerability(null, "some-app-id");
+  void getVulnerability_should_return_validation_error_for_empty_vulnId() {
+    var response = getVulnerabilityTool.getVulnerability("", testData.appId);
 
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("vulnId") && e.contains("required"));
+    assertThat(response.isSuccess()).as("empty vulnId must fail validation").isFalse();
+    assertThat(response.errors())
+        .as("validation error must state vulnId is required")
+        .containsExactly(VULN_ID_REQUIRED_ERROR);
   }
 
   @Test
-  void getVulnerability_should_return_validation_error_for_missing_appId() {
-    var result = getVulnerabilityTool.getVulnerability("some-vuln-id", null);
+  void getVulnerability_should_return_validation_error_for_whitespace_vulnId() {
+    // ToolValidationContext#require uses StringUtils.hasText, which rejects whitespace as well as
+    // null/empty. Without this test a regression that switched to isEmpty() would silently allow
+    // whitespace strings to reach the SDK.
+    var response = getVulnerabilityTool.getVulnerability("   ", testData.appId);
 
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("appId") && e.contains("required"));
+    assertThat(response.isSuccess()).as("whitespace-only vulnId must fail validation").isFalse();
+    assertThat(response.errors())
+        .as("validation error must state vulnId is required")
+        .containsExactly(VULN_ID_REQUIRED_ERROR);
   }
+
+  @Test
+  void getVulnerability_should_return_validation_error_for_null_appId() {
+    var response = getVulnerabilityTool.getVulnerability(testData.vulnId, null);
+
+    assertThat(response.isSuccess()).as("null appId must fail validation").isFalse();
+    assertThat(response.found()).as("validation failure must not report found").isFalse();
+    assertThat(response.data()).as("validation failure must not carry data").isNull();
+    assertThat(response.errors())
+        .as("validation error must state appId is required")
+        .containsExactly(APP_ID_REQUIRED_ERROR);
+    assertThat(response.errors())
+        .as("validation error must not surface as a Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
+  }
+
+  @Test
+  void getVulnerability_should_return_validation_error_for_empty_appId() {
+    var response = getVulnerabilityTool.getVulnerability(testData.vulnId, "");
+
+    assertThat(response.isSuccess()).as("empty appId must fail validation").isFalse();
+    assertThat(response.errors())
+        .as("validation error must state appId is required")
+        .containsExactly(APP_ID_REQUIRED_ERROR);
+  }
+
+  @Test
+  void getVulnerability_should_collect_all_validation_errors_when_both_missing() {
+    // ToolValidationContext collects errors rather than failing fast, so a caller that omits both
+    // params should see both messages in one response. A regression to fail-fast validation would
+    // surface here as a single-element list.
+    var response = getVulnerabilityTool.getVulnerability(null, null);
+
+    assertThat(response.isSuccess()).as("both params missing must fail validation").isFalse();
+    assertThat(response.errors())
+        .as("both required-field errors must be reported together")
+        .containsExactlyInAnyOrder(VULN_ID_REQUIRED_ERROR, APP_ID_REQUIRED_ERROR);
+  }
+
+  // ---------- Successful retrieval (field-mapping coverage) ----------
 
   /**
-   * Validates that getVulnerability retrieves a vulnerability directly by ID. This is the primary
-   * test that proves the refactored tool works identically to the original
-   * AssessService.getVulnerabilityById() method.
-   *
-   * <p>Original test:
-   * AssessServiceIntegrationTest.testGetVulnerabilityById_RetrievesVulnerabilityDirectly()
+   * Comprehensive field-mapping regression: asserts every member of the {@link
+   * com.contrast.labs.ai.mcp.contrast.result.Vulnerability} record. Originally proved the
+   * refactored tool was identical to the legacy {@code AssessService.getVulnerabilityById()}; now
+   * serves as the canonical mapping check. A future regression that drops a field from {@code
+   * VulnerabilityMapper} or breaks a SDK→record translation must surface here.
    */
   @Test
   void getVulnerability_should_retrieve_vulnerability_directly_by_id() {
     var response = getVulnerabilityTool.getVulnerability(testData.vulnId, testData.appId);
 
-    assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.isSuccess()).as("Request should succeed").isTrue();
-    assertThat(response.found()).as("Vulnerability should be found").isTrue();
+    assertThat(response).as("response must not be null").isNotNull();
+    assertThat(response.isSuccess()).as("seeded query must succeed").isTrue();
+    assertThat(response.errors()).as("successful retrieval must produce no errors").isEmpty();
+    assertThat(response.found()).as("seeded vulnerability must be found").isTrue();
+    assertThat(response.data()).as("successful response must carry data").isNotNull();
 
-    var vulnerability = response.data();
-    assertThat(vulnerability).as("Vulnerability data should not be null").isNotNull();
+    var vuln = response.data();
 
-    // Core identification fields
-    assertThat(vulnerability.vulnID())
-        .as("VulnID should match requested")
+    // Core identification fields — Strings; isNotBlank prevents an empty-payload regression
+    // (e.g., a Jackson serialization break) that would pass isNotNull.
+    assertThat(vuln.vulnID())
+        .as("Vulnerability.vulnID must echo the requested ID")
         .isEqualTo(testData.vulnId);
-    assertThat(vulnerability.title()).as("Title should not be null").isNotNull();
-    assertThat(vulnerability.type()).as("Type should not be null").isNotNull();
-    assertThat(vulnerability.severity()).as("Severity should not be null").isNotNull();
-    assertThat(vulnerability.status()).as("Status should not be null").isNotNull();
+    assertThat(vuln.title()).as("Vulnerability.title must be populated").isNotBlank();
+    assertThat(vuln.type()).as("Vulnerability.type must be populated").isNotBlank();
+    assertThat(vuln.severity()).as("Vulnerability.severity must be populated").isNotBlank();
+    assertThat(vuln.status()).as("Vulnerability.status must be populated").isNotBlank();
 
-    // Application correlation fields
-    assertThat(vulnerability.appID()).as("AppID should not be null").isNotNull();
-    assertThat(vulnerability.appName()).as("AppName should not be null").isNotNull();
+    // Application correlation fields — appID must echo the request; appName comes from the
+    // APPLICATION expand and must be populated.
+    assertThat(vuln.appID())
+        .as("Vulnerability.appID must echo the requested appId")
+        .isEqualTo(testData.appId);
+    assertThat(vuln.appName()).as("Vulnerability.appName must be populated").isNotBlank();
 
-    // Timestamp fields (ISO-8601 formatted)
-    assertThat(vulnerability.firstSeenAt()).as("FirstSeenAt should not be null").isNotNull();
-    assertThat(vulnerability.lastSeenAt()).as("LastSeenAt should not be null").isNotNull();
+    // Timestamp fields — ISO-8601 strings, never blank for a real trace.
+    assertThat(vuln.firstSeenAt()).as("Vulnerability.firstSeenAt must be populated").isNotBlank();
+    assertThat(vuln.lastSeenAt()).as("Vulnerability.lastSeenAt must be populated").isNotBlank();
 
-    // Collection fields (should never be null, may be empty)
-    assertThat(vulnerability.environments()).as("Environments should not be null").isNotNull();
-    assertThat(vulnerability.tags()).as("Tags should not be null").isNotNull();
-    assertThat(vulnerability.sessionMetadata())
-        .as("SessionMetadata should not be null")
+    // Collection fields — VulnerabilityMapper guarantees non-null lists, but emptiness is
+    // legitimate (e.g., a vuln seen only in DEVELOPMENT will have no PRODUCTION env entry).
+    // The retrieval contract is "never null"; populate guarantees are exercised by dedicated
+    // tests (see _should_populate_environments_for_seeded_vulnerability).
+    assertThat(vuln.environments())
+        .as("Vulnerability.environments must never be null (may be empty)")
+        .isNotNull();
+    assertThat(vuln.tags()).as("Vulnerability.tags must never be null (may be empty)").isNotNull();
+    assertThat(vuln.sessionMetadata())
+        .as("Vulnerability.sessionMetadata must never be null (may be empty)")
         .isNotNull();
 
-    // Detail-specific fields (should never be null, may be empty)
-    assertThat(vulnerability.hint()).as("Hint should not be null").isNotNull();
-    assertThat(vulnerability.howToFix()).as("HowToFix should not be null").isNotNull();
-    assertThat(vulnerability.stackTrace()).as("StackTrace should not be null").isNotNull();
-    assertThat(vulnerability.vulnerableLibraries())
-        .as("VulnerableLibraries should not be null")
+    // Detail-specific fields — built by the optional-data fetch in buildVulnerabilityContext.
+    // These also have non-null contracts but may be empty when the underlying data isn't
+    // available (graceful degradation, signaled via warnings).
+    assertThat(vuln.howToFix())
+        .as("Vulnerability.howToFix must never be null (may be empty)")
         .isNotNull();
+    assertThat(vuln.stackTrace())
+        .as("Vulnerability.stackTrace must never be null (may be empty)")
+        .isNotNull();
+    assertThat(vuln.vulnerableLibraries())
+        .as("Vulnerability.vulnerableLibraries must never be null (may be empty)")
+        .isNotNull();
+  }
 
-    log.info(
-        "✓ Successfully retrieved vulnerability: {} - {} ({}, {})",
-        vulnerability.vulnID(),
-        vulnerability.title(),
-        vulnerability.severity(),
-        vulnerability.type());
-    log.info("  App: {} ({})", vulnerability.appName(), vulnerability.appID());
-    log.info(
-        "  First seen: {}, Last seen: {}", vulnerability.firstSeenAt(), vulnerability.lastSeenAt());
-    log.info("  Environments: {}", vulnerability.environments());
-    log.info("  Tags: {}", vulnerability.tags());
-    log.info("  Stack trace entries: {}", vulnerability.stackTrace().size());
-    log.info("  Vulnerable libraries: {}", vulnerability.vulnerableLibraries().size());
+  // ---------- Populate guarantees ----------
+
+  @Test
+  void getVulnerability_should_populate_environments_for_seeded_vulnerability() {
+    // Precondition: discovery must have located a vulnerability with non-empty environments.
+    // If absent, the org isn't seeded with deployment context and the populate claim cannot be
+    // verified — fail loudly with an actionable message instead of silently passing.
+    assertThat(testData.envSampleVulnId)
+        .as(
+            "requires at least one vulnerability with non-empty environments in the first %d"
+                + " results — see INTEGRATION_TESTS.md",
+            DISCOVERY_PAGE_SIZE)
+        .isNotBlank();
+    assertThat(testData.envSampleEnvironment)
+        .as("env-populated sample must carry a non-blank environment label")
+        .isNotBlank();
+
+    var response =
+        getVulnerabilityTool.getVulnerability(testData.envSampleVulnId, testData.envSampleAppId);
+
+    assertThat(response.isSuccess()).as("env-populated retrieval must succeed").isTrue();
+    assertThat(response.found()).as("env-populated vulnerability must be found").isTrue();
+
+    var vuln = response.data();
+    assertThat(vuln).as("env-populated retrieval must carry data").isNotNull();
+
+    // The populate claim — if the SearchVulnerabilities response saw environments on this vuln,
+    // GetVulnerability must surface them too. A regression that dropped env propagation in the
+    // detail mapper (or the SERVER_ENVIRONMENTS expand) would surface as an empty list here.
+    assertThat(vuln.environments())
+        .as(
+            "Vulnerability.environments must be populated for vuln %s — search saw %s",
+            testData.envSampleVulnId, testData.envSampleEnvironment)
+        .isNotEmpty()
+        .allSatisfy(env -> assertThat(env).as("environment label").isNotBlank());
+
+    // Cross-check: the environment seen during search must be reflected in the detail response.
+    // Catches a regression that returned a different environment set between endpoints.
+    assertThat(vuln.environments())
+        .as("detail response environments must include the one seen during search")
+        .contains(testData.envSampleEnvironment);
   }
 
   @Test
-  void getVulnerability_should_return_not_found_for_invalid_id() {
-    var response = getVulnerabilityTool.getVulnerability("INVALID-VULN-ID-12345", testData.appId);
-
-    assertThat(response).as("Response should not be null").isNotNull();
-    // The response may be an error or not-found depending on how the API responds
-    // Either way, we should not get a successful data response
-    if (response.isSuccess()) {
-      assertThat(response.found()).as("Should not find invalid vulnerability").isFalse();
-    }
-
-    log.info("✓ Invalid vulnerability ID handled correctly");
-  }
-
-  @Test
-  void getVulnerability_should_populate_remediation_guidance() {
+  void getVulnerability_should_populate_remediation_hint() {
     var response = getVulnerabilityTool.getVulnerability(testData.vulnId, testData.appId);
 
-    assertThat(response.isSuccess()).isTrue();
-    var vulnerability = response.data();
+    assertThat(response.isSuccess()).as("remediation lookup must succeed").isTrue();
+    var vuln = response.data();
+    assertThat(vuln).as("response must carry data").isNotNull();
 
-    // Hint is AI-generated based on vulnerability type - should always be present
-    assertThat(vulnerability.hint())
-        .as("Hint should provide remediation guidance")
-        .isNotNull()
-        .isNotEmpty();
-
-    // HowToFix comes from Contrast's recommendation API - may vary by vuln type
-    assertThat(vulnerability.howToFix()).as("HowToFix field should exist").isNotNull();
-
-    log.info("✓ Remediation guidance populated");
-    log.info(
-        "  Hint: {}",
-        vulnerability.hint().substring(0, Math.min(100, vulnerability.hint().length())) + "...");
-    if (!vulnerability.howToFix().isEmpty()) {
-      log.info(
-          "  HowToFix: {}",
-          vulnerability.howToFix().substring(0, Math.min(100, vulnerability.howToFix().length()))
-              + "...");
-    }
+    // The hint is generated from a static rule→guidance map in the hint subsystem and is keyed
+    // by the trace's rule. Every recognised rule produces a non-blank hint; an unrecognised
+    // rule produces a generic non-blank hint. A blank result would mean the hint subsystem was
+    // bypassed or returned the empty default — exactly the regression "Populate ≠ non-null"
+    // catches.
+    assertThat(vuln.hint())
+        .as("Vulnerability.hint must provide non-blank remediation guidance")
+        .isNotBlank();
   }
 
+  // ---------- Not-found path ----------
+
   @Test
-  void getVulnerability_should_include_warnings_for_unavailable_data() {
+  void getVulnerability_should_reject_nonexistent_vulnId_with_unknown_resource_error() {
+    // The Contrast API returns 401/403 (not 404) for any vuln/app ID that the caller cannot
+    // resolve — a deliberate security choice that conflates "doesn't exist" with "no
+    // permission" to avoid leaking resource existence. SingleTool's UnauthorizedException
+    // handler emits a single canonical user-facing message; this test asserts the exact text
+    // so a regression that exposed the raw "Resource not found" or stack trace would surface.
+    var response = getVulnerabilityTool.getVulnerability(NONEXISTENT_UUID, testData.appId);
+
+    assertThat(response).as("response must not be null").isNotNull();
+    assertThat(response.isSuccess())
+        .as("unknown-resource response must surface as an error (not a silent notFound)")
+        .isFalse();
+    assertThat(response.found())
+        .as("nonexistent vulnerability must not be reported as found")
+        .isFalse();
+    assertThat(response.data()).as("error response must not carry vulnerability data").isNull();
+    assertThat(response.errors())
+        .as("errors must contain exactly the documented unknown-resource message")
+        .containsExactly(UNKNOWN_RESOURCE_ERROR);
+    assertThat(response.errors())
+        .as("error must not surface as a Contrast API (5xx) error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
+  }
+
+  /**
+   * Regression coverage for the (vulnId, appId) cross-validation contract: the tool accepts both
+   * IDs, and {@code GET /traces/{org}/{appId}/{traceId}} enforces the relationship. If the trace
+   * exists but the appId belongs to a different application, the API responds with the same 401/403
+   * → unknown-resource error as a fully nonexistent ID. Without this test, a future change that
+   * ignored {@code appId} (or routed via a non-scoped endpoint) would silently return data for the
+   * wrong app.
+   */
+  @Test
+  void getVulnerability_should_reject_when_appId_does_not_own_vulnId() {
+    var response = getVulnerabilityTool.getVulnerability(testData.vulnId, NONEXISTENT_UUID);
+
+    assertThat(response.isSuccess())
+        .as("appId/vulnId mismatch must not surface as a successful retrieval")
+        .isFalse();
+    assertThat(response.found())
+        .as(
+            "vuln %s belongs to app %s, not %s — must not be reported as found",
+            testData.vulnId, testData.appId, NONEXISTENT_UUID)
+        .isFalse();
+    assertThat(response.data())
+        .as("error response must not carry data even when vulnId is real")
+        .isNull();
+    assertThat(response.errors())
+        .as("errors must contain exactly the documented unknown-resource message")
+        .containsExactly(UNKNOWN_RESOURCE_ERROR);
+  }
+
+  // ---------- Warnings (graceful degradation) ----------
+
+  @Test
+  void getVulnerability_should_provide_non_null_warnings_list() {
+    // The warnings list is part of the response contract regardless of whether degradation
+    // occurred. Some optional sub-fetches (recommendation, HTTP request, stack/library) are
+    // permitted to fail and are surfaced as warnings — but the list itself must always exist.
     var response = getVulnerabilityTool.getVulnerability(testData.vulnId, testData.appId);
 
-    assertThat(response.isSuccess()).isTrue();
-    assertThat(response.warnings()).as("Warnings list should exist").isNotNull();
-
-    // Warnings indicate graceful degradation when optional data isn't available
-    // This is expected behavior, not an error
-    if (!response.warnings().isEmpty()) {
-      log.info("✓ Warnings present for unavailable optional data:");
-      response.warnings().forEach(w -> log.info("  - {}", w));
-    } else {
-      log.info("✓ All optional data was available (no warnings)");
-    }
+    assertThat(response.isSuccess()).as("seeded retrieval must succeed").isTrue();
+    assertThat(response.warnings())
+        .as("warnings list is part of the response contract — must never be null")
+        .isNotNull();
+    // Each warning, if present, must carry a non-blank message — a blank warning provides no
+    // diagnostic value to the AI consumer and would represent a producer-side bug.
+    assertThat(response.warnings())
+        .as("every warning must carry a non-blank message")
+        .allSatisfy(w -> assertThat(w).as("warning message").isNotBlank());
   }
 }

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesToolIT.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.contrast.labs.ai.mcp.contrast.config.IntegrationTestConfig;
 import com.contrast.labs.ai.mcp.contrast.util.AbstractIntegrationTest;
 import java.io.IOException;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -54,13 +55,23 @@ public class ListVulnerabilityTypesToolIT
 
   @Autowired private ListVulnerabilityTypesTool listVulnerabilityTypesTool;
 
-  /** Container for discovered test data - minimal for this tool. */
+  // Canonical rule-name format: lowercase letters/digits, optionally separated by single hyphens
+  // (e.g., "sql-injection", "reflected-xss", "nosql-injection-dynamodb", "xxe", "csrf").
+  private static final Pattern RULE_NAME_PATTERN = Pattern.compile("[a-z0-9]+(-[a-z0-9]+)*");
+
+  // Canonical OWASP-relevant rules every Contrast rule catalogue exposes — used to verify the
+  // tool's documented contract (see ListVulnerabilityTypesTool javadoc).
+  private static final String SQL_INJECTION = "sql-injection";
+  private static final String PATH_TRAVERSAL = "path-traversal";
+  private static final String CMD_INJECTION = "cmd-injection";
+
+  /** Container for discovered test data. */
   static class TestData {
-    boolean apiAccessible;
+    int totalRules;
 
     @Override
     public String toString() {
-      return String.format("TestData{apiAccessible=%s}", apiAccessible);
+      return String.format("TestData{totalRules=%d}", totalRules);
     }
   }
 
@@ -76,97 +87,104 @@ public class ListVulnerabilityTypesToolIT
 
   @Override
   protected void logTestDataDetails(TestData data) {
-    log.info("Test data: apiAccessible={}", data.apiAccessible);
+    log.info("Test data: totalRules={}", data.totalRules);
   }
 
   @Override
   protected TestData performDiscovery() throws IOException {
-    // Just verify we can access the API
     var response = listVulnerabilityTypesTool.listVulnerabilityTypes();
+    if (!response.isSuccess() || response.data() == null || response.data().isEmpty()) {
+      throw new NoTestDataException(
+          "list_vulnerability_types returned no rules — requires a configured Contrast org with"
+              + " an enabled rule catalogue. See INTEGRATION_TESTS.md");
+    }
 
-    var testData = new TestData();
-    testData.apiAccessible = response.isSuccess();
-
-    log.info("Discovery: API accessible={}", testData.apiAccessible);
-
-    return testData;
+    var data = new TestData();
+    data.totalRules = response.data().size();
+    log.info("Discovery: {} vulnerability types available", data.totalRules);
+    return data;
   }
 
   @Test
-  void listVulnerabilityTypes_should_return_valid_response() {
+  void listVulnerabilityTypes_should_return_success_with_non_null_data_and_no_errors() {
     var response = listVulnerabilityTypesTool.listVulnerabilityTypes();
 
     assertThat(response).isNotNull();
-    assertThat(response.isSuccess()).isTrue();
-    assertThat(response.found()).isTrue();
-    assertThat(response.data()).isNotNull();
-
-    log.info("Retrieved {} vulnerability types", response.data().size());
+    assertThat(response.isSuccess()).as("happy-path call must succeed").isTrue();
+    assertThat(response.errors()).as("happy-path call must surface no errors").isEmpty();
+    assertThat(response.found()).as("rule catalogue must be reported as found").isTrue();
+    assertThat(response.data()).as("rule list must be non-null on success").isNotNull();
   }
 
   @Test
-  void listVulnerabilityTypes_should_return_non_empty_list() {
+  void listVulnerabilityTypes_should_return_non_empty_list_of_well_formed_rule_names() {
     var response = listVulnerabilityTypesTool.listVulnerabilityTypes();
 
     assertThat(response.isSuccess()).isTrue();
-    assertThat(response.data()).isNotEmpty();
-
-    // Should have common vulnerability types
-    log.info("First 10 vulnerability types: {}", response.data().stream().limit(10).toList());
+    assertThat(response.data())
+        .as("vulnerability-types catalogue should never be empty for a configured org")
+        .isNotEmpty()
+        .allSatisfy(
+            type -> {
+              assertThat(type).as("rule name must not be blank").isNotBlank();
+              assertThat(type)
+                  .as(
+                      "rule name '%s' must match canonical lowercase-hyphenated format %s",
+                      type, RULE_NAME_PATTERN.pattern())
+                  .matches(RULE_NAME_PATTERN);
+            });
   }
 
   @Test
-  void listVulnerabilityTypes_should_return_sorted_list() {
+  void listVulnerabilityTypes_should_return_alphabetically_sorted_list() {
     var response = listVulnerabilityTypesTool.listVulnerabilityTypes();
 
     assertThat(response.isSuccess()).isTrue();
-    assertThat(response.data()).isNotEmpty();
-
-    // Verify sorted alphabetically
-    var types = response.data();
-    for (int i = 1; i < types.size(); i++) {
-      assertThat(types.get(i).compareTo(types.get(i - 1)))
-          .as("List should be sorted alphabetically at index %d", i)
-          .isGreaterThanOrEqualTo(0);
-    }
-
-    log.info("All {} vulnerability types are sorted alphabetically", types.size());
+    assertThat(response.data())
+        .as("rule names must be returned in stable alphabetical order")
+        .isNotEmpty()
+        .isSortedAccordingTo(String::compareTo);
   }
 
   @Test
-  void listVulnerabilityTypes_should_contain_common_vulnerability_types() {
+  void listVulnerabilityTypes_should_contain_well_known_owasp_rules() {
     var response = listVulnerabilityTypesTool.listVulnerabilityTypes();
 
     assertThat(response.isSuccess()).isTrue();
-
-    // Should contain some well-known vulnerability types (case-insensitive check)
-    var typesLower = response.data().stream().map(String::toLowerCase).toList();
-
-    // Check for at least some common types (may not have all depending on org config)
-    boolean hasInjection =
-        typesLower.stream()
-            .anyMatch(t -> t.contains("injection") || t.contains("sql") || t.contains("xss"));
-
-    if (hasInjection) {
-      log.info("Found common injection-related vulnerability types");
-    } else {
-      log.info(
-          "Note: No common injection types found (may be org-specific). Types: {}",
-          response.data().stream().limit(20).toList());
-    }
-
-    // The main assertion is that we got valid data back
-    assertThat(response.data()).allMatch(type -> type != null && !type.trim().isEmpty());
-    log.info("All vulnerability types are non-null and non-empty");
+    assertThat(response.data())
+        .as("Contrast catalogue must expose SQL injection rule (sql-injection)")
+        .contains(SQL_INJECTION);
+    assertThat(response.data())
+        .as("Contrast catalogue must expose path traversal rule (path-traversal)")
+        .contains(PATH_TRAVERSAL);
+    assertThat(response.data())
+        .as("Contrast catalogue must expose command injection rule (cmd-injection)")
+        .contains(CMD_INJECTION);
+    assertThat(response.data())
+        .as("Contrast catalogue must expose at least one XSS rule (reflected-xss / stored-xss)")
+        .anyMatch(type -> type.contains("xss"));
+    assertThat(response.data())
+        .as("Contrast catalogue must expose multiple injection-class rules")
+        .filteredOn(type -> type.contains("injection"))
+        .hasSizeGreaterThan(1);
   }
 
   @Test
   void listVulnerabilityTypes_should_have_no_errors() {
     var response = listVulnerabilityTypesTool.listVulnerabilityTypes();
 
-    assertThat(response.isSuccess()).isTrue();
-    assertThat(response.errors()).isEmpty();
+    assertThat(response.errors()).as("happy-path call must not surface errors").isEmpty();
+  }
 
-    log.info("No errors returned from list_vulnerability_types");
+  @Test
+  void listVulnerabilityTypes_should_be_idempotent_across_consecutive_calls() {
+    var first = listVulnerabilityTypesTool.listVulnerabilityTypes();
+    var second = listVulnerabilityTypesTool.listVulnerabilityTypes();
+
+    assertThat(first.isSuccess()).isTrue();
+    assertThat(second.isSuccess()).isTrue();
+    assertThat(second.data())
+        .as("two consecutive calls must return the same catalogue in the same order")
+        .containsExactlyElementsOf(first.data());
   }
 }

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesToolIT.java
@@ -90,6 +90,12 @@ public class ListVulnerabilityTypesToolIT
     log.info("Test data: totalRules={}", data.totalRules);
   }
 
+  /**
+   * Confirms the org's rule catalogue is reachable and non-empty before any test runs. Captures
+   * {@code totalRules} so a regression that empties the catalogue fails the discovery precondition
+   * up front rather than letting downstream {@code allSatisfy}/{@code contains} assertions pass
+   * vacuously on an empty list. The catalogue is org-static, so no per-app seed data is required.
+   */
   @Override
   protected TestData performDiscovery() throws IOException {
     var response = listVulnerabilityTypesTool.listVulnerabilityTypes();

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolIT.java
@@ -18,9 +18,20 @@ package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrast.labs.ai.mcp.contrast.config.IntegrationTestConfig;
-import com.contrast.labs.ai.mcp.contrast.tool.application.SearchApplicationsTool;
+import com.contrast.labs.ai.mcp.contrast.result.VulnLight;
 import com.contrast.labs.ai.mcp.contrast.util.AbstractIntegrationTest;
+import com.contrastsecurity.models.SessionMetadata;
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -54,19 +65,89 @@ public class SearchAppVulnerabilitiesToolIT
     extends AbstractIntegrationTest<SearchAppVulnerabilitiesToolIT.TestData> {
 
   @Autowired private SearchAppVulnerabilitiesTool searchAppVulnerabilitiesTool;
-  @Autowired private SearchApplicationsTool searchApplicationsTool;
+  @Autowired private SearchVulnerabilitiesTool searchVulnerabilitiesTool;
+
+  // Discovery probe — bounded scan over the org's vulnerabilities to identify a vulnerability-
+  // rich application. Browsing applications first hit sparse sample apps; sampling
+  // vulnerabilities directly lets us pick the app with the most seed coverage.
+  private static final int VULN_DISCOVERY_PAGE_SIZE = 100;
+  private static final int VULN_SAMPLE_PAGE_SIZE = 100;
+
+  // Pagination probe — small page so multi-page behavior surfaces on apps with even a handful of
+  // seeded vulns.
+  private static final int PAGINATION_PROBE_SIZE = 2;
+  private static final int MIN_VULNS_FOR_PAGINATION = PAGINATION_PROBE_SIZE + 1;
+
+  // Severity labels returned by the API are capitalized ("Critical", "High", ...) — see
+  // RuleSeverity in the SDK. Tests compare case-insensitively to insulate from label drift.
+  private static final Set<String> CRITICAL_HIGH_LABELS = Set.of("critical", "high");
+
+  // Default-status filter excludes these terminal statuses. The API returns capitalized labels
+  // for non-default statuses ("Fixed", "Remediated"); the auto-remediated flow has been observed
+  // both as "AutoRemediated" and "Auto-Remediated" depending on TeamServer version, so the
+  // assertion compares case-insensitively against both spellings.
+  private static final Set<String> DEFAULT_STATUS_FILTER_EXCLUDES =
+      Set.of("fixed", "remediated", "autoremediated", "auto-remediated", "notaproblem");
+
+  // Full status set — used to bypass the default-status filter when looking for tagged
+  // vulnerabilities (which are commonly on Remediated/Fixed traces).
+  private static final String ALL_STATUSES =
+      "Reported,Suspicious,Confirmed,NotAProblem,Remediated,Fixed,AutoRemediated";
+
+  // Date format accepted by the SDK's dateParam: ISO YYYY-MM-DD.
+  private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+  // SingleTool's 5xx mapping — validation errors must never look like this.
+  private static final String CONTRAST_API_ERROR = "Contrast API error";
+
+  // String the API will not match against any real application.
+  private static final String NONEXISTENT_APP_ID = "nonexistent-app-id-12345";
+
+  // Tool warning emitted when useLatestSession=true but the app has no recorded sessions.
+  private static final String NO_SESSIONS_WARNING = "No sessions found for this application";
 
   /** Container for discovered test data. */
   static class TestData {
-    boolean hasApplications;
     String sampleAppId;
     String sampleAppName;
+    int totalVulnerabilities;
+    String sampleVulnId;
+    String sampleVulnType;
+    String sampleSeverity;
+    String sampleStatus;
+    String sampleEnvironment;
+    String sampleTag;
+
+    /** Session metadata field/value pair captured from a vuln, used for valid-JSON filter test. */
+    String sampleSessionField;
+
+    String sampleSessionValue;
+
+    boolean anyHasEnvironments;
+    boolean anyHasTags;
+    boolean anyHasSessionMetadata;
 
     @Override
     public String toString() {
       return String.format(
-          "TestData{hasApplications=%s, sampleAppId='%s', sampleAppName='%s'}",
-          hasApplications, sampleAppId, sampleAppName);
+          "TestData{appId='%s', appName='%s', totalVulns=%d, sampleVulnId='%s', "
+              + "type='%s', severity='%s', status='%s', env='%s', tag='%s', "
+              + "sessionField='%s', sessionValue='%s', "
+              + "anyEnvs=%s, anyTags=%s, anySessionMetadata=%s}",
+          sampleAppId,
+          sampleAppName,
+          totalVulnerabilities,
+          sampleVulnId,
+          sampleVulnType,
+          sampleSeverity,
+          sampleStatus,
+          sampleEnvironment,
+          sampleTag,
+          sampleSessionField,
+          sampleSessionValue,
+          anyHasEnvironments,
+          anyHasTags,
+          anyHasSessionMetadata);
     }
   }
 
@@ -82,33 +163,240 @@ public class SearchAppVulnerabilitiesToolIT
 
   @Override
   protected void logTestDataDetails(TestData data) {
-    log.info(
-        "Test data: hasApplications={}, sampleAppId={}, sampleAppName={}",
-        data.hasApplications,
-        data.sampleAppId,
-        data.sampleAppName);
+    log.info("Test data: {}", data);
   }
 
   @Override
   protected TestData performDiscovery() throws IOException {
-    var response = searchApplicationsTool.searchApplications(1, 5, null, null, null);
+    // Sample the org's vulnerabilities directly to find applications that carry rich seed data.
+    // Listing applications and probing each in turn surfaces sparse apps first (e.g., one vuln
+    // with no tags/sessions); piggy-backing on the org-wide search restricts the candidate set
+    // to apps that are demonstrably vulnerability-rich.
+    //
+    // Two probes: open-status (mirrors SearchVulnerabilities's default) and ALL_STATUSES (surfaces
+    // tagged vulns on terminal traces). Tagged apps from either probe rank ahead of untagged apps
+    // by raw count.
+    var openVulns =
+        searchVulnerabilitiesTool.searchVulnerabilities(
+            1, VULN_DISCOVERY_PAGE_SIZE, null, null, null, null, null, null, null);
+    var allVulns =
+        searchVulnerabilitiesTool.searchVulnerabilities(
+            1, VULN_DISCOVERY_PAGE_SIZE, null, ALL_STATUSES, null, null, null, null, null);
 
-    var testData = new TestData();
-    testData.hasApplications = response.isSuccess() && !response.items().isEmpty();
-
-    if (testData.hasApplications) {
-      var firstApp = response.items().get(0);
-      testData.sampleAppId = firstApp.appID();
-      testData.sampleAppName = firstApp.name();
+    if (!openVulns.isSuccess() && !allVulns.isSuccess()) {
+      throw new NoTestDataException(
+          "SearchAppVulnerabilitiesToolIT discovery failed listing org-wide vulnerabilities — "
+              + "errors: open="
+              + openVulns.errors()
+              + " all="
+              + allVulns.errors());
+    }
+    if (openVulns.items().isEmpty() && allVulns.items().isEmpty()) {
+      throw new NoTestDataException(
+          "SearchAppVulnerabilitiesToolIT requires at least one vulnerability in the organization"
+              + " — see INTEGRATION_TESTS.md");
     }
 
-    log.info(
-        "Discovery: found {} applications (hasApps={})",
-        response.items().size(),
-        testData.hasApplications);
+    // Bucket vulns from both probes by application. Track which apps surface tagged vulns in any
+    // probe — those apps are demonstrably tag-bearing and rank ahead of every other app in the
+    // candidate list, regardless of raw vuln count. This guarantees the vulnTags filter test
+    // reaches a tag-bearing app even when the org's most-vulnerable app has no tagged vulns.
+    var appCounts = new LinkedHashMap<String, Long>();
+    var appNames = new HashMap<String, String>();
+    var taggedAppIds = new LinkedHashSet<String>();
+    for (var v : openVulns.items()) {
+      bucketByApp(v, appCounts, appNames, taggedAppIds);
+    }
+    for (var v : allVulns.items()) {
+      bucketByApp(v, appCounts, appNames, taggedAppIds);
+    }
+    // Rank tagged apps first (by descending bucket count), then untagged apps (by descending
+    // bucket count). Tagged apps win deterministically — even one tagged vuln in either probe
+    // means the app outranks every untagged candidate. The vulnTags filter test (which requires
+    // a tag-bearing app) is the most stringent precondition; ranking tagged apps first keeps
+    // discovery from picking a vulnerable-but-untagged app like the previous regression where
+    // the chosen app had 22 vulns and zero tags.
+    var taggedRanked =
+        taggedAppIds.stream()
+            .sorted(
+                Comparator.comparing(
+                    (String id) -> appCounts.getOrDefault(id, 0L), Comparator.reverseOrder()))
+            .toList();
+    var untaggedRanked =
+        appCounts.entrySet().stream()
+            .filter(e -> !taggedAppIds.contains(e.getKey()))
+            .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+            .map(Map.Entry::getKey)
+            .toList();
+    var rankedAppIds = Stream.concat(taggedRanked.stream(), untaggedRanked.stream()).toList();
 
-    return testData;
+    TestData best = null;
+    int bestScore = -1;
+    for (var appId : rankedAppIds) {
+      var candidate = sampleApp(appId, appNames.get(appId));
+      if (candidate == null) {
+        continue;
+      }
+      int score = scoreCandidate(candidate);
+      if (score > bestScore) {
+        best = candidate;
+        bestScore = score;
+      }
+      // Early exit once we have an app that satisfies every downstream test's preconditions.
+      if (candidate.totalVulnerabilities >= MIN_VULNS_FOR_PAGINATION
+          && candidate.anyHasSessionMetadata
+          && candidate.sampleSessionField != null
+          && candidate.anyHasTags
+          && candidate.anyHasEnvironments) {
+        break;
+      }
+    }
+
+    if (best == null) {
+      throw new NoTestDataException(
+          "SearchAppVulnerabilitiesToolIT failed to sample any vulnerability-bearing application"
+              + " — see INTEGRATION_TESTS.md");
+    }
+    return best;
   }
+
+  private static void bucketByApp(
+      VulnLight v, Map<String, Long> counts, Map<String, String> names, Set<String> taggedAppIds) {
+    if (v.appID() == null || v.appID().isBlank()) {
+      return;
+    }
+    counts.merge(v.appID(), 1L, Long::sum);
+    names.putIfAbsent(v.appID(), v.appName());
+    if (v.tags() != null && !v.tags().isEmpty()) {
+      taggedAppIds.add(v.appID());
+    }
+  }
+
+  /**
+   * Samples the first VULN_SAMPLE_PAGE_SIZE vulns from {@code appId} (across all statuses) and
+   * captures the sample fields used by downstream tests. Returns {@code null} if the app has no
+   * vulns.
+   */
+  private TestData sampleApp(String appId, String appName) {
+    var vulns =
+        searchAppVulnerabilitiesTool.searchAppVulnerabilities(
+            appId,
+            1,
+            VULN_SAMPLE_PAGE_SIZE,
+            null,
+            ALL_STATUSES,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+    if (!vulns.isSuccess() || vulns.items().isEmpty()) {
+      return null;
+    }
+
+    var data = new TestData();
+    data.sampleAppId = appId;
+    data.sampleAppName = appName;
+    data.totalVulnerabilities =
+        vulns.totalItems() != null ? vulns.totalItems() : vulns.items().size();
+
+    for (var v : vulns.items()) {
+      if (data.sampleVulnId == null && v.vulnID() != null && !v.vulnID().isBlank()) {
+        data.sampleVulnId = v.vulnID();
+        data.sampleVulnType = v.type();
+        data.sampleSeverity = v.severity();
+        data.sampleStatus = v.status();
+      }
+      if (data.sampleEnvironment == null
+          && v.environments() != null
+          && !v.environments().isEmpty()) {
+        data.sampleEnvironment = v.environments().get(0);
+      }
+      if (data.sampleTag == null && v.tags() != null) {
+        for (var tag : v.tags()) {
+          if (tag != null && !tag.isBlank()) {
+            data.sampleTag = tag;
+            break;
+          }
+        }
+      }
+      if (v.environments() != null && !v.environments().isEmpty()) {
+        data.anyHasEnvironments = true;
+      }
+      if (v.tags() != null && !v.tags().isEmpty()) {
+        data.anyHasTags = true;
+      }
+      if (v.sessionMetadata() != null && !v.sessionMetadata().isEmpty()) {
+        data.anyHasSessionMetadata = true;
+        if (data.sampleSessionField == null) {
+          captureSessionSample(v, data);
+        }
+      }
+    }
+    return data;
+  }
+
+  private void captureSessionSample(VulnLight vuln, TestData data) {
+    for (var session : vuln.sessionMetadata()) {
+      if (session.getMetadata() == null) {
+        continue;
+      }
+      for (var item : session.getMetadata()) {
+        if (item != null
+            && item.getDisplayLabel() != null
+            && !item.getDisplayLabel().isBlank()
+            && item.getValue() != null
+            && !item.getValue().isBlank()) {
+          data.sampleSessionField = item.getDisplayLabel();
+          data.sampleSessionValue = item.getValue();
+          return;
+        }
+      }
+    }
+  }
+
+  /**
+   * Scores a candidate app on test-coverage richness. Heavy weights favor seed data that is rare
+   * org-wide (session metadata, tags), so the chosen app maximizes deterministic coverage across
+   * the test suite.
+   */
+  private int scoreCandidate(TestData candidate) {
+    int score = candidate.totalVulnerabilities;
+    if (candidate.anyHasSessionMetadata) {
+      score += 1000;
+    }
+    if (candidate.sampleSessionField != null) {
+      score += 1000;
+    }
+    if (candidate.anyHasTags) {
+      score += 500;
+    }
+    if (candidate.anyHasEnvironments) {
+      score += 100;
+    }
+    return score;
+  }
+
+  // ---------- Discovery precondition ----------
+
+  @Test
+  void testDiscoveredTestDataExists() {
+    assertThat(testData).as("discovery must populate test data").isNotNull();
+    assertThat(testData.sampleAppId)
+        .as("discovery must resolve a vulnerability-bearing application — see INTEGRATION_TESTS.md")
+        .isNotBlank();
+    assertThat(testData.totalVulnerabilities)
+        .as("discovered application must carry at least one vulnerability")
+        .isPositive();
+    assertThat(testData.sampleVulnId).as("sample vulnID must be non-blank").isNotBlank();
+    assertThat(testData.sampleVulnType).as("sample vuln type must be non-blank").isNotBlank();
+    assertThat(testData.sampleSeverity).as("sample severity must be non-blank").isNotBlank();
+    assertThat(testData.sampleStatus).as("sample status must be non-blank").isNotBlank();
+  }
+
+  // ---------- Validation errors ----------
 
   @Test
   void searchAppVulnerabilities_should_return_validation_error_for_missing_appId() {
@@ -116,214 +404,659 @@ public class SearchAppVulnerabilitiesToolIT
         searchAppVulnerabilitiesTool.searchAppVulnerabilities(
             null, 1, 10, null, null, null, null, null, null, null, null, null);
 
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("appId") && e.contains("required"));
+    assertThat(result.isSuccess()).as("null appId must fail validation").isFalse();
+    assertThat(result.items()).as("validation failure must carry no items").isEmpty();
+    assertThat(result.errors())
+        .as("validation error must state appId is required")
+        .containsExactly("appId is required");
+    assertThat(result.errors())
+        .as("validation error must not surface as a Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
   }
+
+  @Test
+  void searchAppVulnerabilities_should_return_validation_error_for_blank_appId() {
+    var result =
+        searchAppVulnerabilitiesTool.searchAppVulnerabilities(
+            "   ", 1, 10, null, null, null, null, null, null, null, null, null);
+
+    assertThat(result.isSuccess()).as("whitespace-only appId must fail validation").isFalse();
+    assertThat(result.errors())
+        .as("validation error must state appId is required")
+        .containsExactly("appId is required");
+  }
+
+  // ---------- Response shape ----------
 
   @Test
   void searchAppVulnerabilities_should_return_valid_response() {
-    // First get an app ID
-    var appsResponse = searchApplicationsTool.searchApplications(1, 1, null, null, null);
-
-    if (!appsResponse.isSuccess() || appsResponse.items().isEmpty()) {
-      log.warn("No applications found in org - skipping test");
-      return;
-    }
-
-    var appId = appsResponse.items().get(0).appID();
-
     var response =
         searchAppVulnerabilitiesTool.searchAppVulnerabilities(
-            appId, 1, 10, null, null, null, null, null, null, null, null, null);
+            testData.sampleAppId, 1, 10, null, null, null, null, null, null, null, null, null);
 
-    assertThat(response).isNotNull();
-    assertThat(response.isSuccess()).isTrue();
-    assertThat(response.page()).isEqualTo(1);
-    assertThat(response.pageSize()).isEqualTo(10);
-    assertThat(response.items()).isNotNull();
-
-    log.info("Found {} vulnerabilities in app {}", response.items().size(), appId);
+    assertThat(response).as("response must never be null").isNotNull();
+    assertThat(response.isSuccess()).as("baseline query must succeed").isTrue();
+    assertThat(response.errors()).as("baseline query must have no errors").isEmpty();
+    assertThat(response.items()).as("items list must never be null").isNotNull();
+    assertThat(response.page()).as("page echoed").isEqualTo(1);
+    assertThat(response.pageSize()).as("pageSize echoed").isEqualTo(10);
+    if (response.items().size() < response.pageSize()) {
+      assertThat(response.hasMorePages())
+          .as("partial page must report hasMorePages=false")
+          .isFalse();
+    }
   }
 
   @Test
-  void searchAppVulnerabilities_should_populate_session_metadata() {
-    var appsResponse = searchApplicationsTool.searchApplications(1, 1, null, null, null);
-
-    if (!appsResponse.isSuccess() || appsResponse.items().isEmpty()) {
-      log.warn("No applications found in org - skipping test");
-      return;
-    }
-
-    var appId = appsResponse.items().get(0).appID();
-    var appName = appsResponse.items().get(0).name();
-
-    log.info("Calling search_app_vulnerabilities() for app: {} (ID: {})", appName, appId);
-
+  void searchAppVulnerabilities_should_scope_results_to_requested_app() {
+    // Every returned vuln must report the requested appId — otherwise the app-scoping was
+    // silently dropped and we leaked vulns from other applications.
     var response =
         searchAppVulnerabilitiesTool.searchAppVulnerabilities(
-            appId, 1, 50, null, null, null, null, null, null, null, null, null);
+            testData.sampleAppId,
+            1,
+            VULN_SAMPLE_PAGE_SIZE,
+            null,
+            ALL_STATUSES,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
 
-    assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.isSuccess()).isTrue();
-    assertThat(response.items()).as("Vulnerabilities list should not be null").isNotNull();
+    assertThat(response.isSuccess()).as("scoped query must succeed").isTrue();
+    assertThat(response.items())
+        .as("scoped query for seeded app must return at least one vulnerability")
+        .isNotEmpty();
+    assertThat(response.items())
+        .as("every returned vuln must report appID='%s'", testData.sampleAppId)
+        .allSatisfy(
+            v ->
+                assertThat(v.appID())
+                    .as("%s.appID vs filter", v.vulnID())
+                    .isEqualTo(testData.sampleAppId));
+  }
 
-    log.info("Retrieved {} vulnerability(ies)", response.items().size());
+  // ---------- Field population ----------
 
-    if (response.items().isEmpty()) {
-      log.info("No vulnerabilities for this app (this is OK for the test)");
-      return;
-    }
+  @Test
+  void searchAppVulnerabilities_should_populate_basic_fields() {
+    var response =
+        searchAppVulnerabilitiesTool.searchAppVulnerabilities(
+            testData.sampleAppId,
+            1,
+            VULN_SAMPLE_PAGE_SIZE,
+            null,
+            ALL_STATUSES,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
 
-    // Verify session metadata is populated
-    int withSessionMetadata = 0;
-    for (var vuln : response.items()) {
-      assertThat(vuln.sessionMetadata()).as("Session metadata should never be null").isNotNull();
+    assertThat(response.isSuccess()).as("baseline query must succeed").isTrue();
+    assertThat(response.items())
+        .as("requires seeded vulnerabilities for the discovered app — see INTEGRATION_TESTS.md")
+        .isNotEmpty();
 
-      if (!vuln.sessionMetadata().isEmpty()) {
-        withSessionMetadata++;
-        log.info("Vuln {} has {} session(s)", vuln.vulnID(), vuln.sessionMetadata().size());
-      }
-    }
-
-    log.info(
-        "Vulnerabilities with session metadata: {}/{}",
-        withSessionMetadata,
-        response.items().size());
-    log.info("search_app_vulnerabilities() returns vulnerabilities with session metadata");
+    assertThat(response.items())
+        .as("every vulnerability must populate core identification fields")
+        .allSatisfy(
+            v -> {
+              assertThat(v.vulnID()).as("vulnID").isNotBlank();
+              assertThat(v.title()).as("%s.title", v.vulnID()).isNotBlank();
+              assertThat(v.type()).as("%s.type", v.vulnID()).isNotBlank();
+              assertThat(v.severity()).as("%s.severity", v.vulnID()).isNotBlank();
+              assertThat(v.status()).as("%s.status", v.vulnID()).isNotBlank();
+              assertThat(v.appID()).as("%s.appID", v.vulnID()).isNotBlank();
+              // Mapper contract: collections never null.
+              assertThat(v.environments()).as("%s.environments", v.vulnID()).isNotNull();
+              assertThat(v.tags()).as("%s.tags", v.vulnID()).isNotNull();
+              assertThat(v.sessionMetadata()).as("%s.sessionMetadata", v.vulnID()).isNotNull();
+            });
   }
 
   @Test
-  void searchAppVulnerabilities_should_support_useLatestSession() {
-    var appsResponse = searchApplicationsTool.searchApplications(1, 1, null, null, null);
-
-    if (!appsResponse.isSuccess() || appsResponse.items().isEmpty()) {
-      log.warn("No applications found in org - skipping test");
-      return;
-    }
-
-    var appId = appsResponse.items().get(0).appID();
-    var appName = appsResponse.items().get(0).name();
-
-    log.info(
-        "Calling search_app_vulnerabilities(useLatestSession=true) for app: {} (ID: {})",
-        appName,
-        appId);
+  void searchAppVulnerabilities_should_populate_session_metadata_when_seeded() {
+    // SESSION_METADATA expand attaches per-vuln session info. Per the test's "populate" claim, we
+    // require at least one returned vuln to carry a non-empty session-metadata list — otherwise
+    // the expand has regressed to returning empty payloads.
+    assertThat(testData.anyHasSessionMetadata)
+        .as(
+            "populate test requires at least one vuln with non-empty sessionMetadata in app '%s'"
+                + " — see INTEGRATION_TESTS.md",
+            testData.sampleAppId)
+        .isTrue();
 
     var response =
         searchAppVulnerabilitiesTool.searchAppVulnerabilities(
-            appId, 1, 50, null, null, null, null, null, null, null, null, true);
+            testData.sampleAppId,
+            1,
+            VULN_SAMPLE_PAGE_SIZE,
+            null,
+            ALL_STATUSES,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
 
-    assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.isSuccess()).isTrue();
-    assertThat(response.items()).as("Vulnerabilities list should not be null").isNotNull();
-
-    log.info("Retrieved {} vulnerability(ies) for latest session", response.items().size());
-
-    if (response.items().isEmpty()) {
-      // Check if warning about no sessions
-      if (response.warnings().stream().anyMatch(w -> w.contains("No sessions found"))) {
-        log.info("No sessions found for this app - returning all vulns (this is OK)");
-      } else {
-        log.info("No vulnerabilities in latest session (this is valid)");
-      }
-      return;
-    }
-
-    // Verify session metadata is populated in results
-    int withSessionMetadata = 0;
-    for (var vuln : response.items()) {
-      assertThat(vuln.sessionMetadata()).as("Session metadata should never be null").isNotNull();
-
-      if (!vuln.sessionMetadata().isEmpty()) {
-        withSessionMetadata++;
-        var sessionId = vuln.sessionMetadata().get(0).getSessionId();
-        log.info("Vuln {} has session ID: {}", vuln.vulnID(), sessionId);
-      }
-    }
-
-    log.info("Vulnerabilities returned: {}", response.items().size());
-    log.info(
-        "Vulnerabilities with session metadata: {}/{}",
-        withSessionMetadata,
-        response.items().size());
-    log.info("search_app_vulnerabilities(useLatestSession=true) works correctly");
+    assertThat(response.isSuccess()).as("baseline query must succeed").isTrue();
+    assertThat(response.items())
+        .as("requires seeded vulnerabilities for the discovered app")
+        .isNotEmpty();
+    assertThat(response.items())
+        .as("every vuln must expose a non-null sessionMetadata collection (mapper contract)")
+        .allSatisfy(
+            v -> assertThat(v.sessionMetadata()).as("%s.sessionMetadata", v.vulnID()).isNotNull());
+    assertThat(response.items())
+        .as(
+            "at least one vuln must populate sessionMetadata — proves SESSION_METADATA expand "
+                + "decodes end-to-end")
+        .anyMatch(v -> !v.sessionMetadata().isEmpty());
   }
+
+  // ---------- useLatestSession ----------
+
+  @Test
+  void searchAppVulnerabilities_should_narrow_to_single_session_when_useLatestSession_true() {
+    // Precondition: requires an app where at least one vuln carries session metadata. Without this,
+    // useLatestSession=true would fall through to the documented no-sessions fallback and the
+    // narrowing claim made by this test could not be verified.
+    assertThat(testData.anyHasSessionMetadata)
+        .as(
+            "useLatestSession test requires app '%s' to carry session metadata —"
+                + " see INTEGRATION_TESTS.md",
+            testData.sampleAppId)
+        .isTrue();
+
+    var latest =
+        searchAppVulnerabilitiesTool.searchAppVulnerabilities(
+            testData.sampleAppId,
+            1,
+            VULN_SAMPLE_PAGE_SIZE,
+            null,
+            ALL_STATUSES,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            true);
+
+    assertThat(latest.isSuccess()).as("useLatestSession=true must succeed").isTrue();
+    assertThat(latest.errors()).as("useLatestSession=true must not surface errors").isEmpty();
+    assertThat(latest.warnings())
+        .as(
+            "app '%s' has session metadata, so the no-sessions fallback warning must not fire",
+            testData.sampleAppId)
+        .noneMatch(w -> w.contains(NO_SESSIONS_WARNING));
+
+    // Every returned vuln must carry sessionMetadata — the parameter scopes the result set to
+    // a single session, so missing sessionMetadata on any item indicates the param was silently
+    // dropped or the SESSION_METADATA expand has regressed.
+    assertThat(latest.items())
+        .as(
+            "every useLatestSession=true result must expose at least one sessionMetadata entry"
+                + " (param scopes the query to a session, so missing metadata means the param"
+                + " was dropped)")
+        .allSatisfy(
+            v ->
+                assertThat(v.sessionMetadata())
+                    .as("%s.sessionMetadata", v.vulnID())
+                    .isNotNull()
+                    .isNotEmpty());
+
+    // Strongest narrowing proof: every result must reference exactly the same session_id. A
+    // regression that silently dropped the agent_session_id filter would mix vulns from multiple
+    // historical sessions, surfacing here as more than one distinct session_id.
+    var distinctSessionIds =
+        latest.items().stream()
+            .flatMap(v -> v.sessionMetadata().stream())
+            .map(SessionMetadata::getSessionId)
+            .filter(id -> id != null && !id.isBlank())
+            .distinct()
+            .toList();
+    assertThat(distinctSessionIds)
+        .as(
+            "useLatestSession=true must constrain results to a single session_id; multiple"
+                + " ids indicate the session filter was dropped")
+        .hasSizeLessThanOrEqualTo(1);
+  }
+
+  // ---------- Severity filter ----------
 
   @Test
   void searchAppVulnerabilities_should_filter_by_severity() {
-    var appsResponse = searchApplicationsTool.searchApplications(1, 1, null, null, null);
-
-    if (!appsResponse.isSuccess() || appsResponse.items().isEmpty()) {
-      log.warn("No applications found in org - skipping test");
-      return;
-    }
-
-    var appId = appsResponse.items().get(0).appID();
-
     var response =
         searchAppVulnerabilitiesTool.searchAppVulnerabilities(
-            appId, 1, 10, "CRITICAL,HIGH", null, null, null, null, null, null, null, null);
+            testData.sampleAppId,
+            1,
+            VULN_SAMPLE_PAGE_SIZE,
+            "CRITICAL,HIGH",
+            ALL_STATUSES,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
 
-    assertThat(response.isSuccess()).isTrue();
+    assertThat(response.isSuccess()).as("severity-filtered query must succeed").isTrue();
+    assertThat(response.errors()).as("severity filter must not produce errors").isEmpty();
 
-    // If we have results, verify they match filter
-    if (!response.items().isEmpty()) {
-      assertThat(response.items())
-          .allMatch(
-              v ->
-                  "Critical".equalsIgnoreCase(v.severity())
-                      || "High".equalsIgnoreCase(v.severity()));
-      log.info("All {} results match severity filter CRITICAL,HIGH", response.items().size());
-    }
+    // Every returned vuln must carry one of the requested severities (case-insensitive — the API
+    // returns "Critical"/"High" labels, we sent "CRITICAL,HIGH"). A regression that silently
+    // dropped the filter would surface as a Medium/Low/Note row in the result set. The result set
+    // may legitimately be empty if the seeded app has no Critical/High vulns; the proof that the
+    // filter was honored is the universal-quantifier check below.
+    assertThat(response.items())
+        .as("every result must carry severity in {CRITICAL, HIGH}")
+        .allSatisfy(
+            v ->
+                assertThat(v.severity())
+                    .as("%s.severity", v.vulnID())
+                    .isNotBlank()
+                    .satisfies(
+                        s ->
+                            assertThat(CRITICAL_HIGH_LABELS)
+                                .as("%s.severity '%s' must match filter", v.vulnID(), s)
+                                .contains(s.toLowerCase(Locale.ROOT))));
+  }
+
+  // ---------- Status filter ----------
+
+  @Test
+  void searchAppVulnerabilities_should_filter_by_status() {
+    // Single-status positive probe. We send "Reported" (canonical fresh-open status) and assert
+    // every returned row carries it case-insensitively.
+    var response =
+        searchAppVulnerabilitiesTool.searchAppVulnerabilities(
+            testData.sampleAppId,
+            1,
+            VULN_SAMPLE_PAGE_SIZE,
+            null,
+            "Reported",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    assertThat(response.isSuccess()).as("status-filtered query must succeed").isTrue();
+    assertThat(response.errors()).as("status filter must not produce errors").isEmpty();
+    assertThat(response.items())
+        .as("every result must carry status='Reported' (case-insensitive)")
+        .allSatisfy(
+            v ->
+                assertThat(v.status())
+                    .as("%s.status", v.vulnID())
+                    .isNotBlank()
+                    .isEqualToIgnoringCase("Reported"));
   }
 
   @Test
-  void searchAppVulnerabilities_should_handle_pagination() {
-    var appsResponse = searchApplicationsTool.searchApplications(1, 1, null, null, null);
-
-    if (!appsResponse.isSuccess() || appsResponse.items().isEmpty()) {
-      log.warn("No applications found in org - skipping test");
-      return;
-    }
-
-    var appId = appsResponse.items().get(0).appID();
-
-    // First page
-    var page1 =
+  void searchAppVulnerabilities_should_apply_default_status_filter() {
+    // When no statuses param is supplied, SearchAppVulnerabilitiesParams substitutes the default
+    // (Reported, Suspicious, Confirmed) and emits a warning. This test verifies BOTH halves of
+    // that contract: the warning fires AND the filter actually narrows the result set — every
+    // returned vuln must have a non-terminal status.
+    var response =
         searchAppVulnerabilitiesTool.searchAppVulnerabilities(
-            appId, 1, 5, null, null, null, null, null, null, null, null, null);
+            testData.sampleAppId,
+            1,
+            VULN_SAMPLE_PAGE_SIZE,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
 
-    assertThat(page1.isSuccess()).isTrue();
+    assertThat(response.isSuccess()).as("default-filter query must succeed").isTrue();
+    assertThat(response.errors()).as("default-filter query must not produce errors").isEmpty();
+    assertThat(response.warnings())
+        .as("must surface the default-status warning identifying which statuses were excluded")
+        .anyMatch(w -> w.contains("excluding Fixed and Remediated"));
 
-    // If there are more pages, fetch page 2
-    if (page1.hasMorePages()) {
-      var page2 =
-          searchAppVulnerabilitiesTool.searchAppVulnerabilities(
-              appId, 2, 5, null, null, null, null, null, null, null, null, null);
-
-      assertThat(page2.isSuccess()).isTrue();
-      assertThat(page2.page()).isEqualTo(2);
-      log.info(
-          "Pagination works: page 1 has {}, page 2 has {} items",
-          page1.items().size(),
-          page2.items().size());
-    }
+    // Universal-quantifier check: any returned row must NOT have a terminal status. Vacuously
+    // true on empty (when the seeded app has only Fixed/Remediated vulns), but the warning
+    // assertion above already proves the filter was applied. A regression that forwarded the
+    // wrong status set server-side would surface here as a Fixed/Remediated row leaking through.
+    assertThat(response.items())
+        .as(
+            "default-status filter must exclude terminal statuses (Fixed, Remediated, "
+                + "AutoRemediated, NotAProblem); a row with one of those proves the filter "
+                + "wasn't forwarded server-side")
+        .allSatisfy(
+            v ->
+                assertThat(v.status())
+                    .as("%s.status", v.vulnID())
+                    .isNotBlank()
+                    .satisfies(
+                        s ->
+                            assertThat(DEFAULT_STATUS_FILTER_EXCLUDES)
+                                .as("%s.status '%s' must not be in excluded set", v.vulnID(), s)
+                                .doesNotContain(s.toLowerCase(Locale.ROOT))));
   }
+
+  // ---------- vulnTypes filter ----------
+
+  @Test
+  void searchAppVulnerabilities_should_filter_by_vulnTypes() {
+    assertThat(testData.sampleVulnType)
+        .as(
+            "vulnTypes filter test requires at least one vuln with a non-blank type in app '%s'"
+                + " — see INTEGRATION_TESTS.md",
+            testData.sampleAppId)
+        .isNotBlank();
+
+    var response =
+        searchAppVulnerabilitiesTool.searchAppVulnerabilities(
+            testData.sampleAppId,
+            1,
+            VULN_SAMPLE_PAGE_SIZE,
+            null,
+            ALL_STATUSES,
+            testData.sampleVulnType,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    assertThat(response.isSuccess())
+        .as("vulnTypes filter for '%s' must succeed", testData.sampleVulnType)
+        .isTrue();
+    assertThat(response.errors()).as("vulnTypes filter must not produce errors").isEmpty();
+    assertThat(response.items())
+        .as(
+            "vulnTypes filter '%s' must return at least the seed vuln in app '%s'",
+            testData.sampleVulnType, testData.sampleAppId)
+        .isNotEmpty();
+    assertThat(response.items())
+        .as(
+            "every result must carry type='%s' — a different type proves the filter was dropped",
+            testData.sampleVulnType)
+        .allSatisfy(
+            v -> assertThat(v.type()).as("%s.type", v.vulnID()).isEqualTo(testData.sampleVulnType));
+  }
+
+  // ---------- environments filter ----------
+
+  @Test
+  void searchAppVulnerabilities_should_filter_by_environment() {
+    // Precondition: app must have at least one vuln with a non-empty environments list, so the
+    // discovered sample environment is filterable. Without seeded environment data the API would
+    // return zero rows even on a healthy filter, which would be indistinguishable from a dropped
+    // filter.
+    assertThat(testData.anyHasEnvironments)
+        .as(
+            "environment filter test requires at least one vuln with non-empty environments in"
+                + " app '%s' — see INTEGRATION_TESTS.md",
+            testData.sampleAppId)
+        .isTrue();
+    assertThat(testData.sampleEnvironment).as("sample environment must be non-blank").isNotBlank();
+
+    var response =
+        searchAppVulnerabilitiesTool.searchAppVulnerabilities(
+            testData.sampleAppId,
+            1,
+            VULN_SAMPLE_PAGE_SIZE,
+            null,
+            ALL_STATUSES,
+            null,
+            testData.sampleEnvironment,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    assertThat(response.isSuccess())
+        .as("environment filter for '%s' must succeed", testData.sampleEnvironment)
+        .isTrue();
+    assertThat(response.errors()).as("environment filter must not produce errors").isEmpty();
+    assertThat(response.items())
+        .as(
+            "environment filter '%s' must return at least one vulnerability in app '%s'",
+            testData.sampleEnvironment, testData.sampleAppId)
+        .isNotEmpty();
+    assertThat(response.items())
+        .as(
+            "every result must list environment '%s' — a result without it proves the server-side"
+                + " filter was dropped",
+            testData.sampleEnvironment)
+        .allSatisfy(
+            v ->
+                assertThat(v.environments())
+                    .as("%s.environments", v.vulnID())
+                    .isNotNull()
+                    .contains(testData.sampleEnvironment));
+  }
+
+  // ---------- Date filters ----------
+
+  @Test
+  void searchAppVulnerabilities_should_filter_lastSeenAfter_far_future_returns_no_results() {
+    // The tightest proof that the filter is forwarded: a far-future cutoff cannot possibly match
+    // any past activity. A non-empty result would mean the filter was dropped.
+    var farFuture = LocalDate.now().plusYears(50).format(DATE_FMT);
+
+    var response =
+        searchAppVulnerabilitiesTool.searchAppVulnerabilities(
+            testData.sampleAppId,
+            1,
+            VULN_SAMPLE_PAGE_SIZE,
+            null,
+            ALL_STATUSES,
+            null,
+            null,
+            farFuture,
+            null,
+            null,
+            null,
+            null);
+
+    assertThat(response.isSuccess()).as("far-future lastSeenAfter must succeed").isTrue();
+    assertThat(response.errors()).as("far-future lastSeenAfter must not error").isEmpty();
+    assertThat(response.warnings())
+        .as("date filter must surface the lastTimeSeen advisory")
+        .anyMatch(w -> w.contains("LAST ACTIVITY DATE") || w.contains("lastTimeSeen"));
+    assertThat(response.items())
+        .as("lastSeenAfter=%s (50y in future) must return zero results", farFuture)
+        .isEmpty();
+  }
+
+  @Test
+  void searchAppVulnerabilities_should_filter_lastSeenBefore_far_past_returns_no_results() {
+    // Symmetric proof for lastSeenBefore: a far-past cutoff can match nothing.
+    var farPast = LocalDate.now().minusYears(50).format(DATE_FMT);
+
+    var response =
+        searchAppVulnerabilitiesTool.searchAppVulnerabilities(
+            testData.sampleAppId,
+            1,
+            VULN_SAMPLE_PAGE_SIZE,
+            null,
+            ALL_STATUSES,
+            null,
+            null,
+            null,
+            farPast,
+            null,
+            null,
+            null);
+
+    assertThat(response.isSuccess()).as("far-past lastSeenBefore must succeed").isTrue();
+    assertThat(response.errors()).as("far-past lastSeenBefore must not error").isEmpty();
+    assertThat(response.items())
+        .as("lastSeenBefore=%s (50y in past) must return zero results", farPast)
+        .isEmpty();
+  }
+
+  @Test
+  void searchAppVulnerabilities_should_reject_inverted_date_range() {
+    // lastSeenAfter must be strictly before lastSeenBefore. An inverted range must surface as an
+    // actionable validation error naming both parameters — not as a Contrast API error.
+    var after = LocalDate.now().format(DATE_FMT);
+    var before = LocalDate.now().minusYears(1).format(DATE_FMT);
+
+    var response =
+        searchAppVulnerabilitiesTool.searchAppVulnerabilities(
+            testData.sampleAppId, 1, 10, null, null, null, null, after, before, null, null, null);
+
+    assertThat(response.isSuccess()).as("inverted date range must fail validation").isFalse();
+    assertThat(response.items()).as("validation failure must carry no items").isEmpty();
+    assertThat(response.errors())
+        .as("error must name both date params and describe the ordering rule")
+        .isNotEmpty()
+        .anyMatch(
+            e ->
+                e.contains("lastSeenAfter")
+                    && e.contains("lastSeenBefore")
+                    && e.contains("must be before"));
+    assertThat(response.errors())
+        .as("validation error must not surface as a Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
+  }
+
+  // ---------- Tag filter ----------
+
+  @Test
+  void searchAppVulnerabilities_should_filter_by_vulnTag() {
+    assertThat(testData.sampleTag)
+        .as(
+            "vulnTags filter test requires at least one vuln with a non-blank tag in app '%s' —"
+                + " see INTEGRATION_TESTS.md",
+            testData.sampleAppId)
+        .isNotBlank();
+
+    var response =
+        searchAppVulnerabilitiesTool.searchAppVulnerabilities(
+            testData.sampleAppId,
+            1,
+            VULN_SAMPLE_PAGE_SIZE,
+            null,
+            ALL_STATUSES,
+            null,
+            null,
+            null,
+            null,
+            testData.sampleTag,
+            null,
+            null);
+
+    assertThat(response.isSuccess())
+        .as("tag filter for '%s' must succeed", testData.sampleTag)
+        .isTrue();
+    assertThat(response.errors()).as("tag filter must not produce errors").isEmpty();
+    assertThat(response.items())
+        .as(
+            "tag filter '%s' must return at least one vulnerability in app '%s'",
+            testData.sampleTag, testData.sampleAppId)
+        .isNotEmpty();
+    assertThat(response.items())
+        .as(
+            "every returned vuln must carry tag '%s' (case-insensitive) — a vuln without that"
+                + " tag proves the filter was dropped",
+            testData.sampleTag)
+        .allSatisfy(
+            v ->
+                assertThat(v.tags())
+                    .as("%s.tags vs filter", v.vulnID())
+                    .isNotNull()
+                    .anyMatch(t -> t != null && t.equalsIgnoreCase(testData.sampleTag)));
+  }
+
+  // ---------- sessionMetadataFilters (positive valid path) ----------
+
+  @Test
+  void searchAppVulnerabilities_should_filter_by_valid_sessionMetadataFilters() {
+    // Positive-path proof that sessionMetadataFilters JSON is accepted, parsed, resolved to a
+    // numeric field id, and forwarded server-side as a TraceMetadataFilter. We use a discovered
+    // (field, value) pair so we know at least one trace matches; the count is therefore expected
+    // to be >= 1 and strictly <= the unfiltered count for the same app.
+    assertThat(testData.sampleSessionField)
+        .as(
+            "valid-sessionMetadataFilters test requires a discovered session metadata "
+                + "field/value pair on app '%s' — see INTEGRATION_TESTS.md",
+            testData.sampleAppId)
+        .isNotBlank();
+    assertThat(testData.sampleSessionValue)
+        .as("sample session value must be non-blank")
+        .isNotBlank();
+
+    var unfiltered =
+        searchAppVulnerabilitiesTool.searchAppVulnerabilities(
+            testData.sampleAppId,
+            1,
+            VULN_SAMPLE_PAGE_SIZE,
+            null,
+            ALL_STATUSES,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+    assertThat(unfiltered.isSuccess()).as("unfiltered baseline must succeed").isTrue();
+
+    var json =
+        String.format(
+            "{\"%s\":\"%s\"}",
+            testData.sampleSessionField.replace("\"", "\\\""),
+            testData.sampleSessionValue.replace("\"", "\\\""));
+    var filtered =
+        searchAppVulnerabilitiesTool.searchAppVulnerabilities(
+            testData.sampleAppId,
+            1,
+            VULN_SAMPLE_PAGE_SIZE,
+            null,
+            ALL_STATUSES,
+            null,
+            null,
+            null,
+            null,
+            null,
+            json,
+            null);
+
+    assertThat(filtered.isSuccess())
+        .as("valid sessionMetadataFilters %s must succeed (errors=%s)", json, filtered.errors())
+        .isTrue();
+    assertThat(filtered.errors())
+        .as("valid sessionMetadataFilters must not produce errors")
+        .isEmpty();
+    assertThat(filtered.items().size())
+        .as(
+            "filtered count must not exceed unfiltered count — proves the filter was forwarded "
+                + "server-side and narrowed (or held steady), never broadened")
+        .isLessThanOrEqualTo(unfiltered.items().size());
+  }
+
+  // ---------- sessionMetadataFilters (validation paths) ----------
 
   @Test
   void searchAppVulnerabilities_should_reject_invalid_sessionMetadataFilters_json() {
-    var appsResponse = searchApplicationsTool.searchApplications(1, 1, null, null, null);
-
-    if (!appsResponse.isSuccess() || appsResponse.items().isEmpty()) {
-      log.warn("No applications found in org - skipping test");
-      return;
-    }
-
-    var appId = appsResponse.items().get(0).appID();
-
     var response =
         searchAppVulnerabilitiesTool.searchAppVulnerabilities(
-            appId,
+            testData.sampleAppId,
             1,
             10,
             null,
@@ -333,29 +1066,36 @@ public class SearchAppVulnerabilitiesToolIT
             null,
             null,
             null,
-            "not valid json", // invalid JSON
+            "not valid json",
             null);
 
-    assertThat(response.isSuccess()).isFalse();
-    assertThat(response.errors()).anyMatch(e -> e.contains("Invalid JSON"));
-    log.info("Validation correctly rejects invalid JSON for sessionMetadataFilters");
+    assertThat(response.isSuccess())
+        .as("malformed JSON for sessionMetadataFilters must fail validation")
+        .isFalse();
+    assertThat(response.items()).as("validation failure must carry no items").isEmpty();
+    // Assert full error shape — both the canonical "Invalid JSON for <param>" prefix and the
+    // expected-format guidance shipped with the validation message. A bare "JSON" substring
+    // would coincidentally match unrelated error text.
+    assertThat(response.errors())
+        .as("error must name the param and explain the expected format")
+        .anyMatch(
+            e ->
+                e.contains("Invalid JSON for sessionMetadataFilters")
+                    && e.contains("Expected format"));
+    assertThat(response.errors())
+        .as("validation error must not surface as a Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
   }
 
   @Test
-  void searchAppVulnerabilities_should_return_error_for_invalid_sessionMetadataFilters_field() {
-    var appsResponse = searchApplicationsTool.searchApplications(1, 1, null, null, null);
-
-    if (!appsResponse.isSuccess() || appsResponse.items().isEmpty()) {
-      log.warn("No applications found in org - skipping test");
-      return;
-    }
-
-    var appId = appsResponse.items().get(0).appID();
-
-    // Use a field name that definitely doesn't exist
+  void searchAppVulnerabilities_should_reject_unknown_sessionMetadataFilters_field() {
+    // Use a field name that definitely does not exist on the seeded app. The tool must reject
+    // it server-side-resolved-name-not-found with the canonical "field(s) not found" error,
+    // which echoes the offending field name and points the user at get_session_metadata.
+    var unknownField = "nonexistent_field_xyz_12345";
     var response =
         searchAppVulnerabilitiesTool.searchAppVulnerabilities(
-            appId,
+            testData.sampleAppId,
             1,
             10,
             null,
@@ -365,14 +1105,141 @@ public class SearchAppVulnerabilitiesToolIT
             null,
             null,
             null,
-            "{\"nonexistent_field_xyz_12345\":\"value\"}", // field name that doesn't exist
+            String.format("{\"%s\":\"value\"}", unknownField),
             null);
 
-    // Should return an error, not a 400 Bad Request
-    assertThat(response.isSuccess()).isFalse();
-    assertThat(response.errors()).anyMatch(e -> e.contains("not found") || e.contains("Invalid"));
+    assertThat(response.isSuccess())
+        .as("unknown sessionMetadataFilters field must surface as failure")
+        .isFalse();
+    assertThat(response.items()).as("error response must carry no items").isEmpty();
+    assertThat(response.errors())
+        .as(
+            "error must include the canonical not-found phrase, echo the offending field name "
+                + "'%s', and point at get_session_metadata for discovery",
+            unknownField)
+        .anyMatch(
+            e ->
+                e.contains("Session metadata field(s) not found")
+                    && e.contains(unknownField)
+                    && e.contains("get_session_metadata"));
+    assertThat(response.errors())
+        .as("error must not surface as a Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
+  }
 
-    log.info(
-        "Correctly returns error for invalid sessionMetadataFilters field: {}", response.errors());
+  @Test
+  void searchAppVulnerabilities_should_reject_useLatestSession_with_sessionMetadataFilters() {
+    // Mutually-exclusive combo: useLatestSession=true and sessionMetadataFilters define the same
+    // axis (which session to filter by) and must not be combined. The validation layer rejects
+    // it with a message naming both params.
+    var response =
+        searchAppVulnerabilitiesTool.searchAppVulnerabilities(
+            testData.sampleAppId,
+            1,
+            10,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "{\"branch\":\"main\"}",
+            true);
+
+    assertThat(response.isSuccess()).as("mutually-exclusive combo must fail validation").isFalse();
+    assertThat(response.items()).as("validation failure must carry no items").isEmpty();
+    assertThat(response.errors())
+        .as("error must name both params and describe the mutual-exclusivity rule")
+        .anyMatch(
+            e ->
+                e.contains("useLatestSession")
+                    && e.contains("sessionMetadataFilters")
+                    && e.contains("mutually exclusive"));
+    assertThat(response.errors())
+        .as("validation error must not surface as a Contrast API error")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
+  }
+
+  // ---------- Pagination ----------
+
+  @Test
+  void searchAppVulnerabilities_should_handle_pagination() {
+    assertThat(testData.totalVulnerabilities)
+        .as(
+            "pagination test requires app '%s' to carry >= %d vulnerabilities — see "
+                + "INTEGRATION_TESTS.md",
+            testData.sampleAppId, MIN_VULNS_FOR_PAGINATION)
+        .isGreaterThanOrEqualTo(MIN_VULNS_FOR_PAGINATION);
+
+    var page1 =
+        searchAppVulnerabilitiesTool.searchAppVulnerabilities(
+            testData.sampleAppId,
+            1,
+            PAGINATION_PROBE_SIZE,
+            null,
+            ALL_STATUSES,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+    assertThat(page1.isSuccess()).as("page 1 must succeed").isTrue();
+    assertThat(page1.items())
+        .as("page 1 must contain exactly %d items", PAGINATION_PROBE_SIZE)
+        .hasSize(PAGINATION_PROBE_SIZE);
+    assertThat(page1.hasMorePages()).as("page 1 must report hasMorePages=true").isTrue();
+
+    var page2 =
+        searchAppVulnerabilitiesTool.searchAppVulnerabilities(
+            testData.sampleAppId,
+            2,
+            PAGINATION_PROBE_SIZE,
+            null,
+            ALL_STATUSES,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+    assertThat(page2.isSuccess()).as("page 2 must succeed").isTrue();
+    assertThat(page2.page()).as("page 2 page number").isEqualTo(2);
+    assertThat(page2.items()).as("page 2 must contain at least one item").isNotEmpty();
+
+    var page1Ids = page1.items().stream().map(VulnLight::vulnID).toList();
+    var page2Ids = page2.items().stream().map(VulnLight::vulnID).toList();
+    assertThat(page2Ids)
+        .as("page 2 vulnIDs must be disjoint from page 1 vulnIDs — proves server honored offset")
+        .doesNotContainAnyElementsOf(page1Ids);
+  }
+
+  // ---------- API rejection path ----------
+
+  @Test
+  void searchAppVulnerabilities_should_surface_actionable_error_for_unknown_appId() {
+    // TeamServer rejects unknown applications when fetching trace data, which surfaces in this
+    // tool's pipeline as a non-success response with errors. The exact error text varies by
+    // TeamServer version (403/404) so we assert only that the error is non-empty, the response
+    // carries no items, and the error is not a generic 5xx Contrast-API error.
+    var response =
+        searchAppVulnerabilitiesTool.searchAppVulnerabilities(
+            NONEXISTENT_APP_ID, 1, 10, null, null, null, null, null, null, null, null, null);
+
+    assertThat(response.isSuccess())
+        .as("unknown appId must surface as a non-success response, not as an empty success")
+        .isFalse();
+    assertThat(response.items()).as("error response must carry no items").isEmpty();
+    assertThat(response.errors())
+        .as("error response must carry at least one actionable error message")
+        .isNotEmpty();
+    assertThat(response.errors())
+        .as(
+            "unknown appId must not surface as a generic 5xx Contrast API error — that masks "
+                + "the actionable auth/not-found message")
+        .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
   }
 }

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolIT.java
@@ -166,6 +166,23 @@ public class SearchAppVulnerabilitiesToolIT
     log.info("Test data: {}", data);
   }
 
+  /**
+   * Selects a single vulnerability-rich application that satisfies as many downstream filter
+   * preconditions as possible — {@code totalVulnerabilities} for pagination, populated tags for
+   * {@code vulnTags}, populated environments for the environments filter, and populated session
+   * metadata for the session-metadata filter — and captures one concrete value per filter path
+   * ({@code sampleVulnId}, {@code sampleVulnType}, {@code sampleSeverity}, {@code sampleStatus},
+   * {@code sampleEnvironment}, {@code sampleTag}, {@code sampleSessionField}, etc.) so each filter
+   * test calls the tool with a value known to exist on the chosen app.
+   *
+   * <p>Why the multi-stage ranking: a previous regression picked the org's most-vulnerable app (22
+   * vulns, zero tags), which silently passed the count-bearing tests but failed the tag-filter
+   * precondition. To prevent this, discovery probes both the default-status and {@code
+   * ALL_STATUSES} org-wide vulnerability searches, buckets results by app, ranks tag-bearing apps
+   * ahead of every untagged app (regardless of count), and stops at the first app that satisfies
+   * <em>all</em> downstream preconditions. {@code scoreCandidate} chooses the strongest fallback
+   * when no app is fully-populated.
+   */
   @Override
   protected TestData performDiscovery() throws IOException {
     // Sample the org's vulnerabilities directly to find applications that carry rich seed data.

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolIT.java
@@ -18,8 +18,16 @@ package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrast.labs.ai.mcp.contrast.config.IntegrationTestConfig;
+import com.contrast.labs.ai.mcp.contrast.result.VulnLight;
 import com.contrast.labs.ai.mcp.contrast.util.AbstractIntegrationTest;
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -54,13 +62,81 @@ public class SearchVulnerabilitiesToolIT
 
   @Autowired private SearchVulnerabilitiesTool searchVulnerabilitiesTool;
 
-  /** Container for discovered test data - no specific data needed for basic search. */
+  // Discovery sample size — broad enough to surface tags, environments, and rule types without
+  // pulling the entire org corpus on every run.
+  private static final int DISCOVERY_PAGE_SIZE = 100;
+
+  // Pagination probe — small page size so we can exercise multi-page behavior on small orgs.
+  private static final int PAGINATION_PROBE_SIZE = 2;
+  private static final int MIN_VULNS_FOR_PAGINATION = PAGINATION_PROBE_SIZE + 1;
+
+  // Default-status filter excludes these terminal statuses. The API returns capitalized labels
+  // for non-default statuses ("Fixed", "Remediated"); the auto-remediated flow has been observed
+  // both as "AutoRemediated" and "Auto-Remediated" depending on TeamServer version, so the
+  // assertion compares case-insensitively against both spellings.
+  private static final Set<String> DEFAULT_STATUS_FILTER_EXCLUDES =
+      Set.of("fixed", "remediated", "autoremediated", "auto-remediated", "notaproblem");
+
+  // Severity labels returned by the API are capitalized ("Critical", "High", ...) — see
+  // RuleSeverity in the SDK. Tests compare case-insensitively to insulate from label drift.
+  private static final Set<String> CRITICAL_HIGH_LABELS = Set.of("critical", "high");
+
+  // ServerEnvironment values are reflected verbatim ("DEVELOPMENT", "QA", "PRODUCTION") — see
+  // ServerEnvironment in the SDK and VulnerabilityMapper#extractEnvironments.
+  private static final String PRODUCTION_ENV = "PRODUCTION";
+
+  // Date format accepted by VulnerabilityFilterParams.dateParam: ISO YYYY-MM-DD.
+  private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+  // Full status set — used to bypass the default-status filter when looking for tagged
+  // vulnerabilities (which are commonly on Remediated/Fixed traces).
+  private static final String ALL_STATUSES =
+      "Reported,Suspicious,Confirmed,NotAProblem,Remediated,Fixed,AutoRemediated";
+
+  // Cap pages walked when searching for a seeded tag — bounds discovery cost on large orgs.
+  private static final int TAG_DISCOVERY_PAGES = 5;
+
+  // Common vulnerability tags applied during remediation workflows. We probe each as a fallback
+  // when scanning a few pages of vulnerabilities surfaces no tag — the @Tool docs themselves
+  // reference these as canonical examples (e.g., "SmartFix Remediated").
+  private static final List<String> COMMON_VULN_TAG_PROBES =
+      List.of("SmartFix Remediated", "reviewed", "urgent", "false-positive");
+
+  /**
+   * Container for discovered test data. Populated once per class by {@link #performDiscovery()}.
+   */
   static class TestData {
-    boolean hasVulnerabilities;
+    int totalVulnerabilities;
+    String sampleVulnId;
+    String sampleAppId;
+    String sampleAppName;
+    String sampleVulnType;
+    String sampleSeverity;
+    String sampleEnvironment;
+    String sampleStatus;
+    String sampleTag;
+    boolean anyHasEnvironments;
+    boolean anyHasTags;
+    boolean anyHasSessionMetadata;
 
     @Override
     public String toString() {
-      return String.format("TestData{hasVulnerabilities=%s}", hasVulnerabilities);
+      return String.format(
+          "TestData{total=%d, sampleVulnId='%s', appId='%s', appName='%s', type='%s', "
+              + "severity='%s', env='%s', status='%s', tag='%s', "
+              + "anyEnvs=%s, anyTags=%s, anySessionMetadata=%s}",
+          totalVulnerabilities,
+          sampleVulnId,
+          sampleAppId,
+          sampleAppName,
+          sampleVulnType,
+          sampleSeverity,
+          sampleEnvironment,
+          sampleStatus,
+          sampleTag,
+          anyHasEnvironments,
+          anyHasTags,
+          anyHasSessionMetadata);
     }
   }
 
@@ -76,26 +152,150 @@ public class SearchVulnerabilitiesToolIT
 
   @Override
   protected void logTestDataDetails(TestData data) {
-    log.info("Test data: hasVulnerabilities={}", data.hasVulnerabilities);
+    log.info("Test data: {}", data);
   }
 
   @Override
   protected TestData performDiscovery() throws IOException {
-    // Just check if we can get any vulnerabilities
+    var data = new TestData();
+
     var response =
         searchVulnerabilitiesTool.searchVulnerabilities(
-            1, 5, null, null, null, null, null, null, null);
+            1, DISCOVERY_PAGE_SIZE, null, null, null, null, null, null, null);
 
-    var testData = new TestData();
-    testData.hasVulnerabilities = response.isSuccess() && !response.items().isEmpty();
+    if (!response.isSuccess()) {
+      throw new NoTestDataException(
+          "SearchVulnerabilitiesToolIT discovery failed — errors: " + response.errors());
+    }
+    if (response.items().isEmpty()) {
+      throw new NoTestDataException(
+          "SearchVulnerabilitiesToolIT requires at least one vulnerability in the organization — "
+              + "see INTEGRATION_TESTS.md");
+    }
 
-    log.info(
-        "Discovery: found {} vulnerabilities (hasVulns={})",
-        response.items().size(),
-        testData.hasVulnerabilities);
+    data.totalVulnerabilities =
+        response.totalItems() != null ? response.totalItems() : response.items().size();
 
-    return testData;
+    for (var vuln : response.items()) {
+      if (data.sampleVulnId == null && vuln.vulnID() != null && !vuln.vulnID().isBlank()) {
+        data.sampleVulnId = vuln.vulnID();
+        data.sampleAppId = vuln.appID();
+        data.sampleAppName = vuln.appName();
+        data.sampleVulnType = vuln.type();
+        data.sampleSeverity = vuln.severity();
+        data.sampleStatus = vuln.status();
+      }
+
+      if (data.sampleEnvironment == null
+          && vuln.environments() != null
+          && !vuln.environments().isEmpty()) {
+        data.sampleEnvironment = vuln.environments().get(0);
+      }
+
+      if (data.sampleTag == null && vuln.tags() != null && !vuln.tags().isEmpty()) {
+        for (var tag : vuln.tags()) {
+          if (tag != null && !tag.isBlank()) {
+            data.sampleTag = tag;
+            break;
+          }
+        }
+      }
+
+      if (vuln.environments() != null && !vuln.environments().isEmpty()) {
+        data.anyHasEnvironments = true;
+      }
+      if (vuln.tags() != null && !vuln.tags().isEmpty()) {
+        data.anyHasTags = true;
+      }
+      if (vuln.sessionMetadata() != null && !vuln.sessionMetadata().isEmpty()) {
+        data.anyHasSessionMetadata = true;
+      }
+    }
+
+    // Tagged vulnerabilities are typically on Remediated/Fixed traces (e.g., "SmartFix
+    // Remediated"). The default-status filter above excludes them, so paginate over all
+    // statuses to surface a tagged vuln for the tag filter test. Cap at TAG_DISCOVERY_PAGES
+    // pages so discovery stays bounded on large orgs.
+    if (data.sampleTag == null) {
+      data.sampleTag = scanForTaggedVulnerability(data);
+      if (data.sampleTag != null) {
+        data.anyHasTags = true;
+      }
+    }
+
+    return data;
   }
+
+  /**
+   * Walks up to {@link #TAG_DISCOVERY_PAGES} pages of vulnerabilities (across all statuses) to find
+   * one carrying a non-blank tag, then falls back to probing common tag names directly via the
+   * vulnTags filter. Returns the tag or {@code null} if none can be found.
+   */
+  private String scanForTaggedVulnerability(TestData data) throws IOException {
+    for (int page = 1; page <= TAG_DISCOVERY_PAGES; page++) {
+      var response =
+          searchVulnerabilitiesTool.searchVulnerabilities(
+              page, DISCOVERY_PAGE_SIZE, null, ALL_STATUSES, null, null, null, null, null);
+      if (!response.isSuccess() || response.items().isEmpty()) {
+        break;
+      }
+      for (var vuln : response.items()) {
+        if (vuln.tags() == null || vuln.tags().isEmpty()) {
+          continue;
+        }
+        for (var tag : vuln.tags()) {
+          if (tag != null && !tag.isBlank()) {
+            return tag;
+          }
+        }
+      }
+      if (!response.hasMorePages()) {
+        break;
+      }
+    }
+
+    // Fallback: probe well-known vulnerability tag names directly. If any returns results, the
+    // org seeds that tag — use it as the sample. This catches orgs where tags exist but aren't
+    // surfaced in the first few pages of paginated results.
+    for (var probe : COMMON_VULN_TAG_PROBES) {
+      var probeResponse =
+          searchVulnerabilitiesTool.searchVulnerabilities(
+              1, 5, null, ALL_STATUSES, null, null, null, null, probe);
+      if (probeResponse.isSuccess() && !probeResponse.items().isEmpty()) {
+        log.info("Tag discovery fallback hit common probe '{}'", probe);
+        return probe;
+      }
+    }
+
+    log.warn(
+        "Tag discovery exhausted {} pages of {} vulns AND {} common probes without finding "
+            + "a non-blank tag (total in org: {})",
+        TAG_DISCOVERY_PAGES,
+        DISCOVERY_PAGE_SIZE,
+        COMMON_VULN_TAG_PROBES.size(),
+        data.totalVulnerabilities);
+    return null;
+  }
+
+  // ---------- Discovery precondition ----------
+
+  @Test
+  void testDiscoveredTestDataExists() {
+    assertThat(testData).as("discovery must populate test data").isNotNull();
+    assertThat(testData.totalVulnerabilities)
+        .as("organization must carry at least one vulnerability")
+        .isPositive();
+    assertThat(testData.sampleVulnId).as("sample vulnID must be non-blank").isNotBlank();
+    assertThat(testData.sampleAppId)
+        .as("sample appID must be non-blank — APPLICATION expand should populate it")
+        .isNotBlank();
+    assertThat(testData.sampleAppName).as("sample appName must be non-blank").isNotBlank();
+    assertThat(testData.sampleVulnType).as("sample vuln type must be non-blank").isNotBlank();
+    assertThat(testData.sampleSeverity).as("sample severity must be non-blank").isNotBlank();
+    assertThat(testData.sampleStatus).as("sample status must be non-blank").isNotBlank();
+  }
+
+  // ---------- Response shape ----------
 
   @Test
   void searchVulnerabilities_should_return_valid_response() {
@@ -103,182 +303,531 @@ public class SearchVulnerabilitiesToolIT
         searchVulnerabilitiesTool.searchVulnerabilities(
             1, 10, null, null, null, null, null, null, null);
 
-    assertThat(response).isNotNull();
-    assertThat(response.isSuccess()).isTrue();
-    assertThat(response.page()).isEqualTo(1);
-    assertThat(response.pageSize()).isEqualTo(10);
-    // Items may or may not be present depending on org data
-    assertThat(response.items()).isNotNull();
+    assertThat(response).as("response must never be null").isNotNull();
+    assertThat(response.isSuccess()).as("baseline query must succeed").isTrue();
+    assertThat(response.errors()).as("baseline query must have no errors").isEmpty();
+    assertThat(response.items()).as("items list must never be null").isNotNull();
+    assertThat(response.page()).as("page echoed").isEqualTo(1);
+    assertThat(response.pageSize()).as("pageSize echoed").isEqualTo(10);
+    if (response.items().size() < response.pageSize()) {
+      assertThat(response.hasMorePages())
+          .as("partial page must report hasMorePages=false")
+          .isFalse();
+    }
   }
+
+  // ---------- Severity filter ----------
 
   @Test
   void searchVulnerabilities_should_filter_by_severity() {
     var response =
         searchVulnerabilitiesTool.searchVulnerabilities(
-            1, 10, "CRITICAL,HIGH", null, null, null, null, null, null);
+            1, 50, "CRITICAL,HIGH", null, null, null, null, null, null);
 
-    assertThat(response.isSuccess()).isTrue();
-    // If we have results, verify they match filter (API returns capitalized: Critical, High)
-    if (!response.items().isEmpty()) {
-      assertThat(response.items())
-          .allMatch(
-              v ->
-                  "Critical".equalsIgnoreCase(v.severity())
-                      || "High".equalsIgnoreCase(v.severity()));
-    }
+    assertThat(response.isSuccess()).as("severity-filtered query must succeed").isTrue();
+    assertThat(response.items())
+        .as(
+            "severity filter CRITICAL,HIGH must return at least one result — "
+                + "if none, see INTEGRATION_TESTS.md for required seed data")
+        .isNotEmpty();
+
+    // Every returned vuln must carry one of the requested severities (case-insensitive — the
+    // API returns "Critical"/"High" labels, we sent "CRITICAL,HIGH"). A regression that
+    // silently dropped the filter would surface as a Medium/Low/Note row in the result set.
+    assertThat(response.items())
+        .as("every result must carry severity in {CRITICAL, HIGH}")
+        .allSatisfy(
+            v ->
+                assertThat(v.severity())
+                    .as("%s.severity", v.vulnID())
+                    .isNotBlank()
+                    .satisfies(
+                        s ->
+                            assertThat(CRITICAL_HIGH_LABELS)
+                                .as("%s.severity '%s' must match filter", v.vulnID(), s)
+                                .contains(s.toLowerCase(Locale.ROOT))));
   }
+
+  // ---------- Environment filter ----------
 
   @Test
   void searchVulnerabilities_should_filter_by_environment() {
+    // Exercise the PRODUCTION filter. If the org has no PRODUCTION vulnerabilities, the
+    // filter should still run cleanly but return zero rows — that's a successful narrowing
+    // contract, not a missing-data failure. The filter-effect proof comes from the
+    // allSatisfy on environments: every returned row must carry PRODUCTION, otherwise the
+    // server silently dropped the filter.
     var response =
         searchVulnerabilitiesTool.searchVulnerabilities(
-            1, 10, null, null, null, "PRODUCTION", null, null, null);
+            1, 50, null, null, null, PRODUCTION_ENV, null, null, null);
 
-    assertThat(response.isSuccess()).isTrue();
-    // Results may be empty if no production vulns exist
-    assertThat(response.items()).isNotNull();
+    assertThat(response.isSuccess()).as("environment-filtered query must succeed").isTrue();
+    assertThat(response.errors()).as("filter must not produce errors").isEmpty();
+
+    assertThat(response.items())
+        .as(
+            "every result must list PRODUCTION in its environments — a result without it"
+                + " proves the server-side filter was dropped")
+        .allSatisfy(
+            v ->
+                assertThat(v.environments())
+                    .as("%s.environments", v.vulnID())
+                    .isNotNull()
+                    .contains(PRODUCTION_ENV));
+  }
+
+  // ---------- Status filter ----------
+
+  @Test
+  void searchVulnerabilities_should_filter_by_status() {
+    // Reported is the canonical "fresh open" status. Every actionable org has at least one,
+    // so this is a safe positive-filter probe. We assert every returned row carries the
+    // requested status (case-insensitive); a regression that broadened to all statuses
+    // would surface a Confirmed/Remediated/Fixed row.
+    var response =
+        searchVulnerabilitiesTool.searchVulnerabilities(
+            1, 50, null, "Reported", null, null, null, null, null);
+
+    assertThat(response.isSuccess()).as("status-filtered query must succeed").isTrue();
+    assertThat(response.errors()).as("status filter must not produce errors").isEmpty();
+    assertThat(response.items())
+        .as(
+            "status filter 'Reported' must return at least one result — "
+                + "if none, see INTEGRATION_TESTS.md for required seed data")
+        .isNotEmpty();
+
+    assertThat(response.items())
+        .as("every result must carry status='Reported' (case-insensitive)")
+        .allSatisfy(
+            v ->
+                assertThat(v.status())
+                    .as("%s.status", v.vulnID())
+                    .isNotBlank()
+                    .isEqualToIgnoringCase("Reported"));
   }
 
   @Test
-  void searchVulnerabilities_should_include_default_status_warning() {
+  void searchVulnerabilities_should_apply_default_status_filter() {
+    // When no status param is supplied, VulnerabilityFilterParams substitutes the default
+    // (Reported, Suspicious, Confirmed) and emits a warning. This test verifies BOTH halves
+    // of that contract: the warning fires AND the filter actually narrows the result set —
+    // every returned vuln must have a non-terminal status. A regression that emitted the
+    // warning text without applying the filter would surface here.
     var response =
         searchVulnerabilitiesTool.searchVulnerabilities(
-            1, 10, null, null, null, null, null, null, null);
+            1, 50, null, null, null, null, null, null, null);
 
-    assertThat(response.isSuccess()).isTrue();
-    assertThat(response.warnings()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+    assertThat(response.isSuccess()).as("default-filter query must succeed").isTrue();
+    assertThat(response.warnings())
+        .as("must surface the default-status warning")
+        .anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+
+    if (response.items().isEmpty()) {
+      // With the default filter applied, an empty result set is plausible only on orgs
+      // that have zero open vulnerabilities — fail loudly because the rest of this suite
+      // assumes seeded vulnerabilities exist.
+      assertThat(testData.totalVulnerabilities)
+          .as(
+              "default-status filter returned no vulnerabilities — discovery saw %d, "
+                  + "indicating a regression that drops all results")
+          .isZero();
+      return;
+    }
+
+    assertThat(response.items())
+        .as(
+            "default-status filter must exclude terminal statuses (Fixed, Remediated, "
+                + "AutoRemediated, NotAProblem); a row with one of those proves the "
+                + "filter wasn't forwarded server-side")
+        .allSatisfy(
+            v ->
+                assertThat(v.status())
+                    .as("%s.status", v.vulnID())
+                    .isNotBlank()
+                    .satisfies(
+                        s ->
+                            assertThat(DEFAULT_STATUS_FILTER_EXCLUDES)
+                                .as("%s.status '%s' must not be in excluded set", v.vulnID(), s)
+                                .doesNotContain(s.toLowerCase(Locale.ROOT))));
   }
+
+  // ---------- Vulnerability type filter ----------
+
+  @Test
+  void searchVulnerabilities_should_filter_by_vulnTypes() {
+    assertThat(testData.sampleVulnType)
+        .as(
+            "vulnTypes filter test requires at least one vulnerability with a non-blank type — "
+                + "see INTEGRATION_TESTS.md")
+        .isNotBlank();
+
+    var response =
+        searchVulnerabilitiesTool.searchVulnerabilities(
+            1, 50, null, null, testData.sampleVulnType, null, null, null, null);
+
+    assertThat(response.isSuccess())
+        .as("vulnTypes-filtered query for '%s' must succeed", testData.sampleVulnType)
+        .isTrue();
+    assertThat(response.errors()).as("vulnTypes filter must not produce errors").isEmpty();
+    assertThat(response.items())
+        .as("vulnTypes filter '%s' must return at least the seed vuln", testData.sampleVulnType)
+        .isNotEmpty();
+
+    assertThat(response.items())
+        .as(
+            "every result must carry type='%s' — a different type proves the filter "
+                + "was silently dropped",
+            testData.sampleVulnType)
+        .allSatisfy(
+            v -> assertThat(v.type()).as("%s.type", v.vulnID()).isEqualTo(testData.sampleVulnType));
+  }
+
+  // ---------- Date range filters ----------
+
+  @Test
+  void searchVulnerabilities_should_filter_lastSeenAfter_far_future_returns_no_results() {
+    // The tightest proof that the filter is forwarded: a far-future cutoff cannot possibly
+    // match any past activity. A non-empty result would mean the filter was dropped.
+    var farFuture = LocalDate.now().plusYears(50).format(DATE_FMT);
+
+    var response =
+        searchVulnerabilitiesTool.searchVulnerabilities(
+            1, 50, null, null, null, null, farFuture, null, null);
+
+    assertThat(response.isSuccess()).as("far-future lastSeenAfter must succeed").isTrue();
+    assertThat(response.errors()).as("far-future lastSeenAfter must not error").isEmpty();
+    assertThat(response.warnings())
+        .as("date filter must surface the lastTimeSeen advisory")
+        .anyMatch(w -> w.contains("LAST ACTIVITY DATE") || w.contains("lastTimeSeen"));
+    assertThat(response.items())
+        .as("lastSeenAfter=%s (50y in future) must return zero results", farFuture)
+        .isEmpty();
+  }
+
+  @Test
+  void searchVulnerabilities_should_filter_lastSeenBefore_far_past_returns_no_results() {
+    // Symmetric proof for lastSeenBefore: a far-past cutoff can match nothing.
+    var farPast = LocalDate.now().minusYears(50).format(DATE_FMT);
+
+    var response =
+        searchVulnerabilitiesTool.searchVulnerabilities(
+            1, 50, null, null, null, null, null, farPast, null);
+
+    assertThat(response.isSuccess()).as("far-past lastSeenBefore must succeed").isTrue();
+    assertThat(response.errors()).as("far-past lastSeenBefore must not error").isEmpty();
+    assertThat(response.items())
+        .as("lastSeenBefore=%s (50y in past) must return zero results", farPast)
+        .isEmpty();
+  }
+
+  @Test
+  void searchVulnerabilities_should_filter_by_lastSeenAfter_inclusive_window() {
+    // Positive-path date filter. A cutoff comfortably in the past should return >=1 result,
+    // and every returned row's lastSeenAt must parse as a date >= the cutoff. We use a
+    // 10-year-ago cutoff so the test is robust even on long-lived orgs.
+    var cutoff = LocalDate.now().minusYears(10);
+    var cutoffParam = cutoff.format(DATE_FMT);
+
+    var response =
+        searchVulnerabilitiesTool.searchVulnerabilities(
+            1, 50, null, null, null, null, cutoffParam, null, null);
+
+    assertThat(response.isSuccess()).as("lastSeenAfter=%s must succeed", cutoffParam).isTrue();
+    assertThat(response.items())
+        .as("10y-ago cutoff must return at least one vulnerability")
+        .isNotEmpty();
+    assertThat(response.items())
+        .as("every result must have lastSeenAt >= %s", cutoffParam)
+        .allSatisfy(
+            v ->
+                assertThat(v.lastSeenAt())
+                    .as("%s.lastSeenAt", v.vulnID())
+                    .isNotBlank()
+                    .satisfies(
+                        ts ->
+                            assertThat(OffsetDateTime.parse(ts).toLocalDate())
+                                .as("%s.lastSeenAt parsed", v.vulnID())
+                                .isAfterOrEqualTo(cutoff)));
+  }
+
+  @Test
+  void searchVulnerabilities_should_reject_inverted_date_range() {
+    // lastSeenAfter must be strictly before lastSeenBefore. An inverted range must surface
+    // as an actionable validation error naming both parameters — not as a Contrast API error.
+    var after = LocalDate.now().format(DATE_FMT);
+    var before = LocalDate.now().minusYears(1).format(DATE_FMT);
+
+    var response =
+        searchVulnerabilitiesTool.searchVulnerabilities(
+            1, 10, null, null, null, null, after, before, null);
+
+    assertThat(response.isSuccess()).as("inverted date range must fail validation").isFalse();
+    assertThat(response.items()).as("validation failure must carry no items").isEmpty();
+    assertThat(response.errors())
+        .as("error must name both date params and describe the ordering rule")
+        .isNotEmpty()
+        .anyMatch(
+            e ->
+                e.contains("lastSeenAfter")
+                    && e.contains("lastSeenBefore")
+                    && e.contains("must be before"));
+    assertThat(response.errors())
+        .as("validation error must not surface as a Contrast API error")
+        .noneMatch(e -> e.contains("Contrast API error"));
+  }
+
+  // ---------- Tag filter ----------
+
+  @Test
+  void searchVulnerabilities_should_filter_by_vulnTag() {
+    assertThat(testData.sampleTag)
+        .as(
+            "vulnTags filter test requires at least one vulnerability with a non-blank tag — "
+                + "see INTEGRATION_TESTS.md")
+        .isNotBlank();
+
+    // Search broadly enough to include the seed vuln. Note the filter is status-defaulted,
+    // so we include the full status set to avoid a status filter masking the tag filter.
+    var response =
+        searchVulnerabilitiesTool.searchVulnerabilities(
+            1, 50, null, ALL_STATUSES, null, null, null, null, testData.sampleTag);
+
+    assertThat(response.isSuccess())
+        .as("tag-filtered query for '%s' must succeed", testData.sampleTag)
+        .isTrue();
+    assertThat(response.errors()).as("tag filter must not produce errors").isEmpty();
+    assertThat(response.items())
+        .as(
+            "tag filter '%s' must return at least one vulnerability — discovery found a "
+                + "vuln with this tag",
+            testData.sampleTag)
+        .isNotEmpty();
+
+    assertThat(response.items())
+        .as(
+            "every returned vuln must carry tag '%s' (case-insensitive) — a vuln without "
+                + "that tag proves the filter was dropped",
+            testData.sampleTag)
+        .allSatisfy(
+            v ->
+                assertThat(v.tags())
+                    .as("%s.tags vs filter", v.vulnID())
+                    .isNotNull()
+                    .anyMatch(t -> t != null && t.equalsIgnoreCase(testData.sampleTag)));
+  }
+
+  @Test
+  void searchVulnerabilities_should_handle_vulnTags_with_spaces() {
+    // The vulnTags parameter accepts comma-separated values where individual tags may
+    // contain spaces (e.g., "SmartFix Remediated"). The SDK URL-encodes them. This test
+    // exercises the wire-level handling — the call must succeed and return a well-formed
+    // response. We do NOT assert isNotEmpty because the org may legitimately have no
+    // SmartFix-Remediated vulns; the existence proof for tag filtering is covered by
+    // searchVulnerabilities_should_filter_by_vulnTag using a discovered tag.
+    var response =
+        searchVulnerabilitiesTool.searchVulnerabilities(
+            1, 50, null, ALL_STATUSES, null, null, null, null, "SmartFix Remediated,another tag");
+
+    assertThat(response).as("response must never be null").isNotNull();
+    assertThat(response.isSuccess())
+        .as("multi-tag query with spaces must succeed (errors=%s)", response.errors())
+        .isTrue();
+    assertThat(response.errors()).as("space-containing tags must not error").isEmpty();
+    // Every result (if any) must carry one of the requested tags — proves the filter wasn't
+    // silently dropped due to encoding issues.
+    assertThat(response.items())
+        .as(
+            "every result must carry 'SmartFix Remediated' or 'another tag' "
+                + "(case-insensitive); a row without either proves the filter was dropped")
+        .allSatisfy(
+            v ->
+                assertThat(v.tags())
+                    .as("%s.tags vs space-containing filter", v.vulnID())
+                    .isNotNull()
+                    .anyMatch(
+                        t ->
+                            t != null
+                                && (t.equalsIgnoreCase("SmartFix Remediated")
+                                    || t.equalsIgnoreCase("another tag"))));
+  }
+
+  // ---------- Pagination ----------
 
   @Test
   void searchVulnerabilities_should_handle_pagination() {
-    // First page
+    assertThat(testData.totalVulnerabilities)
+        .as(
+            "pagination test requires org to have >= %d vulnerabilities — see INTEGRATION_TESTS.md",
+            MIN_VULNS_FOR_PAGINATION)
+        .isGreaterThanOrEqualTo(MIN_VULNS_FOR_PAGINATION);
+
     var page1 =
         searchVulnerabilitiesTool.searchVulnerabilities(
-            1, 5, null, null, null, null, null, null, null);
+            1, PAGINATION_PROBE_SIZE, null, null, null, null, null, null, null);
+    assertThat(page1.isSuccess()).as("page 1 must succeed").isTrue();
+    assertThat(page1.items())
+        .as("page 1 must contain exactly %d items", PAGINATION_PROBE_SIZE)
+        .hasSize(PAGINATION_PROBE_SIZE);
+    assertThat(page1.hasMorePages()).as("page 1 must report hasMorePages=true").isTrue();
 
-    assertThat(page1.isSuccess()).isTrue();
-
-    // If there are more pages, fetch page 2
-    if (page1.hasMorePages()) {
-      var page2 =
-          searchVulnerabilitiesTool.searchVulnerabilities(
-              2, 5, null, null, null, null, null, null, null);
-
-      assertThat(page2.isSuccess()).isTrue();
-      assertThat(page2.page()).isEqualTo(2);
-    }
-  }
-
-  @Test
-  void searchVulnerabilities_should_populate_environments_and_tags() {
-    var response =
+    var page2 =
         searchVulnerabilitiesTool.searchVulnerabilities(
-            1, 10, null, null, null, null, null, null, null);
+            2, PAGINATION_PROBE_SIZE, null, null, null, null, null, null, null);
+    assertThat(page2.isSuccess()).as("page 2 must succeed").isTrue();
+    assertThat(page2.page()).as("page 2 page number").isEqualTo(2);
+    assertThat(page2.items()).as("page 2 must contain at least one item").isNotEmpty();
 
-    assertThat(response.isSuccess()).isTrue();
-
-    if (!response.items().isEmpty()) {
-      // Verify each vulnerability has non-null environments and tags collections
-      for (var vuln : response.items()) {
-        assertThat(vuln.environments())
-            .as("Environments should never be null for vuln %s", vuln.vulnID())
-            .isNotNull();
-        assertThat(vuln.tags())
-            .as("Tags should never be null for vuln %s", vuln.vulnID())
-            .isNotNull();
-      }
-      log.info(
-          "✓ All {} vulnerabilities have non-null environments and tags", response.items().size());
-    }
+    var page1Ids = page1.items().stream().map(VulnLight::vulnID).toList();
+    var page2Ids = page2.items().stream().map(VulnLight::vulnID).toList();
+    assertThat(page2Ids)
+        .as("page 2 vulnIDs must be disjoint from page 1 vulnIDs — proves server honored offset")
+        .doesNotContainAnyElementsOf(page1Ids);
   }
 
-  @Test
-  void searchVulnerabilities_should_populate_session_metadata() {
-    var response =
-        searchVulnerabilitiesTool.searchVulnerabilities(
-            1, 10, null, null, null, null, null, null, null);
-
-    assertThat(response.isSuccess()).isTrue();
-
-    if (!response.items().isEmpty()) {
-      int withSessionMetadata = 0;
-
-      for (var vuln : response.items()) {
-        assertThat(vuln.sessionMetadata())
-            .as("Session metadata should never be null for vuln %s", vuln.vulnID())
-            .isNotNull();
-
-        if (!vuln.sessionMetadata().isEmpty()) {
-          withSessionMetadata++;
-        }
-      }
-
-      log.info(
-          "✓ Session metadata field present on all vulns ({}/{} have session data)",
-          withSessionMetadata,
-          response.items().size());
-    }
-  }
+  // ---------- Field population ----------
 
   @Test
   void searchVulnerabilities_should_populate_basic_fields() {
     var response =
         searchVulnerabilitiesTool.searchVulnerabilities(
-            1, 5, null, null, null, null, null, null, null);
+            1, 10, null, null, null, null, null, null, null);
 
-    assertThat(response.isSuccess()).isTrue();
+    assertThat(response.isSuccess()).as("baseline query must succeed").isTrue();
+    assertThat(response.items())
+        .as("requires seeded vulnerabilities — see INTEGRATION_TESTS.md")
+        .isNotEmpty();
 
-    if (!response.items().isEmpty()) {
-      for (var vuln : response.items()) {
-        // Core identification fields
-        assertThat(vuln.title()).as("Title should not be null").isNotNull();
-        assertThat(vuln.type()).as("Type should not be null").isNotNull();
-        assertThat(vuln.vulnID()).as("VulnID should not be null").isNotNull();
-        assertThat(vuln.severity()).as("Severity should not be null").isNotNull();
-        assertThat(vuln.status()).as("Status should not be null").isNotNull();
-
-        // Application correlation fields (from APPLICATION expand)
-        assertThat(vuln.appID())
-            .as("appID should not be null (APPLICATION expand)")
-            .isNotNull()
-            .isNotEmpty();
-        assertThat(vuln.appName())
-            .as("appName should not be null (APPLICATION expand)")
-            .isNotNull()
-            .isNotEmpty();
-
-        log.info(
-            "✓ {}: {} ({}) - App: {} ({})",
-            vuln.vulnID(),
-            vuln.title(),
-            vuln.severity(),
-            vuln.appName(),
-            vuln.appID());
-      }
-    }
+    assertThat(response.items())
+        .as("every vulnerability must populate core identification and application fields")
+        .allSatisfy(
+            v -> {
+              assertThat(v.vulnID()).as("vulnID").isNotBlank();
+              assertThat(v.title()).as("%s.title", v.vulnID()).isNotBlank();
+              assertThat(v.type()).as("%s.type", v.vulnID()).isNotBlank();
+              assertThat(v.severity()).as("%s.severity", v.vulnID()).isNotBlank();
+              assertThat(v.status()).as("%s.status", v.vulnID()).isNotBlank();
+              // Application correlation fields — populated by APPLICATION expand.
+              assertThat(v.appID()).as("%s.appID (APPLICATION expand)", v.vulnID()).isNotBlank();
+              assertThat(v.appName())
+                  .as("%s.appName (APPLICATION expand)", v.vulnID())
+                  .isNotBlank();
+              // Timestamps — at minimum lastSeenAt must be populated; firstSeenAt may be
+              // null on legacy traces, so we don't enforce it here.
+              assertThat(v.lastSeenAt())
+                  .as("%s.lastSeenAt", v.vulnID())
+                  .isNotBlank()
+                  .satisfies(
+                      ts ->
+                          // Round-trip-parse the timestamp to prove it's a valid ISO format,
+                          // not just any non-blank string.
+                          assertThat(OffsetDateTime.parse(ts))
+                              .as("%s.lastSeenAt must be ISO-8601", v.vulnID())
+                              .isNotNull());
+            });
   }
 
   @Test
-  void searchVulnerabilities_should_handle_vulnTags_with_spaces() {
-    // Query with a tag that contains spaces - SDK should handle URL encoding
+  void searchVulnerabilities_should_correlate_appID_with_appName() {
+    // The mapper extracts appID and appName from the same Trace.application object, so a
+    // given appID must always map to exactly one appName across the response. A regression
+    // that swapped or shuffled them would surface here.
     var response =
         searchVulnerabilitiesTool.searchVulnerabilities(
-            1, 50, null, null, null, null, null, null, "SmartFix Remediated");
+            1, DISCOVERY_PAGE_SIZE, null, null, null, null, null, null, null);
 
-    // The query should complete without error
-    assertThat(response).as("Response should not be null").isNotNull();
-    assertThat(response.isSuccess()).isTrue();
+    assertThat(response.isSuccess()).as("baseline query must succeed").isTrue();
+    assertThat(response.items())
+        .as("requires seeded vulnerabilities — see INTEGRATION_TESTS.md")
+        .isNotEmpty();
 
-    log.info(
-        "✓ Query with 'SmartFix Remediated' tag completed ({} results)", response.items().size());
+    var seenPairs = new HashSet<List<String>>();
+    var idToName = new java.util.HashMap<String, String>();
+    for (var v : response.items()) {
+      assertThat(v.appID()).as("%s.appID", v.vulnID()).isNotBlank();
+      assertThat(v.appName()).as("%s.appName", v.vulnID()).isNotBlank();
+      seenPairs.add(List.of(v.appID(), v.appName()));
+      var prior = idToName.put(v.appID(), v.appName());
+      if (prior != null) {
+        assertThat(prior)
+            .as("appID '%s' must map to a single appName across the response", v.appID())
+            .isEqualTo(v.appName());
+      }
+    }
+    assertThat(seenPairs).as("at least one (appID, appName) pair must be present").isNotEmpty();
+  }
 
-    // Try with multiple tags including spaces
-    var multiTagResponse =
+  @Test
+  void searchVulnerabilities_should_populate_environments_when_seeded() {
+    // The mapper guarantees a non-null environments list even when the trace carries no
+    // server_environments data. Per the test name's "populate" claim, we additionally
+    // require that at least one returned vuln carries a non-empty environments list —
+    // otherwise the SERVER_ENVIRONMENTS expand has regressed to returning empty payloads.
+    assertThat(testData.anyHasEnvironments)
+        .as(
+            "populate test requires at least one vuln with a non-empty environments list — "
+                + "discovery scanned %d vulns and found none; see INTEGRATION_TESTS.md",
+            testData.totalVulnerabilities)
+        .isTrue();
+
+    var response =
         searchVulnerabilitiesTool.searchVulnerabilities(
-            1, 10, null, null, null, null, null, null, "Tag With Spaces,another-tag");
+            1, DISCOVERY_PAGE_SIZE, null, null, null, null, null, null, null);
 
-    assertThat(multiTagResponse).as("Response should not be null").isNotNull();
-    assertThat(multiTagResponse.isSuccess()).isTrue();
-    log.info("✓ Query with multiple tags (including spaces) completed");
+    assertThat(response.isSuccess()).as("baseline query must succeed").isTrue();
+    assertThat(response.items())
+        .as("every vuln must expose a non-null environments collection")
+        .allSatisfy(
+            v -> assertThat(v.environments()).as("%s.environments", v.vulnID()).isNotNull());
+    assertThat(response.items())
+        .as(
+            "at least one vuln must populate environments — proves SERVER_ENVIRONMENTS "
+                + "expand decodes end-to-end")
+        .anyMatch(v -> !v.environments().isEmpty());
+  }
+
+  @Test
+  void searchVulnerabilities_should_expose_tags_collection() {
+    // tags is populated only for vulns the user has tagged. We don't require any seeded
+    // tags here (that's covered by searchVulnerabilities_should_filter_by_vulnTag), but
+    // we do require the collection to never be null — the mapper's contract.
+    var response =
+        searchVulnerabilitiesTool.searchVulnerabilities(
+            1, DISCOVERY_PAGE_SIZE, null, null, null, null, null, null, null);
+
+    assertThat(response.isSuccess()).as("baseline query must succeed").isTrue();
+    assertThat(response.items())
+        .as("requires seeded vulnerabilities — see INTEGRATION_TESTS.md")
+        .isNotEmpty();
+    assertThat(response.items())
+        .as("every vuln must expose a non-null tags collection (mapper contract)")
+        .allSatisfy(v -> assertThat(v.tags()).as("%s.tags", v.vulnID()).isNotNull());
+  }
+
+  @Test
+  void searchVulnerabilities_should_populate_session_metadata_when_seeded() {
+    // SESSION_METADATA expand attaches per-vuln session info. Per the test's "populate"
+    // claim, we require at least one returned vuln to carry a non-empty session-metadata
+    // list — otherwise the expand has regressed.
+    assertThat(testData.anyHasSessionMetadata)
+        .as(
+            "populate test requires at least one vuln with non-empty sessionMetadata — "
+                + "discovery scanned %d vulns and found none; see INTEGRATION_TESTS.md",
+            testData.totalVulnerabilities)
+        .isTrue();
+
+    var response =
+        searchVulnerabilitiesTool.searchVulnerabilities(
+            1, DISCOVERY_PAGE_SIZE, null, null, null, null, null, null, null);
+
+    assertThat(response.isSuccess()).as("baseline query must succeed").isTrue();
+    assertThat(response.items())
+        .as("every vuln must expose a non-null sessionMetadata collection")
+        .allSatisfy(
+            v -> assertThat(v.sessionMetadata()).as("%s.sessionMetadata", v.vulnID()).isNotNull());
+    assertThat(response.items())
+        .as(
+            "at least one vuln must populate sessionMetadata — proves SESSION_METADATA "
+                + "expand decodes end-to-end")
+        .anyMatch(v -> !v.sessionMetadata().isEmpty());
   }
 }

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolIT.java
@@ -155,6 +155,25 @@ public class SearchVulnerabilitiesToolIT
     log.info("Test data: {}", data);
   }
 
+  /**
+   * Captures the seed values needed to exercise every {@code search_vulnerabilities} filter path:
+   *
+   * <ul>
+   *   <li>{@code totalVulnerabilities} — drives the pagination test.
+   *   <li>{@code sampleVulnId} / {@code sampleAppId} / {@code sampleAppName} / {@code
+   *       sampleVulnType} / {@code sampleSeverity} / {@code sampleStatus} — drive the per-field
+   *       filter tests by mirroring values that are known to exist in the org.
+   *   <li>{@code sampleEnvironment} — drives the environments-filter test.
+   *   <li>{@code sampleTag} — drives the {@code vulnTags} filter test. Tagged vulnerabilities
+   *       typically live on Remediated/Fixed traces (e.g. "SmartFix Remediated") which the default
+   *       status filter excludes; if the first page yields no tag, {@link
+   *       #scanForTaggedVulnerability} paginates {@link #TAG_DISCOVERY_PAGES} pages over {@code
+   *       ALL_STATUSES} and finally probes a small list of common tag names directly.
+   *   <li>{@code anyHasEnvironments} / {@code anyHasTags} / {@code anyHasSessionMetadata} — flags
+   *       that let downstream populate-tests fail loudly with a precondition message rather than
+   *       passing vacuously on an empty list.
+   * </ul>
+   */
   @Override
   protected TestData performDiscovery() throws IOException {
     var data = new TestData();

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/util/TestDataDiscoveryHelper.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/util/TestDataDiscoveryHelper.java
@@ -88,6 +88,11 @@ public class TestDataDiscoveryHelper {
     int appsChecked = 0;
     int actualMaxToCheck = Math.min(applications.size(), maxAppsToCheck);
 
+    // Prefer an app whose libraries include a populated vulnerabilities array so SCA tests can
+    // exercise severity breakdowns and CVE surfacing. Fall back to the first app with any
+    // libraries if no vulnerable-lib app exists within maxAppsToCheck.
+    ApplicationWithLibraries firstAnyLibMatch = null;
+
     for (Application app : applications) {
       if (appsChecked >= actualMaxToCheck) {
         logger.info("Reached max apps to check ({}), stopping search", actualMaxToCheck);
@@ -104,36 +109,52 @@ public class TestDataDiscoveryHelper {
 
       try {
         var libraries = IntegrationTestDataCache.getLibraries(orgId, app.getAppId(), sdkExtension);
-        if (libraries != null && !libraries.isEmpty()) {
+        if (libraries == null || libraries.isEmpty()) {
+          continue;
+        }
+
+        boolean hasVulnerableLibrary = false;
+        String vulnerableCveId = null;
+        for (LibraryExtended lib : libraries) {
+          if (lib.getVulnerabilities() != null && !lib.getVulnerabilities().isEmpty()) {
+            hasVulnerableLibrary = true;
+            var firstVuln = lib.getVulnerabilities().get(0);
+            if (firstVuln.getName() != null && firstVuln.getName().startsWith("CVE-")) {
+              vulnerableCveId = firstVuln.getName();
+            }
+            break;
+          }
+        }
+
+        if (hasVulnerableLibrary) {
           logger.info(
-              "✓ Found application with {} library/libraries: {} (ID: {})",
+              "✓ Found application with {} library/libraries (vulnerable, CVE={}): {} (ID: {})",
               libraries.size(),
+              vulnerableCveId,
               app.getName(),
               app.getAppId());
+          return Optional.of(new ApplicationWithLibraries(app, libraries, true, vulnerableCveId));
+        }
 
-          // Check for vulnerable libraries
-          boolean hasVulnerableLibrary = false;
-          String vulnerableCveId = null;
-
-          for (LibraryExtended lib : libraries) {
-            if (lib.getVulnerabilities() != null && !lib.getVulnerabilities().isEmpty()) {
-              hasVulnerableLibrary = true;
-              var firstVuln = lib.getVulnerabilities().get(0);
-              if (firstVuln.getName() != null && firstVuln.getName().startsWith("CVE-")) {
-                vulnerableCveId = firstVuln.getName();
-                logger.info("  ✓ Has vulnerable library with CVE: {}", vulnerableCveId);
-                break;
-              }
-            }
-          }
-
-          return Optional.of(
-              new ApplicationWithLibraries(app, libraries, hasVulnerableLibrary, vulnerableCveId));
+        if (firstAnyLibMatch == null) {
+          logger.debug(
+              "Remembering app as non-vulnerable fallback: {} (ID: {})",
+              app.getName(),
+              app.getAppId());
+          firstAnyLibMatch = new ApplicationWithLibraries(app, libraries, false, null);
         }
       } catch (IOException e) {
         logger.warn("Error checking libraries for app {}: {}", app.getAppId(), e.getMessage());
         // Continue to next app
       }
+    }
+
+    if (firstAnyLibMatch != null) {
+      logger.info(
+          "✓ Falling back to non-vulnerable app with libraries: {} (ID: {})",
+          firstAnyLibMatch.getApplication().getName(),
+          firstAnyLibMatch.getApplication().getAppId());
+      return Optional.of(firstAnyLibMatch);
     }
 
     logger.warn("No application with libraries found after checking {} apps", appsChecked);

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/util/TestDataDiscoveryHelper.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/util/TestDataDiscoveryHelper.java
@@ -88,9 +88,10 @@ public class TestDataDiscoveryHelper {
     int appsChecked = 0;
     int actualMaxToCheck = Math.min(applications.size(), maxAppsToCheck);
 
-    // Prefer an app whose libraries include a populated vulnerabilities array so SCA tests can
-    // exercise severity breakdowns and CVE surfacing. Fall back to the first app with any
-    // libraries if no vulnerable-lib app exists within maxAppsToCheck.
+    // Prefer an app whose libraries include a populated vulnerabilities array AND surface a
+    // CVE-prefixed vulnerability name so SCA tests can exercise severity breakdowns and CVE
+    // lookups. Fall back tiers: vulnerable-but-no-CVE-name, then any app with libraries.
+    ApplicationWithLibraries firstVulnerableNoCveMatch = null;
     ApplicationWithLibraries firstAnyLibMatch = null;
 
     for (Application app : applications) {
@@ -116,17 +117,22 @@ public class TestDataDiscoveryHelper {
         boolean hasVulnerableLibrary = false;
         String vulnerableCveId = null;
         for (LibraryExtended lib : libraries) {
-          if (lib.getVulnerabilities() != null && !lib.getVulnerabilities().isEmpty()) {
-            hasVulnerableLibrary = true;
-            var firstVuln = lib.getVulnerabilities().get(0);
-            if (firstVuln.getName() != null && firstVuln.getName().startsWith("CVE-")) {
-              vulnerableCveId = firstVuln.getName();
+          if (lib.getVulnerabilities() == null || lib.getVulnerabilities().isEmpty()) {
+            continue;
+          }
+          hasVulnerableLibrary = true;
+          for (var vuln : lib.getVulnerabilities()) {
+            if (vuln.getName() != null && vuln.getName().startsWith("CVE-")) {
+              vulnerableCveId = vuln.getName();
+              break;
             }
+          }
+          if (vulnerableCveId != null) {
             break;
           }
         }
 
-        if (hasVulnerableLibrary) {
+        if (hasVulnerableLibrary && vulnerableCveId != null) {
           logger.info(
               "✓ Found application with {} library/libraries (vulnerable, CVE={}): {} (ID: {})",
               libraries.size(),
@@ -134,6 +140,17 @@ public class TestDataDiscoveryHelper {
               app.getName(),
               app.getAppId());
           return Optional.of(new ApplicationWithLibraries(app, libraries, true, vulnerableCveId));
+        }
+
+        if (hasVulnerableLibrary) {
+          if (firstVulnerableNoCveMatch == null) {
+            logger.debug(
+                "Remembering vulnerable app without CVE-named vuln as fallback: {} (ID: {})",
+                app.getName(),
+                app.getAppId());
+            firstVulnerableNoCveMatch = new ApplicationWithLibraries(app, libraries, true, null);
+          }
+          continue;
         }
 
         if (firstAnyLibMatch == null) {
@@ -147,6 +164,14 @@ public class TestDataDiscoveryHelper {
         logger.warn("Error checking libraries for app {}: {}", app.getAppId(), e.getMessage());
         // Continue to next app
       }
+    }
+
+    if (firstVulnerableNoCveMatch != null) {
+      logger.info(
+          "✓ Falling back to vulnerable app without CVE-named vuln: {} (ID: {})",
+          firstVulnerableNoCveMatch.getApplication().getName(),
+          firstVulnerableNoCveMatch.getApplication().getAppId());
+      return Optional.of(firstVulnerableNoCveMatch);
     }
 
     if (firstAnyLibMatch != null) {


### PR DESCRIPTION
_Rebased onto main after #97 merged._

## Note
These are test updates only, no production code changes other than fixing a tool description about case-insensitive searches. Don't feel like you have to review this in great detail. Its a lot of changes, but they are tests only.

## Summary
- Codifies assertion-quality standards for integration tests in `CLAUDE.md` so future contributors (human or AI) cannot regress them silently.
- Hardens 13 `*IT.java` files end-to-end so each integration test verifies real SDK/API contract behavior — filter predicates, sort ordering, pagination boundaries, error-message shape, and field mapping — instead of confirming auth still works.
- Replaces silent-skip anti-patterns (`Assumptions.assumeTrue`, `if (data.isEmpty()) return;`) with fail-loudly preconditions, and replaces shape-only assertions (`isNotNull`) with content-level and behavioral assertions.
- Includes one small product-side fix: `GetSastProjectTool` documentation now correctly states that project-name matching is case-insensitive (uncovered while hardening `GetSastProjectToolIT`).

## Why This Change Exists

This branch is the test-quality prerequisite for the Hosted MCP Server epic (AIML-110). Before we expose this MCP server as a Contrast-hosted product, we need integration tests that catch real contract regressions — not tests that pass whenever credentials work and an HTTP 200 comes back.

Auditing the existing `*IT.java` suite revealed three classes of degraded tests:

1. **Silent-skip anti-pattern.** Many tests started with `assumeTrue(data != null && !data.isEmpty(), ...)` or `if (data.isEmpty()) return;`. When seeded test data drifts in the integration environment, these tests turn into no-ops and CI stays green. We had several tests effectively skipping in CI.
2. **Exercise ≠ verify.** Tests that called the tool, asserted `isNotNull()` on the response, and emitted a `log.info("✓ filter works")` line — but never asserted that the filter actually filtered, the sort actually sorted, or the pagination actually paginated. A `log.info` is not a test.
3. **Dual-path "always green" tests.** Patterns like `if (response.isSuccess()) { assertA } else { assertB }` treated both outcomes as a pass, so the test could not fail.

If the Hosted MCP Server ships against a test suite that doesn't actually verify the SDK/API contract, regressions land in production unseen. The cost of finding contract bugs in a hosted multi-tenant service is far higher than the cost of fixing them now.

## Approach We Chose

Two parallel workstreams:

### 1. Codify the standard

`CLAUDE.md` gains two new sections:
- **Assertion quality (applies to every test)** — eight rules covering deletion policy, mutation-check thinking, AAA completeness, fail-fast on missing data, behavioral over shape assertions, deterministic expectations, and "populated ≠ non-null".
- **Testing anti-patterns (do not reintroduce)** — eleven specific patterns that have been removed from this branch and must not return.
- **Integration Test Standards** — a dedicated subsection under "Testing Requirements Before Moving to Review" listing the required assertion patterns per test type (filter, sort, pagination, combined filters, error path, field mapping, populate claim, deterministic behavior), the data-dependency rule, and four canonical example IT classes to emulate.

The rationale for codifying this in `CLAUDE.md` rather than a separate doc: AI agents read `CLAUDE.md` on every session, so the standard is enforced at the point of contact. The anti-patterns list specifically calls out the failure modes we just fixed, so future agents don't reintroduce them.

### 2. Harden each IT systematically

One commit per IT (cleanly bisectable). Each commit follows the same playbook:

- Replace `Assumptions.assumeTrue(...)` and silent `return` with `assertThat(data).as("requires seeded X — see INTEGRATION_TESTS.md").isNotEmpty()` as the first assertion. Missing data now fails CI with an actionable message.
- Replace `assertThat(filtered).isNotEmpty()` with `assertThat(filtered).allSatisfy(item -> assertThat(item.field())...)` — proves every result matches the filter predicate, not just one.
- Replace manual sort-order loops with `assertThat(items).isSortedAccordingTo(Comparator.comparing(...))`.
- Replace `if (response.isSuccess()) ... else ...` dual-path tests by splitting them into two named tests, each with one expected outcome.
- For "_populate_*" / "_return_*" tests, replace `isNotNull()` on the claimed field with `isNotBlank()` for strings and `isNotEmpty()` for collections, plus content-level assertions.
- For error-path tests, assert the full validation message shape (e.g., `"projectName is required"`) and additionally assert `noneMatch("Contrast API error")` to ensure validation errors aren't masquerading as 5xx responses.
- For pagination tests, fetch page N+1 and verify it is disjoint from page N by ID, with item count = `min(pageSize, remaining)`.
- For field-mapping tests, verify response values reflect inputs (e.g., the response's `appID` equals the filter's `appId`).

Each commit message is suffixed with the originating bead (`mcp-wv00.N`) so the work is traceable back to the parent task tree.

## Outcome of This Change

- 13 IT files now genuinely verify SDK/API contract behavior. If we delete production logic under test, the corresponding IT goes red — the mutation-check property the new standard demands.
- Silent skips are gone. Missing seeded data fails CI loudly with a pointer to `INTEGRATION_TESTS.md`.
- The standard is documented and enforced through `CLAUDE.md`, so the next agent (human or AI) gets the same playbook on day one.
- Net diff: +4,780 / −1,431 across 16 files (13 IT files, `CLAUDE.md`, `TestDataDiscoveryHelper`, `GetSastProjectTool`).

## Reviewer Guide

The diff is large but mechanical and repetitive. Recommended order:

1. **`CLAUDE.md` first** — read the new "Assertion quality", "Testing anti-patterns", and "Integration Test Standards" sections. These define what every IT change is supposed to look like.
2. **One canonical IT** — pick `src/test/java/.../coverage/GetRouteCoverageToolIT.java` (cited in `CLAUDE.md` as the canonical pagination + filter + edge-cases example). Read it end-to-end. Once you understand the pattern, the other 12 IT files are variations on the same theme.
3. **Remaining IT files** — skim. Look for any place where `isNotNull` / `isNotEmpty` survives without a content-level companion assertion, or any `if (success) … else …` you can find. None should remain.
4. **`GetSastProjectTool.java`** — three-line product fix. Verify the description matches actual SDK behavior.
5. **`TestDataDiscoveryHelper.java`** — small refactor to prefer apps with vulnerable libraries. Confirm fallback behavior is preserved.

Per-commit review also works well — each commit is one IT and fully self-contained.

## Logic Walkthrough

### 1. Problem framing — why ITs were drifting

The previous IT pattern was "call the tool, confirm no exception, confirm response is non-null, log a checkmark." This passes whenever:
- The user is authenticated and the server returns 200.
- The seeded data still exists (or the test silently skips).
- The response object is constructed (which always happens regardless of filter/sort correctness).

None of those conditions exercise the SDK/API contract. A regression where a filter parameter is silently dropped, a sort comparator is inverted, or a pagination cursor is off-by-one would not turn any of these tests red.

### 2. Codifying the new standard (`CLAUDE.md`)

`CLAUDE.md` is the file every AI agent reads first. By placing the rules and anti-patterns there — with concrete examples and named canonical files — the standard is enforced at the point of contact. The anti-patterns list is intentionally specific (e.g., "filter test that never calls `allSatisfy`") so future violations are recognizable in code review.

### 3. Per-IT hardening (13 commits)

Each commit replaces the same set of patterns:

| Old pattern | New pattern |
|---|---|
| `assumeTrue(data != null && !data.isEmpty(), ...)` | `assertThat(data).as("requires seeded X").isNotEmpty()` (first assertion) |
| `if (data.isEmpty()) return;` | Same as above |
| `assertThat(filtered).isNotEmpty(); log.info("✓ filter")` | `assertThat(filtered).allSatisfy(...)` |
| Manual sort-order `for` loop | `isSortedAccordingTo(Comparator.comparing(...))` |
| `if (success) {...} else {...}` | Split into two named tests, each deterministic |
| `assertThat(field).isNotNull()` (on a "_populate_" test) | `assertThat(field).isNotBlank()` / `isNotEmpty()` + content check |
| Pagination via `isNotEmpty()` only | Page N+1 disjoint from page N by ID, `min(pageSize, remaining)` |
| Error-path `errors().anyMatch(e -> e.contains("paramName"))` | Full message shape, plus `noneMatch("Contrast API error")` |

### 4. Supporting changes

**`GetSastProjectTool.java` (3-line fix)** — While hardening `GetSastProjectToolIT`, the test exercising case-insensitive lookups passed against a tool whose Javadoc claimed names were case-sensitive. The SDK behavior was correct; the documentation was wrong. Fixed the `@Tool` description and `@ToolParam` description to match real behavior.

**`TestDataDiscoveryHelper.java`** — Previously the helper returned the first app with any libraries. The SCA tests need an app with a *vulnerable* library to exercise CVE surfacing, so the helper now scans up to `maxAppsToCheck` apps preferring one with vulnerabilities, falling back to any-libraries-app only if no vulnerable-lib app is found within the limit. Logging is added on the fallback path.

### 5. Edge cases and safeguards

- **Validation messages** — error-path tests now assert the full message including the list of valid options where applicable, not just the parameter name. This prevents false positives where any error happens to contain the param name.
- **5xx vs validation** — error-path tests additionally assert `noneMatch("Contrast API error")` to ensure validation errors are never masquerading as the 5xx-mapped string.
- **Determinism** — every test asserts a single expected outcome. Where a behavior previously had two legitimate outcomes (e.g., success or graceful-not-found), the test was split into two named tests, each with one expected outcome.

## What Changed

### Standards
- `CLAUDE.md` — new "Assertion quality" rules, new "Testing anti-patterns" list, new "Integration Test Standards" section with required patterns, data-dependency rule, and canonical examples; minor strengthening of the existing test-naming bullet.

### Integration tests (13 files)
- `tool/application/GetSessionMetadataToolIT.java`
- `tool/application/SearchApplicationsToolIT.java`
- `tool/attack/GetProtectRulesToolIT.java`
- `tool/attack/SearchAttacksToolIT.java`
- `tool/coverage/GetRouteCoverageToolIT.java`
- `tool/library/ListApplicationLibrariesToolIT.java`
- `tool/library/ListApplicationsByCveToolIT.java`
- `tool/sast/GetSastProjectToolIT.java`
- `tool/sast/GetSastResultsToolIT.java`
- `tool/vulnerability/GetVulnerabilityToolIT.java`
- `tool/vulnerability/ListVulnerabilityTypesToolIT.java`
- `tool/vulnerability/SearchAppVulnerabilitiesToolIT.java`
- `tool/vulnerability/SearchVulnerabilitiesToolIT.java`

### Test infrastructure
- `util/TestDataDiscoveryHelper.java` — prefer apps with vulnerable libraries; deterministic fallback to any-libraries-app.

### Product
- `tool/sast/GetSastProjectTool.java` — corrects `@Tool` and `@ToolParam` descriptions to state that project-name matching is case-insensitive (the SDK was already case-insensitive; only the documentation was wrong).

## Testing

**Automated:**
- `make check-test` — passes (unit tests + style + checkstyle, 0 violations).
- `make verify` — passes against the integration environment with seeded data; every IT now asserts its precondition up front and exercises real contract behavior.

**Mutation-check (informal):** For each IT, asked the question "if I deleted the production logic under test, would this go red?" and strengthened assertions until the answer was yes. The same check applies to reviewers.

**Failure-mode validation:** Confirmed that removing seeded data causes a clear `requires seeded X — see INTEGRATION_TESTS.md` failure (instead of a silent green pass).

**Important gaps:** None known. Integration tests run against the same shared environment used by all `*IT.java` tests; new precondition assertions surface seed drift loudly rather than skipping.

## Risks / Rollout / Follow-ups

- **Risk: tighter preconditions may surface seed drift in CI.** This is intentional — the previous behavior was to pass anyway. If a precondition fails, the message points to `INTEGRATION_TESTS.md` for the seed contract. This is a feature, not a regression.
- **No runtime risk.** The only product-side change is a documentation correction in `GetSastProjectTool` (`@Tool` / `@ToolParam` descriptions). Behavior is unchanged; the SDK was already case-insensitive.
- **No rollout concerns.** This branch ships only to the test suite and developer documentation.
- **Follow-up:** AIML-110 (Hosted MCP Server) can now build on a test suite that genuinely catches contract regressions. Subsequent work should adopt the same patterns from day one — the canonical examples in `CLAUDE.md` provide the template.
