### PR TITLE
Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      maven-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Adds missing grouped updates for the maven ecosystem. The github-actions entry already had groups; this adds the same for maven to prevent individual PRs per dependency in future runs.