### PR TITLE
AIML-758: address PR #124 and #125 code review feedback

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -11,7 +11,7 @@
       <property name="severity" value="error"/>
     </module>
     <module name="RegexpSinglelineJava">
-      <property name="format" value="^\s+com\.[a-z]+\.[a-zA-Z.]+\.[A-Z][a-zA-Z]+\s"/>
+      <property name="format" value="^\s+(com|java|org|io|net)\.[a-z]+\.[a-zA-Z.]+\.[A-Z][a-zA-Z]+[\s&lt;(]"/>
       <property name="message" value="Use import instead of fully-qualified class name"/>
       <property name="severity" value="error"/>
       <property name="ignoreComments" value="true"/>

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesTool.java
@@ -21,7 +21,6 @@ import com.contrast.labs.ai.mcp.contrast.tool.base.SingleToolResponse;
 import com.contrast.labs.ai.mcp.contrast.tool.base.WarningCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.vulnerability.params.ListVulnerabilityTypesParams;
 import com.contrastsecurity.models.Rules;
-import java.util.ArrayList;
 import java.util.List;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.annotation.Tool;
@@ -69,13 +68,12 @@ public class ListVulnerabilityTypesTool
 
     if (rules == null || rules.getRules() == null) {
       collector.warn("No rules returned from Contrast API");
-      return new ArrayList<>();
+      return List.of();
     }
 
-    // Extract rule names, trim whitespace, filter out null/empty, and sort alphabetically
     return rules.getRules().stream()
         .map(Rules.Rule::getName)
-        .filter(name -> name != null && !name.trim().isEmpty())
+        .filter(name -> name != null && !name.isBlank())
         .map(String::trim)
         .sorted()
         .toList();

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/CoreBoundaryTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/CoreBoundaryTest.java
@@ -65,15 +65,15 @@ class CoreBoundaryTest {
           new LocalOnlyPattern(
               "Spring AI transport/runtime dependency", "org.springframework.ai.support"),
           new LocalOnlyPattern("Spring application configuration", "@Configuration"),
-          new LocalOnlyPattern("local SDK factory", "ContrastSDKFactory"),
+          new LocalOnlyPattern("local SDK class", "ContrastSDK"),
           new LocalOnlyPattern("local SDK extension factory", "SDKExtensionFactory"),
           new LocalOnlyPattern("local SDK API client", "SdkApiClient"),
           new LocalOnlyPattern("local SDK helper/cache implementation", "SDKHelper"),
           new LocalOnlyPattern("stdio application bootstrap", "McpContrastApplication"),
           new LocalOnlyPattern("local SDK helper/cache implementation", "com.google.common.cache"),
           new LocalOnlyPattern("local-only raw SARIF tool", "get_scan_results"),
-          new LocalOnlyPattern("local-only raw SARIF tool", "sarif"),
-          new LocalOnlyPattern("local-only raw SARIF tool", "SARIF"));
+          new LocalOnlyPattern("local-only raw SARIF tool", "GetSastResultsTool"),
+          new LocalOnlyPattern("local-only raw SARIF tool", "SarifResult"));
 
   @Test
   void core_should_include_current_shared_support_types() throws IOException {

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseToolAuthenticationStrategyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseToolAuthenticationStrategyTest.java
@@ -22,7 +22,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.ai.chat.model.ToolContext;
 
 class BaseToolAuthenticationStrategyTest {
@@ -49,7 +53,7 @@ class BaseToolAuthenticationStrategyTest {
   void executePipeline_should_bind_configured_strategy_before_doExecute_and_close_afterward() {
     var events = new ArrayList<String>();
     var tool = new RecordingSingleTool(events);
-    var context = new ToolContext(java.util.Map.of("requestId", "req-123"));
+    var context = new ToolContext(Map.of("requestId", "req-123"));
     tool.setAuthenticationStrategy(
         toolContext -> {
           events.add("authenticate");
@@ -68,7 +72,7 @@ class BaseToolAuthenticationStrategyTest {
   void paginatedExecutePipeline_should_forward_toolContext_to_configured_strategy() {
     var events = new ArrayList<String>();
     var tool = new RecordingPaginatedTool(events);
-    var context = new ToolContext(java.util.Map.of("requestId", "req-456"));
+    var context = new ToolContext(Map.of("requestId", "req-456"));
     tool.setAuthenticationStrategy(
         toolContext -> {
           events.add("authenticate");
@@ -106,7 +110,7 @@ class BaseToolAuthenticationStrategyTest {
   void executePipeline_should_return_error_when_authentication_strategy_throws() {
     var events = new ArrayList<String>();
     var tool = new RecordingSingleTool(events);
-    var context = new ToolContext(java.util.Map.of("requestId", "req-123"));
+    var context = new ToolContext(Map.of("requestId", "req-123"));
     tool.setAuthenticationStrategy(
         toolContext -> {
           events.add("authenticate");
@@ -143,7 +147,7 @@ class BaseToolAuthenticationStrategyTest {
       paginatedExecutePipeline_should_bind_configured_strategy_before_doExecute_and_close_afterward() {
     var events = new ArrayList<String>();
     var tool = new RecordingPaginatedTool(events);
-    var context = new ToolContext(java.util.Map.of("requestId", "req-123"));
+    var context = new ToolContext(Map.of("requestId", "req-123"));
     tool.setAuthenticationStrategy(
         toolContext -> {
           events.add("authenticate");
@@ -162,7 +166,7 @@ class BaseToolAuthenticationStrategyTest {
   void paginatedExecutePipeline_should_return_error_when_authentication_strategy_throws() {
     var events = new ArrayList<String>();
     var tool = new RecordingPaginatedTool(events);
-    var context = new ToolContext(java.util.Map.of("requestId", "req-123"));
+    var context = new ToolContext(Map.of("requestId", "req-123"));
     tool.setAuthenticationStrategy(
         toolContext -> {
           events.add("authenticate");
@@ -179,13 +183,18 @@ class BaseToolAuthenticationStrategyTest {
     assertThat(events).containsExactly("authenticate");
   }
 
-  @Test
-  void executePipeline_unexpected_error_logs_should_not_attach_stack_traces() throws Exception {
-    for (var sourcePath : PIPELINE_SOURCES) {
-      var source = Files.readString(sourcePath, StandardCharsets.UTF_8);
+  static Stream<Path> pipelineSources() {
+    return PIPELINE_SOURCES.stream();
+  }
 
-      assertThat(source).doesNotContain(".setCause(e)");
-    }
+  // Log builders in pipeline classes must not attach the throwable — it can leak sensitive content.
+  @ParameterizedTest
+  @MethodSource("pipelineSources")
+  void executePipeline_unexpected_error_logs_should_not_attach_stack_traces(Path sourcePath)
+      throws Exception {
+    var source = Files.readString(sourcePath, StandardCharsets.UTF_8);
+
+    assertThat(source).doesNotContain(".setCause(e)");
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesToolTest.java
@@ -25,6 +25,7 @@ import com.contrastsecurity.models.Rules;
 import java.lang.reflect.Method;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -145,7 +146,7 @@ class ListVulnerabilityTypesToolTest {
     when(rules.getRules()).thenReturn(List.of(rule));
     when(contrastApiClient.getRules()).thenReturn(rules);
 
-    var toolContext = new ToolContext(java.util.Map.of("requestId", "req-123"));
+    var toolContext = new ToolContext(Map.of("requestId", "req-123"));
     var capturedContext = new AtomicReference<ToolContext>();
     tool.setAuthenticationStrategy(
         context -> {

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesToolTest.java
@@ -23,9 +23,7 @@ import static org.mockito.Mockito.when;
 import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
 import com.contrastsecurity.models.Rules;
 import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,11 +32,6 @@ import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.annotation.Tool;
 
 class ListVulnerabilityTypesToolTest {
-
-  private static final Path TOOL_SOURCE =
-      Path.of(
-          "src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/"
-              + "ListVulnerabilityTypesTool.java");
 
   private ListVulnerabilityTypesTool tool;
   private ContrastApiClient contrastApiClient;
@@ -51,9 +44,9 @@ class ListVulnerabilityTypesToolTest {
 
   @Test
   void listVulnerabilityTypes_should_return_sorted_rule_names() throws Exception {
-    var rule1 = mock(Rules.Rule.class);
-    var rule2 = mock(Rules.Rule.class);
-    var rule3 = mock(Rules.Rule.class);
+    Rules.Rule rule1 = mock();
+    Rules.Rule rule2 = mock();
+    Rules.Rule rule3 = mock();
     when(rule1.getName()).thenReturn("xss-reflected");
     when(rule2.getName()).thenReturn("sql-injection");
     when(rule3.getName()).thenReturn("cmd-injection");
@@ -66,16 +59,18 @@ class ListVulnerabilityTypesToolTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.found()).isTrue();
-    assertThat(result.data()).containsExactly("cmd-injection", "sql-injection", "xss-reflected");
+    assertThat(result.data())
+        .containsExactlyInAnyOrder("cmd-injection", "sql-injection", "xss-reflected")
+        .isSortedAccordingTo(Comparator.naturalOrder());
 
     verify(contrastApiClient).getRules();
   }
 
   @Test
   void listVulnerabilityTypes_should_filter_null_and_empty_names() throws Exception {
-    var rule1 = mock(Rules.Rule.class);
-    var rule2 = mock(Rules.Rule.class);
-    var rule3 = mock(Rules.Rule.class);
+    Rules.Rule rule1 = mock();
+    Rules.Rule rule2 = mock();
+    Rules.Rule rule3 = mock();
     when(rule1.getName()).thenReturn("sql-injection");
     when(rule2.getName()).thenReturn(null);
     when(rule3.getName()).thenReturn("   ");
@@ -92,7 +87,7 @@ class ListVulnerabilityTypesToolTest {
 
   @Test
   void listVulnerabilityTypes_should_trim_whitespace() throws Exception {
-    var rule = mock(Rules.Rule.class);
+    Rules.Rule rule = mock();
     when(rule.getName()).thenReturn("  sql-injection  ");
 
     Rules rules = mock();
@@ -144,7 +139,7 @@ class ListVulnerabilityTypesToolTest {
 
   @Test
   void listVulnerabilityTypes_should_forward_tool_context_to_base_pipeline() throws Exception {
-    var rule = mock(Rules.Rule.class);
+    Rules.Rule rule = mock();
     when(rule.getName()).thenReturn("sql-injection");
     Rules rules = mock();
     when(rules.getRules()).thenReturn(List.of(rule));
@@ -172,21 +167,5 @@ class ListVulnerabilityTypesToolTest {
 
     assertThat(toolMethod.getAnnotation(Tool.class)).isNotNull();
     assertThat(toolMethod.getParameterTypes()).containsExactly(ToolContext.class);
-  }
-
-  @Test
-  void tool_source_should_use_only_contrast_api_client_for_contrast_data_access() throws Exception {
-    var source = Files.readString(TOOL_SOURCE, StandardCharsets.UTF_8);
-
-    assertThat(source).contains("ContrastApiClient");
-    assertThat(source).contains("contrastApiClient.getRules()");
-    assertThat(source)
-        .doesNotContain("ContrastSDKFactory")
-        .doesNotContain("SDKExtensionFactory")
-        .doesNotContain("SDKHelper")
-        .doesNotContain("getContrastSDK")
-        .doesNotContain("getSDKExtension")
-        .doesNotContain("getOrgId")
-        .doesNotContain("new ContrastSDK");
   }
 }

--- a/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/McpContrastApplication.java
+++ b/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/McpContrastApplication.java
@@ -34,6 +34,7 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.support.ToolCallbacks;
 import org.springframework.ai.tool.ToolCallback;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -53,8 +54,7 @@ public class McpContrastApplication {
   }
 
   @Bean
-  public ApplicationRunner logVersion(
-      org.springframework.beans.factory.ObjectProvider<BuildProperties> buildPropertiesProvider) {
+  public ApplicationRunner logVersion(ObjectProvider<BuildProperties> buildPropertiesProvider) {
     return args -> {
       BuildProperties buildProperties = buildPropertiesProvider.getIfAvailable();
       log.info("=".repeat(SEPARATOR_WIDTH));

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityMapperTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityMapperTest.java
@@ -168,7 +168,7 @@ class VulnerabilityMapperTest {
     when(trace.getClosedTime()).thenReturn(null);
 
     // Mock application
-    var app = mock(com.contrastsecurity.models.Application.class);
+    Application app = mock();
     when(app.getId()).thenReturn("app-123");
     when(app.getName()).thenReturn("Test Application");
     when(trace.getApplication()).thenReturn(app);

--- a/hack/verify-s4b-first-tool-boundary.sh
+++ b/hack/verify-s4b-first-tool-boundary.sh
@@ -91,7 +91,7 @@ assert_contains "moved_tool_uses_contrast_api_client" "${CORE_TOOL}" 'ContrastAp
 assert_contains "moved_tool_calls_rules_through_client" "${CORE_TOOL}" 'contrastApiClient\.getRules\(\)'
 assert_contains "tool_method_declares_tool_context" "${CORE_TOOL}" 'listVulnerabilityTypes\(ToolContext toolContext\)'
 assert_contains "tool_context_forwarded_to_pipeline" "${CORE_TOOL}" 'executePipeline\(ListVulnerabilityTypesParams::of, toolContext\)'
-assert_not_contains "moved_tool_has_no_local_sdk_factory_cache_or_raw_sarif_access" "${CORE_TOOL}" 'ContrastSDKFactory|SDKExtensionFactory|SDKHelper|getContrastSDK|getSDKExtension|getOrgId|new ContrastSDK|get_scan_results|sarif|SARIF'
+assert_not_contains "moved_tool_has_no_local_sdk_factory_cache_or_raw_sarif_access" "${CORE_TOOL}" 'ContrastSDK|SDKExtensionFactory|SDKHelper|getSDKExtension|getOrgId|get_scan_results|GetSastResultsTool|SarifResult'
 assert_not_contains "moved_tool_has_no_hidden_auth_or_org_parameters" "${CORE_TOOL}" 'orgId|organizationId|organizationUuid|bearer|token|apiKey|serviceKey|credential'
 
 CORE_TOOL_COUNT="$(


### PR DESCRIPTION
**Jira:** [AIML-758](https://contrast.atlassian.net/browse/AIML-758)

## Summary

Address code review feedback from two PRs:
- All 8 findings from [@JacobMagesHaskinsContrast's review on PR #124](https://github.com/Contrast-Security-OSS/mcp-contrast/pull/124#pullrequestreview-2898213539) — production code hygiene, test standard compliance, and boundary test hardening
- All 3 findings from [@Alex-Contrast](https://github.com/Contrast-Security-OSS/mcp-contrast/pull/125) and [@dougj-contrast](https://github.com/Contrast-Security-OSS/mcp-contrast/pull/125) reviews on PR #125 — FQCN cleanup, parameterized tests, and security rationale documentation

## Why This Change Exists

PR #124 introduced the first shared tool (`list_vulnerability_types`) into `contrast-mcp-core`. The code review identified issues that would compound during Slice 8 when 11 more tools move into core — a redundant stream operation that would get copy-pasted, a per-tool boundary test that doesn't scale, and fragile SARIF substring patterns that would false-positive on legitimate code.

PR #125 added the S4C local parity proof and auth pipeline hardening. Review feedback identified a fully-qualified class name usage, a for-loop that should be a parameterized test, and a source-code assertion that needed a comment explaining the security rationale.

## What Changed

### PR #124 review feedback

#### `ListVulnerabilityTypesTool.java`
- Removed redundant double `.trim()` — filter now uses `isBlank()` (no allocation), single `.map(String::trim)` does the actual trimming
- `new ArrayList<>()` → `List.of()` for the empty-return path, matching the immutable `.toList()` on the happy path
- Removed restate-the-code comment that duplicated what the stream pipeline already says

#### `ListVulnerabilityTypesToolTest.java`
- `mock(Rules.Rule.class)` → typed `Rules.Rule rule = mock()` at all 5 call sites per CLAUDE.md/Checkstyle convention
- Sort assertion changed from `containsExactly` (conflates content + order) to `containsExactlyInAnyOrder` + `isSortedAccordingTo(Comparator.naturalOrder())` per CLAUDE.md testing standards
- Deleted `tool_source_should_use_only_contrast_api_client_for_contrast_data_access` — redundant with module-wide `CoreBoundaryTest` which already walks every `.java` file in core. The per-tool source-scan test doesn't generalize and would need to be duplicated into every tool's test class during Slice 8

#### `CoreBoundaryTest.java` (permanent module-wide invariant)
- `ContrastSDKFactory` → `ContrastSDK` — bare `ContrastSDK` subsumes `ContrastSDKFactory` while also catching direct `import com.contrastsecurity.sdk.ContrastSDK` or field declarations that the narrower pattern would miss
- `sarif` / `SARIF` → `GetSastResultsTool` / `SarifResult` — replaced fragile bare-substring patterns that would false-positive on legitimate code (Javadoc SARIF references, variables like `sarifReport`) with specific class names that represent actual boundary violations

#### `verify-s4b-first-tool-boundary.sh` (temporary gate)
- Aligned regex with the same `CoreBoundaryTest` fixes: `ContrastSDK` subsumes redundant alternates, SARIF patterns replaced with specific class names

### PR #125 review feedback

#### `BaseToolAuthenticationStrategyTest.java` ([@dougj-contrast](https://github.com/Contrast-Security-OSS/mcp-contrast/pull/125), [@Alex-Contrast](https://github.com/Contrast-Security-OSS/mcp-contrast/pull/125))
- Replaced `java.util.Map.of()` FQCN with `Map.of()` and added import (dougj-contrast)
- Converted source-scanning for-loop to `@ParameterizedTest` with `@MethodSource("pipelineSources")` — each pipeline source file now gets its own test invocation with a clear name in the test report (dougj-contrast)
- Added security rationale comment to `.setCause(e)` assertion: log builders in pipeline classes must not attach the throwable because it can leak sensitive content (Alex-Contrast)

#### `checkstyle.xml`
- Broadened FQCN regex to catch `java.*`, `org.*`, `io.*`, `net.*` prefixes (previously only caught `com.*`) — triggered by the `java.util.Map` FQCN finding

#### `McpContrastApplication.java`, `ListVulnerabilityTypesToolTest.java`, `VulnerabilityMapperTest.java`
- Fixed pre-existing FQCN violations caught by the broadened regex

## Testing

- `make check-test` passes: 709 tests, 0 failures, formatting clean, static analysis clean
- S3C workflow alignment gate passes (38 assertions)
- S4B first-tool boundary gate passes with updated regex


[AIML-758]: https://contrast.atlassian.net/browse/AIML-758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
