### PR TITLE
[ENTSEC-0] - Updating WizCLI & Scan Commands

### DIFF
--- a/.github/workflows/wiz-scan.yaml
+++ b/.github/workflows/wiz-scan.yaml
@@ -8,6 +8,11 @@ on:
 jobs:
   wiz-scan:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      POLICY: "Block-VM" # Set the desired Wiz CLI policy to use
     permissions:
       id-token: write
       contents: read
@@ -22,7 +27,7 @@ jobs:
         run: curl -o wizcli https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64 && chmod +x wizcli
 
       - name: Run Wiz CLI container image scan
-        run: ./wizcli scan container-image contrast-mcp:dev --client-id "$WIZ_CLIENT_ID" --client-secret "$WIZ_CLIENT_SECRET" --assist-migration --policies "Block-VM" --csv-output-file="mcp-contrast-wiz-report.zip" --by-policy-hits="BLOCK" --show-ignored-by-grace-period
+        run: ./wizcli scan container-image contrast-mcp:dev --client-id "$WIZ_CLIENT_ID" --client-secret "$WIZ_CLIENT_SECRET" --assist-migration --policies "$POLICY" --csv-output-file="mcp-contrast-wiz-report.zip" --by-policy-hits="BLOCK" --show-ignored-by-grace-period
         env:
           WIZ_CLIENT_ID: ${{ secrets.WIZ_CLIENT_ID }}
           WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}


### PR DESCRIPTION
Wiz CLI v0.x has been deprecated by Wiz. Updating to Wiz CLI v1.x. To prevent scan failures an upgrade to the new version of Wiz CLI is needed to be completed.

Changes:
- Updated Wiz CLI Download URL to point to new v1.x Endpoint
- Updated Wiz CLI Command Set for new format and functionality