### PR TITLE
AIML-481: Address code review findings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
 		<maven-release-plugin.version>3.1.1</maven-release-plugin.version>
 		<guava.version>33.5.0-jre</guava.version>
 		<contrast.sdk.version>3.7.0</contrast.sdk.version>
+		<commons-validator.version>1.10.1</commons-validator.version>
 		<mockito-inline.version>5.2.0</mockito-inline.version>
 		<assertj.version>3.27.7</assertj.version>
 		<maven-failsafe-plugin.version>3.5.3</maven-failsafe-plugin.version>
@@ -49,6 +50,11 @@
 			<groupId>com.contrastsecurity</groupId>
 			<artifactId>contrast-sdk-java</artifactId>
 			<version>${contrast.sdk.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-validator</groupId>
+			<artifactId>commons-validator</artifactId>
+			<version>${commons-validator.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.ai</groupId>

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/config/ContrastSDKFactory.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/config/ContrastSDKFactory.java
@@ -21,6 +21,7 @@ import jakarta.annotation.PostConstruct;
 import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.validator.routines.UrlValidator;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -35,6 +36,11 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 @Slf4j
 public class ContrastSDKFactory {
+
+  private static final UrlValidator HTTPS_URL_VALIDATOR =
+      new UrlValidator(new String[] {"https"}, UrlValidator.ALLOW_LOCAL_URLS);
+
+  private static final String SCHEME_SEPARATOR = "://";
 
   private final ContrastProperties properties;
   private ContrastSDK sdkInstance;
@@ -101,36 +107,26 @@ public class ContrastSDKFactory {
               + String.join(", ", missing));
     }
 
-    var protocol = properties.protocol();
-    if (StringUtils.hasText(protocol)) {
-      var normalizedProtocol = protocol.strip().toLowerCase();
-      if (normalizedProtocol.contains("://")) {
-        throw new IllegalStateException(
-            "Invalid contrast.api.protocol value: '"
-                + protocol
-                + "'. Set to 'https', not 'https://'. The protocol separator is added"
-                + " automatically.");
-      }
-      if (!"https".equals(normalizedProtocol)) {
-        throw new IllegalStateException(
-            "Insecure protocol configured: '"
-                + protocol
-                + "'. The MCP server requires HTTPS to protect API credentials. Set"
-                + " contrast.api.protocol=https or remove the property to use the"
-                + " default.");
-      }
+    var candidateUrl = buildCandidateUrl(properties.protocol(), properties.hostName());
+    if (!HTTPS_URL_VALIDATOR.isValid(candidateUrl)) {
+      throw new IllegalStateException(
+          "Invalid or insecure Contrast TeamServer URL '"
+              + candidateUrl
+              + "' (resolved from contrast.api.protocol='"
+              + properties.protocol()
+              + "', CONTRAST_HOST_NAME='"
+              + properties.hostName()
+              + "'). The MCP server requires an https:// URL with a valid hostname.");
     }
+  }
 
-    var hostName = properties.hostName();
-    if (StringUtils.hasText(hostName)) {
-      var normalizedHostName = hostName.strip().toLowerCase();
-      if (normalizedHostName.contains("://") && !normalizedHostName.startsWith("https://")) {
-        throw new IllegalStateException(
-            "Insecure protocol in CONTRAST_HOST_NAME: '"
-                + hostName
-                + "'. Use 'https://' or provide the hostname without a scheme"
-                + " to use HTTPS by default.");
-      }
+  private static String buildCandidateUrl(String protocol, String hostName) {
+    var bareHost = hostName.strip();
+    if (bareHost.contains(SCHEME_SEPARATOR)) {
+      return bareHost;
     }
+    var effectiveProtocol =
+        StringUtils.hasText(protocol) ? protocol.strip().toLowerCase() : "https";
+    return effectiveProtocol + SCHEME_SEPARATOR + bareHost;
   }
 }

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/config/ContrastSDKFactory.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/config/ContrastSDKFactory.java
@@ -110,13 +110,11 @@ public class ContrastSDKFactory {
     var candidateUrl = buildCandidateUrl(properties.protocol(), properties.hostName());
     if (!HTTPS_URL_VALIDATOR.isValid(candidateUrl)) {
       throw new IllegalStateException(
-          "Invalid or insecure Contrast TeamServer URL '"
-              + candidateUrl
-              + "' (resolved from contrast.api.protocol='"
-              + properties.protocol()
-              + "', CONTRAST_HOST_NAME='"
-              + properties.hostName()
-              + "'). The MCP server requires an https:// URL with a valid hostname.");
+          String.format(
+              "Invalid or insecure Contrast TeamServer URL '%s' (resolved from"
+                  + " contrast.api.protocol='%s', CONTRAST_HOST_NAME='%s'). The MCP server"
+                  + " requires an https:// URL with a valid hostname.",
+              candidateUrl, properties.protocol(), properties.hostName()));
     }
   }
 

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/LoggingKeys.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/LoggingKeys.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool.base;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * String constants for structured log keys used across the codebase.
+ *
+ * <p>Use these instead of inline string literals when calling {@code addKeyValue(...)} or building
+ * a {@code WarningCollector} context map, so the key set stays consistent and renames are
+ * compiler-enforced.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class LoggingKeys {
+
+  public static final String APP_ID = "appId";
+  public static final String DURATION_MS = "durationMs";
+  public static final String ERROR_COUNT = "errorCount";
+  public static final String EXCEPTION_TYPE = "exceptionType";
+  public static final String FILTER_NAME = "filterName";
+  public static final String HTTP_STATUS = "httpStatus";
+  public static final String ITEM_COUNT = "itemCount";
+  public static final String REQUEST_ID = "requestId";
+  public static final String TOTAL_ITEMS = "totalItems";
+  public static final String VULN_ID = "vulnId";
+}

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
@@ -81,7 +81,7 @@ public abstract class PaginatedTool<P extends ToolParams, R> extends BaseTool {
     var params = paramsSupplier.get();
 
     // 3. Collector accumulates warnings from all stages
-    var collector = WarningCollector.forContext(Map.of("requestId", requestId));
+    var collector = WarningCollector.forContext(Map.of(LoggingKeys.REQUEST_ID, requestId));
     pagination.warnings().forEach(collector::warn);
     params.warnings().forEach(collector::warn);
 
@@ -113,7 +113,7 @@ public abstract class PaginatedTool<P extends ToolParams, R> extends BaseTool {
       return handleHttpResponseException(e, pagination, requestId, collector);
     } catch (Exception e) {
       log.atError()
-          .addKeyValue("requestId", requestId)
+          .addKeyValue(LoggingKeys.REQUEST_ID, requestId)
           .setCause(e)
           .setMessage("Request failed unexpectedly")
           .log();
@@ -140,8 +140,8 @@ public abstract class PaginatedTool<P extends ToolParams, R> extends BaseTool {
   private PaginatedToolResponse<R> handleException(
       Exception e, PaginationParams pagination, String requestId, String userMessage) {
     log.atWarn()
-        .addKeyValue("requestId", requestId)
-        .addKeyValue("exceptionType", e.getClass().getSimpleName())
+        .addKeyValue(LoggingKeys.REQUEST_ID, requestId)
+        .addKeyValue(LoggingKeys.EXCEPTION_TYPE, e.getClass().getSimpleName())
         .setMessage("Request failed: {}")
         .addArgument(e.getMessage())
         .log();
@@ -157,8 +157,8 @@ public abstract class PaginatedTool<P extends ToolParams, R> extends BaseTool {
     String errorMessage = mapHttpErrorCode(e.getCode());
 
     log.atWarn()
-        .addKeyValue("requestId", requestId)
-        .addKeyValue("httpStatus", e.getCode())
+        .addKeyValue(LoggingKeys.REQUEST_ID, requestId)
+        .addKeyValue(LoggingKeys.HTTP_STATUS, e.getCode())
         .setMessage("API error: {}")
         .addArgument(e.getMessage())
         .log();
@@ -209,8 +209,8 @@ public abstract class PaginatedTool<P extends ToolParams, R> extends BaseTool {
 
   private void logValidationError(String requestId, List<String> errors) {
     log.atDebug()
-        .addKeyValue("requestId", requestId)
-        .addKeyValue("errorCount", errors.size())
+        .addKeyValue(LoggingKeys.REQUEST_ID, requestId)
+        .addKeyValue(LoggingKeys.ERROR_COUNT, errors.size())
         .setMessage("Validation failed: {}")
         .addArgument(String.join(", ", errors))
         .log();
@@ -218,10 +218,10 @@ public abstract class PaginatedTool<P extends ToolParams, R> extends BaseTool {
 
   private void logSuccess(String requestId, long duration, int itemCount, Integer totalItems) {
     log.atDebug()
-        .addKeyValue("requestId", requestId)
-        .addKeyValue("durationMs", duration)
-        .addKeyValue("itemCount", itemCount)
-        .addKeyValue("totalItems", totalItems)
+        .addKeyValue(LoggingKeys.REQUEST_ID, requestId)
+        .addKeyValue(LoggingKeys.DURATION_MS, duration)
+        .addKeyValue(LoggingKeys.ITEM_COUNT, itemCount)
+        .addKeyValue(LoggingKeys.TOTAL_ITEMS, totalItems)
         .setMessage("Request completed successfully")
         .log();
   }

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
@@ -111,6 +111,10 @@ public abstract class PaginatedTool<P extends ToolParams, R> extends BaseTool {
       return handleException(e, pagination, requestId, "Resource not found");
     } catch (HttpResponseException e) {
       return handleHttpResponseException(e, pagination, requestId, collector);
+    } catch (IllegalArgumentException e) {
+      // User-input rejection raised mid-execution (e.g., resolveAppMetadataFilters when an
+      // unknown field name is supplied). The exception message is the actionable user message.
+      return handleException(e, pagination, requestId, e.getMessage());
     } catch (Exception e) {
       log.atError()
           .addKeyValue(LoggingKeys.REQUEST_ID, requestId)

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
@@ -97,6 +97,10 @@ public abstract class SingleTool<P extends ToolParams, R> extends BaseTool {
           collector);
     } catch (HttpResponseException e) {
       return handleHttpResponseException(e, requestId, collector);
+    } catch (IllegalArgumentException e) {
+      // User-input rejection raised mid-execution (e.g., resolveSessionMetadataFilters when an
+      // unknown field name is supplied). The exception message is the actionable user message.
+      return handleException(e, requestId, e.getMessage(), collector);
     } catch (Exception e) {
       log.atError()
           .addKeyValue(LoggingKeys.REQUEST_ID, requestId)

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
@@ -62,7 +62,7 @@ public abstract class SingleTool<P extends ToolParams, R> extends BaseTool {
     var params = paramsSupplier.get();
 
     // 2. Collector accumulates warnings from all stages
-    var collector = WarningCollector.forContext(Map.of("requestId", requestId));
+    var collector = WarningCollector.forContext(Map.of(LoggingKeys.REQUEST_ID, requestId));
     params.warnings().forEach(collector::warn);
 
     // 3. Single validation checkpoint - ALL errors collected
@@ -99,7 +99,7 @@ public abstract class SingleTool<P extends ToolParams, R> extends BaseTool {
       return handleHttpResponseException(e, requestId, collector);
     } catch (Exception e) {
       log.atError()
-          .addKeyValue("requestId", requestId)
+          .addKeyValue(LoggingKeys.REQUEST_ID, requestId)
           .setCause(e)
           .setMessage("Request failed unexpectedly")
           .log();
@@ -121,8 +121,8 @@ public abstract class SingleTool<P extends ToolParams, R> extends BaseTool {
   private SingleToolResponse<R> handleException(
       Exception e, String requestId, String userMessage, WarningCollector collector) {
     log.atWarn()
-        .addKeyValue("requestId", requestId)
-        .addKeyValue("exceptionType", e.getClass().getSimpleName())
+        .addKeyValue(LoggingKeys.REQUEST_ID, requestId)
+        .addKeyValue(LoggingKeys.EXCEPTION_TYPE, e.getClass().getSimpleName())
         .setMessage("Request failed: {}")
         .addArgument(e.getMessage())
         .log();
@@ -136,8 +136,8 @@ public abstract class SingleTool<P extends ToolParams, R> extends BaseTool {
     String errorMessage = mapHttpErrorCode(e.getCode());
 
     log.atWarn()
-        .addKeyValue("requestId", requestId)
-        .addKeyValue("httpStatus", e.getCode())
+        .addKeyValue(LoggingKeys.REQUEST_ID, requestId)
+        .addKeyValue(LoggingKeys.HTTP_STATUS, e.getCode())
         .setMessage("API error: {}")
         .addArgument(e.getMessage())
         .log();
@@ -147,8 +147,8 @@ public abstract class SingleTool<P extends ToolParams, R> extends BaseTool {
 
   private void logValidationError(String requestId, List<String> errors) {
     log.atDebug()
-        .addKeyValue("requestId", requestId)
-        .addKeyValue("errorCount", errors.size())
+        .addKeyValue(LoggingKeys.REQUEST_ID, requestId)
+        .addKeyValue(LoggingKeys.ERROR_COUNT, errors.size())
         .setMessage("Validation failed: {}")
         .addArgument(String.join(", ", errors))
         .log();
@@ -156,16 +156,16 @@ public abstract class SingleTool<P extends ToolParams, R> extends BaseTool {
 
   private void logNotFound(String requestId, long duration) {
     log.atDebug()
-        .addKeyValue("requestId", requestId)
-        .addKeyValue("durationMs", duration)
+        .addKeyValue(LoggingKeys.REQUEST_ID, requestId)
+        .addKeyValue(LoggingKeys.DURATION_MS, duration)
         .setMessage("Resource not found")
         .log();
   }
 
   private void logSuccess(String requestId, long duration) {
     log.atDebug()
-        .addKeyValue("requestId", requestId)
-        .addKeyValue("durationMs", duration)
+        .addKeyValue(LoggingKeys.REQUEST_ID, requestId)
+        .addKeyValue(LoggingKeys.DURATION_MS, duration)
         .setMessage("Request completed successfully")
         .log();
   }

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/MetadataJsonFilterSpec.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/MetadataJsonFilterSpec.java
@@ -15,6 +15,7 @@
  */
 package com.contrast.labs.ai.mcp.contrast.tool.validation;
 
+import com.contrast.labs.ai.mcp.contrast.tool.base.LoggingKeys;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
@@ -82,7 +83,7 @@ public class MetadataJsonFilterSpec {
       return result.isEmpty() ? null : List.copyOf(result);
     } catch (JsonSyntaxException e) {
       log.atWarn()
-          .addKeyValue("filterName", name)
+          .addKeyValue(LoggingKeys.FILTER_NAME, name)
           .setCause(e)
           .setMessage("Invalid JSON in metadata filter")
           .log();

--- a/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/HttpRequestRedactor.java
+++ b/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/HttpRequestRedactor.java
@@ -17,14 +17,15 @@ package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 
 import java.util.ArrayList;
 import java.util.Set;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.springframework.util.StringUtils;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 final class HttpRequestRedactor {
 
   private static final Set<String> SENSITIVE_HEADERS =
       Set.of("authorization", "cookie", "set-cookie");
-
-  private HttpRequestRedactor() {}
 
   static String redact(String httpRequest) {
     if (!StringUtils.hasText(httpRequest)) {

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/config/ContrastSDKFactoryTest.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/config/ContrastSDKFactoryTest.java
@@ -165,8 +165,9 @@ class ContrastSDKFactoryTest {
 
     assertThatThrownBy(factoryWithInvalidProps::validateConfiguration)
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Insecure protocol")
-        .hasMessageContaining("http");
+        .hasMessageContaining("Invalid or insecure Contrast TeamServer URL")
+        .hasMessageContaining("contrast.api.protocol='http'")
+        .hasMessageContaining("https://");
   }
 
   @Test
@@ -176,8 +177,8 @@ class ContrastSDKFactoryTest {
 
     assertThatThrownBy(factoryWithInvalidProps::validateConfiguration)
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Insecure protocol")
-        .hasMessageContaining("HTTP");
+        .hasMessageContaining("Invalid or insecure Contrast TeamServer URL")
+        .hasMessageContaining("contrast.api.protocol='HTTP'");
   }
 
   @Test
@@ -187,8 +188,8 @@ class ContrastSDKFactoryTest {
 
     assertThatThrownBy(factoryWithInvalidProps::validateConfiguration)
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Insecure protocol")
-        .hasMessageContaining("ftp");
+        .hasMessageContaining("Invalid or insecure Contrast TeamServer URL")
+        .hasMessageContaining("contrast.api.protocol='ftp'");
   }
 
   @Test
@@ -198,7 +199,8 @@ class ContrastSDKFactoryTest {
 
     assertThatThrownBy(factoryWithInvalidProps::validateConfiguration)
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("not 'https://'");
+        .hasMessageContaining("Invalid or insecure Contrast TeamServer URL")
+        .hasMessageContaining("contrast.api.protocol='https://'");
   }
 
   @Test
@@ -240,8 +242,8 @@ class ContrastSDKFactoryTest {
 
     assertThatThrownBy(factoryWithInvalidProps::validateConfiguration)
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("CONTRAST_HOST_NAME")
-        .hasMessageContaining("http://app.example.com");
+        .hasMessageContaining("Invalid or insecure Contrast TeamServer URL")
+        .hasMessageContaining("CONTRAST_HOST_NAME='http://app.example.com'");
   }
 
   @Test
@@ -251,8 +253,8 @@ class ContrastSDKFactoryTest {
 
     assertThatThrownBy(factoryWithInvalidProps::validateConfiguration)
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("CONTRAST_HOST_NAME")
-        .hasMessageContaining("HTTP://app.example.com");
+        .hasMessageContaining("Invalid or insecure Contrast TeamServer URL")
+        .hasMessageContaining("CONTRAST_HOST_NAME='HTTP://app.example.com'");
   }
 
   @Test

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolTest.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolTest.java
@@ -177,8 +177,10 @@ class SearchApplicationsToolTest {
         .singleElement()
         .satisfies(
             error -> {
-              assertThat(error).startsWith("An internal error occurred (ref: ");
-              assertThat(error).doesNotContain("unknownField");
+              assertThat(error).contains("Metadata field(s) not found");
+              assertThat(error).contains("unknownField");
+              assertThat(error).contains("Available fields");
+              assertThat(error).doesNotContain("An internal error occurred");
             });
 
     verify(sdkExtension).getApplicationMetadataFields(anyString());

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolTest.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolTest.java
@@ -179,6 +179,28 @@ class PaginatedToolTest {
   }
 
   @Test
+  void executePipeline_should_surface_illegalArgumentException_message_as_user_error() {
+    var iaeMessage =
+        "Metadata field(s) not found: never_a_real_field_zzq_123. Available fields can be"
+            + " discovered via the Contrast UI.";
+    tool.setDoExecuteHandler(
+        (pagination, params, collector) -> {
+          throw new IllegalArgumentException(iaeMessage);
+        });
+
+    var result = tool.executePipeline(1, 10, () -> TestParams.valid());
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors())
+        .as("IllegalArgumentException message must surface verbatim as the user-facing error")
+        .singleElement()
+        .isEqualTo(iaeMessage);
+    assertThat(result.errors())
+        .as("IllegalArgumentException must not be masked as a generic internal error")
+        .noneMatch(e -> e.contains("An internal error occurred"));
+  }
+
+  @Test
   void executePipeline_should_calculate_hasMorePages_with_known_total() {
     tool.setDoExecuteHandler(
         (pagination, params, collector) ->

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolTest.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolTest.java
@@ -192,6 +192,28 @@ class SingleToolTest {
   }
 
   @Test
+  void executePipeline_should_surface_illegalArgumentException_message_as_user_error() {
+    var iaeMessage =
+        "Session metadata field(s) not found for application 'app-1': nonexistent_field_xyz_12345."
+            + " Use get_session_metadata(appId) to discover available field names.";
+    tool.setDoExecuteHandler(
+        (params, collector) -> {
+          throw new IllegalArgumentException(iaeMessage);
+        });
+
+    var result = tool.executePipeline(() -> TestParams.valid());
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors())
+        .as("IllegalArgumentException message must surface verbatim as the user-facing error")
+        .singleElement()
+        .isEqualTo(iaeMessage);
+    assertThat(result.errors())
+        .as("IllegalArgumentException must not be masked as a generic internal error")
+        .noneMatch(e -> e.contains("An internal error occurred"));
+  }
+
+  @Test
   void executePipeline_should_include_params_warnings() {
     tool.setDoExecuteHandler((params, warnings) -> "result");
 

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolIT.java
@@ -127,13 +127,24 @@ public class SearchAppVulnerabilitiesToolIT
     boolean anyHasTags;
     boolean anyHasSessionMetadata;
 
+    /**
+     * App+tag pair sourced specifically for the vulnTag filter test. May reference a different app
+     * than {@link #sampleAppId} when no single app in the org has both tags and session metadata.
+     * Always sourced from the same app so the (appId, tag) pair is server-resolvable together.
+     */
+    String tagBearingAppId;
+
+    String tagBearingAppName;
+    String tagBearingTag;
+
     @Override
     public String toString() {
       return String.format(
           "TestData{appId='%s', appName='%s', totalVulns=%d, sampleVulnId='%s', "
               + "type='%s', severity='%s', status='%s', env='%s', tag='%s', "
               + "sessionField='%s', sessionValue='%s', "
-              + "anyEnvs=%s, anyTags=%s, anySessionMetadata=%s}",
+              + "anyEnvs=%s, anyTags=%s, anySessionMetadata=%s, "
+              + "tagBearingAppId='%s', tagBearingAppName='%s', tagBearingTag='%s'}",
           sampleAppId,
           sampleAppName,
           totalVulnerabilities,
@@ -147,7 +158,10 @@ public class SearchAppVulnerabilitiesToolIT
           sampleSessionValue,
           anyHasEnvironments,
           anyHasTags,
-          anyHasSessionMetadata);
+          anyHasSessionMetadata,
+          tagBearingAppId,
+          tagBearingAppName,
+          tagBearingTag);
     }
   }
 
@@ -249,10 +263,18 @@ public class SearchAppVulnerabilitiesToolIT
 
     TestData best = null;
     int bestScore = -1;
+    // First candidate (in ranked order) that exposes a non-blank tag, used as the dedicated
+    // tag-bearing app for the vulnTags filter test when the score-winning app lacks tags.
+    TestData firstTagBearing = null;
     for (var appId : rankedAppIds) {
       var candidate = sampleApp(appId, appNames.get(appId));
       if (candidate == null) {
         continue;
+      }
+      if (firstTagBearing == null
+          && candidate.sampleTag != null
+          && !candidate.sampleTag.isBlank()) {
+        firstTagBearing = candidate;
       }
       int score = scoreCandidate(candidate);
       if (score > bestScore) {
@@ -273,6 +295,15 @@ public class SearchAppVulnerabilitiesToolIT
       throw new NoTestDataException(
           "SearchAppVulnerabilitiesToolIT failed to sample any vulnerability-bearing application"
               + " — see INTEGRATION_TESTS.md");
+    }
+    // Lift tag-bearing context onto best. If best already has a tag use it directly; otherwise
+    // fall back to the first separately-discovered tagged app so the vulnTag filter test has a
+    // server-resolvable (appId, tag) pair without sacrificing best's session-metadata richness.
+    var tagSource = (best.sampleTag != null && !best.sampleTag.isBlank()) ? best : firstTagBearing;
+    if (tagSource != null) {
+      best.tagBearingAppId = tagSource.sampleAppId;
+      best.tagBearingAppName = tagSource.sampleAppName;
+      best.tagBearingTag = tagSource.sampleTag;
     }
     return best;
   }
@@ -956,16 +987,21 @@ public class SearchAppVulnerabilitiesToolIT
 
   @Test
   void searchAppVulnerabilities_should_filter_by_vulnTag() {
-    assertThat(testData.sampleTag)
+    assertThat(testData.tagBearingAppId)
         .as(
-            "vulnTags filter test requires at least one vuln with a non-blank tag in app '%s' —"
+            "vulnTags filter test requires at least one app in the org with a tag-bearing"
+                + " vulnerability — see INTEGRATION_TESTS.md")
+        .isNotBlank();
+    assertThat(testData.tagBearingTag)
+        .as(
+            "vulnTags filter test requires a non-blank tag on tagBearingAppId='%s' —"
                 + " see INTEGRATION_TESTS.md",
-            testData.sampleAppId)
+            testData.tagBearingAppId)
         .isNotBlank();
 
     var response =
         searchAppVulnerabilitiesTool.searchAppVulnerabilities(
-            testData.sampleAppId,
+            testData.tagBearingAppId,
             1,
             VULN_SAMPLE_PAGE_SIZE,
             null,
@@ -974,30 +1010,30 @@ public class SearchAppVulnerabilitiesToolIT
             null,
             null,
             null,
-            testData.sampleTag,
+            testData.tagBearingTag,
             null,
             null);
 
     assertThat(response.isSuccess())
-        .as("tag filter for '%s' must succeed", testData.sampleTag)
+        .as("tag filter for '%s' must succeed", testData.tagBearingTag)
         .isTrue();
     assertThat(response.errors()).as("tag filter must not produce errors").isEmpty();
     assertThat(response.items())
         .as(
             "tag filter '%s' must return at least one vulnerability in app '%s'",
-            testData.sampleTag, testData.sampleAppId)
+            testData.tagBearingTag, testData.tagBearingAppId)
         .isNotEmpty();
     assertThat(response.items())
         .as(
             "every returned vuln must carry tag '%s' (case-insensitive) — a vuln without that"
                 + " tag proves the filter was dropped",
-            testData.sampleTag)
+            testData.tagBearingTag)
         .allSatisfy(
             v ->
                 assertThat(v.tags())
                     .as("%s.tags vs filter", v.vulnID())
                     .isNotNull()
-                    .anyMatch(t -> t != null && t.equalsIgnoreCase(testData.sampleTag)));
+                    .anyMatch(t -> t != null && t.equalsIgnoreCase(testData.tagBearingTag)));
   }
 
   // ---------- sessionMetadataFilters (positive valid path) ----------

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolIT.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolIT.java
@@ -28,6 +28,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -93,6 +94,15 @@ public class SearchAppVulnerabilitiesToolIT
   // vulnerabilities (which are commonly on Remediated/Fixed traces).
   private static final String ALL_STATUSES =
       "Reported,Suspicious,Confirmed,NotAProblem,Remediated,Fixed,AutoRemediated";
+
+  // Cap pages walked when searching for a tag-bearing app — bounds discovery cost on large orgs.
+  private static final int TAG_DISCOVERY_PAGES = 5;
+
+  // Common vulnerability tags applied during remediation workflows. Probed as a fallback when
+  // pagination over org-wide vulns surfaces no tagged vuln — mirrors the same fallback used by
+  // SearchVulnerabilitiesToolIT and the @Tool docs themselves (e.g., "SmartFix Remediated").
+  private static final List<String> COMMON_VULN_TAG_PROBES =
+      List.of("SmartFix Remediated", "reviewed", "urgent", "false-positive");
 
   // Date format accepted by the SDK's dateParam: ISO YYYY-MM-DD.
   private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
@@ -296,6 +306,15 @@ public class SearchAppVulnerabilitiesToolIT
           "SearchAppVulnerabilitiesToolIT failed to sample any vulnerability-bearing application"
               + " — see INTEGRATION_TESTS.md");
     }
+    // The candidate loop only sees apps that surface in the first page of either org-level
+    // probe and only inspects each app's first VULN_SAMPLE_PAGE_SIZE vulns. On large orgs the
+    // tag-bearing vulns (typically on Remediated/Fixed traces) can sit deeper than that — fall
+    // back to a paginated + common-probe scan so we surface a server-resolvable (appId, tag)
+    // pair when one exists in the org. Mirrors
+    // SearchVulnerabilitiesToolIT.scanForTaggedVulnerability.
+    if (firstTagBearing == null) {
+      firstTagBearing = scanForTagBearingApp(openVulns.items(), allVulns.items());
+    }
     // Lift tag-bearing context onto best. If best already has a tag use it directly; otherwise
     // fall back to the first separately-discovered tagged app so the vulnTag filter test has a
     // server-resolvable (appId, tag) pair without sacrificing best's session-metadata richness.
@@ -318,6 +337,100 @@ public class SearchAppVulnerabilitiesToolIT
     if (v.tags() != null && !v.tags().isEmpty()) {
       taggedAppIds.add(v.appID());
     }
+  }
+
+  /**
+   * Locates a tag-bearing (appId, tag) pair when the main candidate loop didn't find one. First
+   * re-walks the org-level probe results we already have ({@code sampleApp}'s per-app probe can
+   * miss tags the org probe surfaced when paging differs); then paginates additional pages of
+   * {@code ALL_STATUSES} search; finally probes well-known tag names directly. Returns a minimal
+   * {@code TestData} carrying just {@code sampleAppId}, {@code sampleAppName}, and {@code
+   * sampleTag} — enough for {@code tagSource} to populate {@code tagBearingAppId}/{@code
+   * tagBearingTag} on {@code best} — or {@code null} if no tag-bearing app exists.
+   *
+   * <p>Mirrors {@code SearchVulnerabilitiesToolIT.scanForTaggedVulnerability} so both ITs degrade
+   * the same way on orgs whose tagged vulns sit deeper than the first discovery page.
+   */
+  private TestData scanForTagBearingApp(List<VulnLight> openVulns, List<VulnLight> allVulns)
+      throws IOException {
+    // Step 1 — re-scan the org-level probe items already in memory. taggedAppIds may be
+    // non-empty here even when firstTagBearing is null because sampleApp() only inspects each
+    // app's first VULN_SAMPLE_PAGE_SIZE vulns; the org-level result already has a usable tag.
+    var hit = pickTagBearing(openVulns);
+    if (hit != null) {
+      return hit;
+    }
+    hit = pickTagBearing(allVulns);
+    if (hit != null) {
+      return hit;
+    }
+
+    // Step 2 — paginate further pages of ALL_STATUSES search. Page 1 was already walked above,
+    // so start at page 2.
+    for (int page = 2; page <= TAG_DISCOVERY_PAGES; page++) {
+      var response =
+          searchVulnerabilitiesTool.searchVulnerabilities(
+              page, VULN_DISCOVERY_PAGE_SIZE, null, ALL_STATUSES, null, null, null, null, null);
+      if (!response.isSuccess() || response.items().isEmpty()) {
+        break;
+      }
+      hit = pickTagBearing(response.items());
+      if (hit != null) {
+        return hit;
+      }
+      if (!response.hasMorePages()) {
+        break;
+      }
+    }
+
+    // Step 3 — probe well-known vulnerability tag names directly via the vulnTags filter. If
+    // any returns results, the org seeds that tag — capture the (appId, tag) pair from the
+    // first hit. Catches orgs where tags exist but aren't surfaced in the first few pages.
+    for (var probe : COMMON_VULN_TAG_PROBES) {
+      var response =
+          searchVulnerabilitiesTool.searchVulnerabilities(
+              1, 5, null, ALL_STATUSES, null, null, null, null, probe);
+      if (!response.isSuccess()) {
+        continue;
+      }
+      for (var v : response.items()) {
+        if (v.appID() != null && !v.appID().isBlank()) {
+          log.info("Tag discovery fallback hit common probe '{}' on app '{}'", probe, v.appID());
+          return synthesizeTagBearing(v.appID(), v.appName(), probe);
+        }
+      }
+    }
+
+    log.warn(
+        "Tag discovery exhausted {} pages of {} vulns AND {} common probes without finding a"
+            + " tag-bearing app",
+        TAG_DISCOVERY_PAGES,
+        VULN_DISCOVERY_PAGE_SIZE,
+        COMMON_VULN_TAG_PROBES.size());
+    return null;
+  }
+
+  private static TestData pickTagBearing(List<VulnLight> vulns) {
+    for (var v : vulns) {
+      if (v.appID() == null || v.appID().isBlank() || v.tags() == null || v.tags().isEmpty()) {
+        continue;
+      }
+      for (var tag : v.tags()) {
+        if (tag != null && !tag.isBlank()) {
+          return synthesizeTagBearing(v.appID(), v.appName(), tag);
+        }
+      }
+    }
+    return null;
+  }
+
+  private static TestData synthesizeTagBearing(String appId, String appName, String tag) {
+    var data = new TestData();
+    data.sampleAppId = appId;
+    data.sampleAppName = appName;
+    data.sampleTag = tag;
+    data.anyHasTags = true;
+    return data;
   }
 
   /**

--- a/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolTest.java
+++ b/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolTest.java
@@ -335,8 +335,10 @@ class SearchAppVulnerabilitiesToolTest {
         .singleElement()
         .satisfies(
             error -> {
-              assertThat(error).startsWith("An internal error occurred (ref: ");
-              assertThat(error).doesNotContain("branch");
+              assertThat(error).contains("Session metadata field(s) not found");
+              assertThat(error).contains("branch");
+              assertThat(error).contains("get_session_metadata");
+              assertThat(error).doesNotContain("An internal error occurred");
             });
   }
 


### PR DESCRIPTION
## Summary

- Apply four code-review findings @dougj-contrast left on PRs #83 / #85: Lombok `@NoArgsConstructor` on `HttpRequestRedactor`, Apache `commons-validator` `UrlValidator` for HTTPS check, `LoggingKeys` constants for structured log keys, and `String.format` for the TeamServer URL error message.
- Fix a related bug found while doing the above: `IllegalArgumentException` raised from inside `PaginatedTool` / `SingleTool` execution was caught by the generic `Exception` clause, replacing actionable user-input messages (e.g. `Metadata field(s) not found: <name>...`) with generic `An internal error occurred (ref: ...)`. Two unit tests were locking in that buggy behavior — both updated.
- Stabilize `SearchAppVulnerabilitiesToolIT.searchAppVulnerabilities_should_filter_by_vulnTag` against orgs whose tagged vulns sit beyond the first discovery page — port the paginated + common-probe fallback already proven in `SearchVulnerabilitiesToolIT`.
- All changes target `main` directly. Pure refactor + bug fix on top of AIML-481 — no behavior change for any input previously accepted or rejected by the validation paths.

## Why This Change Exists

PR #83 (AIML-481 security hardening) introduced startup HTTPS validation in `ContrastSDKFactory` and the `HttpRequestRedactor` for `get_vulnerability` HTTP request capture. During review, @dougj-contrast left four suggestions where standard libraries or shared constants should replace ad-hoc code:

1. `HttpRequestRedactor` declares an explicit `private HttpRequestRedactor() {}` to suppress the implicit public constructor on a utility class — Lombok's `@NoArgsConstructor(access = PRIVATE)` does the same thing more idiomatically (see [comment](https://github.com/Contrast-Security-OSS/mcp-contrast/pull/83#discussion_r3149167777)).
2. `ContrastSDKFactory.validateConfiguration()` has two manual blocks that string-match `://`, `https`, and `http` to enforce HTTPS — Apache `commons-validator`'s `UrlValidator` covers the same ground (and more) with one library call (see [comment](https://github.com/Contrast-Security-OSS/mcp-contrast/pull/83#discussion_r3149225715), forwarded from [PR #85's discussion](https://github.com/Contrast-Security-OSS/mcp-contrast/pull/85#discussion_r3149144400)).
3. Structured-log key strings (`requestId`, `durationMs`, `httpStatus`, `exceptionType`, `errorCount`, `itemCount`, `totalItems`, `filterName`, `appId`, `vulnId`) are repeated as inline string literals across `PaginatedTool`, `SingleTool`, and `MetadataJsonFilterSpec` — extract into a `LoggingKeys` constants class so call sites are compiler-checked (see [discussion_r3149750461 + r3149760686](https://github.com/Contrast-Security-OSS/mcp-contrast/pull/83#discussion_r3149750461)).
4. The new `IllegalStateException` for an invalid TeamServer URL was assembled with multi-line `+` concatenation — collapsed into a single `String.format` template with the parameters grouped at the end.

While wiring `LoggingKeys` into the catch blocks of `PaginatedTool.executePipeline` and `SingleTool.executePipeline`, I noticed both pipelines caught `IllegalArgumentException` only via the generic `Exception` clause. Tools resolving user-supplied filter names (e.g., `resolveAppMetadataFilters`, `resolveSessionMetadataFilters`) raise `IllegalArgumentException` mid-execution with messages like `Metadata field(s) not found: foo. Available fields can be discovered via the Contrast UI.` Those messages were silently swallowed and replaced with a generic `An internal error occurred (ref: <uuid>)` string — actively misleading the LLM consumer. Two existing unit tests were asserting that buggy behavior verbatim. Fixed by adding a dedicated `IllegalArgumentException` catch and updating both tests to assert the actionable message surfaces.

Separately, `SearchAppVulnerabilitiesToolIT.searchAppVulnerabilities_should_filter_by_vulnTag` was failing on orgs where tagged vulns sit on later pages — the original discovery only sampled page 1. `SearchVulnerabilitiesToolIT` already had a paginated + common-tag-probe fallback for the same scenario. Ported it.

Addressing all of this in one PR keeps PR #83 / #85 focused on their primary scope while still landing every suggestion, and folds in the bug fix that surfaced naturally from doing the refactor.

## Approach We Chose

**Finding #1 — Lombok refactor.** Trivial — class-level `@NoArgsConstructor(access = AccessLevel.PRIVATE)` replaces the explicit no-arg constructor.

**Finding #2 — `UrlValidator`.** The two manual validation blocks collapse into one helper:

```java
private static String buildCandidateUrl(String protocol, String hostName) {
  var bareHost = hostName.strip();
  if (bareHost.contains(SCHEME_SEPARATOR)) {
    return bareHost;                           // hostName already includes a scheme
  }
  var effectiveProtocol =
      StringUtils.hasText(protocol) ? protocol.strip().toLowerCase() : "https";
  return effectiveProtocol + SCHEME_SEPARATOR + bareHost;
}
```

Then a single `HTTPS_URL_VALIDATOR.isValid(candidateUrl)` check, where `HTTPS_URL_VALIDATOR = new UrlValidator(new String[]{"https"}, ALLOW_LOCAL_URLS)`. The error message echoes both inputs so users can diagnose which is wrong:

> `Invalid or insecure Contrast TeamServer URL '<url>' (resolved from contrast.api.protocol='<p>', CONTRAST_HOST_NAME='<h>'). The MCP server requires an https:// URL with a valid hostname.`

**Tradeoff:** the previous code emitted three different per-branch messages (`Insecure protocol`, `not 'https://'`, `CONTRAST_HOST_NAME insecure scheme`). Those collapse into one consolidated message that always echoes both inputs — slightly less directly diagnostic, but the inputs are right there in the message so the user can still see exactly what they configured.

**Soak window:** `commons-validator:1.10.1` was published 2025-11-14, well past the 7-day soak window required by ENTSEC-1742.

**Finding #3 — `LoggingKeys` constants.** New class `tool/base/LoggingKeys.java` holds every structured-log key currently used in `PaginatedTool`, `SingleTool`, and `MetadataJsonFilterSpec`. Includes `APP_ID` and `VULN_ID` for the domain-identifier use cases Doug called out, even though those are introduced opportunistically as more tools migrate to the constants. Annotated with Lombok `@NoArgsConstructor(access = PRIVATE)` to suppress the implicit public constructor (same pattern as Finding #1). All three call sites updated to use the constants instead of inline literals.

**Finding #4 — `String.format`.** `validateConfiguration`'s `IllegalStateException` swaps `+` concatenation for a single `String.format` call. No behavior change — same message, same parameters, easier to read.

**Bug fix — `IllegalArgumentException` handling.** Add a dedicated catch clause to `PaginatedTool.executePipeline` and `SingleTool.executePipeline` that surfaces `e.getMessage()` verbatim via `handleException(...)`. Two tests in `PaginatedToolTest` and `SingleToolTest` already had `_should_swallow_*` cases asserting the buggy behavior — those become the new `_should_surface_illegalArgumentException_message_as_user_error` tests asserting the correct behavior. `SearchApplicationsToolTest` and `SearchAppVulnerabilitiesToolTest` had their assertions inverted to require the actionable message and forbid the generic one.

**Test stabilization — IT tag-bearing fallback.** `SearchAppVulnerabilitiesToolIT.performDiscovery` now decouples the tag-bearing app from the score-winning app. A new `firstTagBearing` slot tracks any candidate that exposes a non-blank tag during the main candidate loop. If still null at the end, `scanForTagBearingApp` runs three steps: (1) re-walk the org-level probe items already in memory, (2) paginate pages 2–5 of the `ALL_STATUSES` search, (3) probe four well-known tag names (`SmartFix Remediated`, `reviewed`, `urgent`, `false-positive`) directly via `vulnTags`. The discovered (`appId`, `tag`) pair is lifted onto `best.tagBearingAppId/Name/Tag`, and the test now uses those fields. Mirrors `SearchVulnerabilitiesToolIT.scanForTaggedVulnerability` so both ITs degrade the same way on orgs where tagged vulns sit deeper than the first discovery page.

## Outcome of This Change

- Less hand-rolled string parsing in the URL validator — `UrlValidator` handles port validation, IDN, IPv6, etc. that the manual code did not.
- Structured-log keys are compiler-checked; a typo'd `"requstId"` would no longer compile.
- LLM consumers of `search_*` tools now see the actual `Metadata field(s) not found: ...` / `Session metadata field(s) not found ...` messages from the resolvers, including the list of available fields. Previously every such error was masked as `An internal error occurred (ref: <uuid>)`.
- The `vulnTag` IT no longer requires a single app in the org to be both the highest-scoring candidate AND tag-bearing — separates the two preconditions.
- Behavior preserved for every input combination the existing tests cover (URL validation table below in walkthrough).

## Reviewer Guide

1. Start with `ContrastSDKFactory.validateConfiguration()` — the consolidated `UrlValidator` check + `String.format` is the substantive change (Findings #2 + #4).
2. Then `buildCandidateUrl` — the small helper that decides when `hostName` already supplies the scheme.
3. Then `tool/base/LoggingKeys.java` — new constants class, then the three call sites (`PaginatedTool`, `SingleTool`, `MetadataJsonFilterSpec`) that consume it.
4. Then `PaginatedTool.executePipeline` + `SingleTool.executePipeline` — the new `catch (IllegalArgumentException e)` block that surfaces `e.getMessage()`. The fix is the same shape in both files.
5. Skim `HttpRequestRedactor` — pure annotation swap (Finding #1).
6. Then the test files: `PaginatedToolTest` / `SingleToolTest` add the new `_should_surface_illegalArgumentException_message_as_user_error` cases; `SearchApplicationsToolTest` / `SearchAppVulnerabilitiesToolTest` invert their assertions; `ContrastSDKFactoryTest` updates six assertions to the new consolidated message shape (no test cases added or removed).
7. Then `SearchAppVulnerabilitiesToolIT` — the `tagBearingAppId/Name/Tag` slots, the `scanForTagBearingApp` fallback, and the rewired `searchAppVulnerabilities_should_filter_by_vulnTag` test.
8. Finally `pom.xml` — version property + `commons-validator` dependency.

## Logic Walkthrough

### 1. Problem framing

PR #83's `validateConfiguration` had two adjacent blocks: one rejecting bad `protocol` values (with three distinct error messages), and one rejecting `hostName` values whose scheme was not `https://`. Both blocks were manual string matching against `://`, `"https"`, and `.toLowerCase()`. The new `IllegalStateException` for the consolidated check was also concatenated with `+` over multiple lines.

Separately, structured-log key strings were sprinkled across the base tool classes as inline literals — fine while there were two of them, awkward as the surface grew. And `IllegalArgumentException` raised by user-input resolvers was being swallowed by the generic `Exception` clause that wraps every `executePipeline` method.

### 2. Core implementation — URL validation

The replacement is one `UrlValidator.isValid(...)` call. To use it we need a candidate URL string. `buildCandidateUrl` produces that:
- If `hostName` already includes `://`, return it as-is — `UrlValidator` will reject it if its scheme is not `https`.
- Otherwise, prepend the configured `protocol` (defaulting to `https` when blank/null) and `://`.

This deliberately preserves the existing behavior where `hostName=http://x, protocol=https` is rejected (the user's explicit insecure scheme wins; we don't silently rewrite it).

The `IllegalStateException` then uses one `String.format` template instead of seven `+` operations.

### 3. Core implementation — `LoggingKeys`

`LoggingKeys` is a final class with `@NoArgsConstructor(access = PRIVATE)` and a set of `public static final String` constants. Each constant pairs name-to-value: `REQUEST_ID = "requestId"`, `DURATION_MS = "durationMs"`, etc. Call sites change from `addKeyValue("requestId", id)` to `addKeyValue(LoggingKeys.REQUEST_ID, id)` — same wire format on the structured log line, but every key is now a compile-time symbol.

### 4. Core implementation — surfacing `IllegalArgumentException`

The new clauses sit between the existing `HttpResponseException` and `Exception` catches:

```java
} catch (IllegalArgumentException e) {
  // User-input rejection raised mid-execution (e.g., resolveAppMetadataFilters when an
  // unknown field name is supplied). The exception message is the actionable user message.
  return handleException(e, pagination, requestId, e.getMessage());
} catch (Exception e) { ... }
```

The fourth argument to `handleException` is the user-facing message string, which the base class folds into the response's `errors` array. By passing `e.getMessage()` we propagate the resolver's actionable text. The trailing generic `Exception` catch keeps its original `An internal error occurred (ref: ...)` message for genuinely unexpected failures.

### 5. Core implementation — IT tag-bearing fallback

Three new fields on `TestData` (`tagBearingAppId`, `tagBearingAppName`, `tagBearingTag`) carry the tag-bearing context independently from `sampleAppId`. During discovery, if any candidate exposes a non-blank tag we capture it as `firstTagBearing`; if no candidate has one, `scanForTagBearingApp` runs the three-step fallback (re-walk org probes → paginate pages 2–5 → probe common tag names). At the end, `tagSource = best.hasTag ? best : firstTagBearing`, and we lift its appId/name/tag onto `best.tagBearing*`. The test now asserts both `testData.tagBearingAppId` and `testData.tagBearingTag` are non-blank with `.as(...)` clauses pointing back to `INTEGRATION_TESTS.md`, and uses those fields when calling `searchAppVulnerabilities`.

### 6. Edge cases and safeguards (URL validation parity)

| Input | Old behavior | New behavior | Same? |
|---|---|---|---|
| `protocol=http` | throw | throw | yes |
| `protocol=HTTP` | throw | throw | yes |
| `protocol=ftp` | throw | throw | yes |
| `protocol=https://` | throw | throw (URL becomes `https://://host`) | yes |
| `protocol=https` | pass | pass | yes |
| `protocol=HTTPS` | pass | pass | yes |
| `protocol=` (blank) | pass | pass | yes |
| `protocol=null` | pass | pass | yes |
| `hostName=http://x` | throw | throw | yes |
| `hostName=HTTP://x` | throw | throw | yes |
| `hostName=https://x` | pass | pass | yes |
| `hostName=x` (no scheme) | pass | pass | yes |

### 7. How the tests prove it

- **URL validation (`ContrastSDKFactoryTest`)** — already covers every row in the table above (12 protocol/hostname tests, plus three for missing-credential cases). Six assertions are updated from the old per-branch messages to the new consolidated `Invalid or insecure Contrast TeamServer URL` shape — they continue to assert that the offending input is echoed back to the user. No test cases removed.
- **`IllegalArgumentException` surfacing (`PaginatedToolTest`, `SingleToolTest`)** — two new tests stub `doExecuteHandler` to throw an `IllegalArgumentException` with a realistic resolver message, then assert (a) the `errors` array contains that exact message verbatim and (b) does not contain `An internal error occurred`. Both assertions carry `.as(...)` clauses naming the contract.
- **`IllegalArgumentException` surfacing (`SearchApplicationsToolTest`, `SearchAppVulnerabilitiesToolTest`)** — pre-existing tests that asserted the buggy behavior are inverted. They now require `Metadata field(s) not found` / `Session metadata field(s) not found`, the offending field name (`unknownField`, `branch`), and either `Available fields` or `get_session_metadata`, while also asserting `An internal error occurred` is absent.
- **IT tag-bearing fallback (`SearchAppVulnerabilitiesToolIT`)** — `scanForTagBearingApp` is exercised on every `performDiscovery` run that doesn't surface a tag in the main candidate loop. The test's preconditions now fail loudly with `requires at least one app in the org with a tag-bearing vulnerability — see INTEGRATION_TESTS.md` if even the fallback finds nothing.

## What Changed

### `pom.xml`
- Adds `commons-validator.version` property and `commons-validator:commons-validator` dependency.

### `src/main/java/.../config/ContrastSDKFactory.java`
- Imports `UrlValidator`.
- Adds static `HTTPS_URL_VALIDATOR` and `SCHEME_SEPARATOR` constants.
- Replaces the two manual validation blocks with one `UrlValidator.isValid(...)` check.
- Adds `buildCandidateUrl` helper.
- Replaces multi-line `+` concatenation in the `IllegalStateException` with `String.format`.

### `src/main/java/.../tool/base/LoggingKeys.java` (new)
- Constants for every structured-log key used in `PaginatedTool`, `SingleTool`, and `MetadataJsonFilterSpec`, plus `APP_ID` / `VULN_ID` for domain identifiers.

### `src/main/java/.../tool/base/PaginatedTool.java`
- Adds `catch (IllegalArgumentException e)` clause that surfaces `e.getMessage()` verbatim.
- Replaces inline log-key literals with `LoggingKeys.*` constants.

### `src/main/java/.../tool/base/SingleTool.java`
- Same `IllegalArgumentException` catch + `LoggingKeys.*` migration as `PaginatedTool`.

### `src/main/java/.../tool/validation/MetadataJsonFilterSpec.java`
- Replaces inline log-key literal with `LoggingKeys.*`.

### `src/main/java/.../tool/vulnerability/HttpRequestRedactor.java`
- Class-level `@NoArgsConstructor(access = AccessLevel.PRIVATE)` replaces the explicit private no-arg constructor.

### `src/test/java/.../config/ContrastSDKFactoryTest.java`
- Six assertions updated from per-branch messages to the consolidated `Invalid or insecure Contrast TeamServer URL` + input-echo shape.

### `src/test/java/.../tool/base/PaginatedToolTest.java` + `SingleToolTest.java`
- Add `_should_surface_illegalArgumentException_message_as_user_error` test (one each).

### `src/test/java/.../tool/application/SearchApplicationsToolTest.java`
- Inverted assertions on the unknown-metadata-field test to require the actionable message and forbid the generic one.

### `src/test/java/.../tool/vulnerability/SearchAppVulnerabilitiesToolTest.java`
- Same inversion for the unknown-session-metadata-field test.

### `src/test/java/.../tool/vulnerability/SearchAppVulnerabilitiesToolIT.java`
- New `tagBearingAppId/Name/Tag` slots on `TestData`; `firstTagBearing` candidate tracking; `scanForTagBearingApp` paginated-and-probe fallback (mirrors `SearchVulnerabilitiesToolIT`); `searchAppVulnerabilities_should_filter_by_vulnTag` rewired to use the tag-bearing fields.

## Testing

- **Unit tests:** `make format && make check-test` — all unit tests pass, including the four new / inverted assertion cases and the existing `ContrastSDKFactoryTest` matrix.
- **Integration tests:** `mvn verify` — `SearchAppVulnerabilitiesToolIT.searchAppVulnerabilities_should_filter_by_vulnTag` now passes on orgs whose tagged vulns sit beyond the first discovery page; the rest of the IT suite is unaffected (changes to startup `@PostConstruct` validation and the redactor's constructor are smoke-covered by Spring booting at all).
- **Coverage:** the existing `ContrastSDKFactoryTest` already covers every protocol/hostname combination in the URL parity table. The new `_should_surface_illegalArgumentException_message_as_user_error` cases lock in the bug fix; the inverted assertions in `SearchApplicationsToolTest` / `SearchAppVulnerabilitiesToolTest` lock it in at the resolver caller.

## Risks / Rollout / Follow-ups

- **Risk: error-message wording change (URL validation).** Anyone parsing the old error strings (`Insecure protocol`, `not 'https://'`, `CONTRAST_HOST_NAME` + scheme prefix) would break. These are startup misconfiguration messages, not API outputs — unlikely to be parsed by anything outside the test suite.
- **Risk: `UrlValidator` behavior drift.** `UrlValidator` may accept or reject edge cases (IDN, IPv6, unusual ports) differently from the previous string-matching code. The behavior table above confirms parity for every documented input; anything outside that range is governed by `commons-validator`'s URL grammar going forward, which is more correct than the previous regex-style checks.
- **Risk: behavior change for `IllegalArgumentException` callers.** Any code path that intentionally relied on `IllegalArgumentException` being masked as `An internal error occurred` will now see the underlying message. Surveyed: only `resolveAppMetadataFilters` and `resolveSessionMetadataFilters` raise it on this code path, and both produce user-actionable messages by design. No internal invariant violations route through these pipelines as `IllegalArgumentException`.
- **Risk: IT discovery cost.** `scanForTagBearingApp` is bounded — capped at 5 pages and 4 common-tag probes. Only runs when the main candidate loop didn't find a tagged vuln. Mirrors the same bound in `SearchVulnerabilitiesToolIT`.
- **Rollout:** No migration. Drop-in replacement at startup time, plus an error-message improvement that only ever surfaces messages that were already meant for users.
- **Follow-ups:** None planned. `LoggingKeys` is opportunistically extended as more tools migrate to the constants — not a blocker.
