### PR TITLE
[STACKED] AIML-763 add cursor pagination core abstraction for dataplatform tools

### DIFF
--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorExecutionResult.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorExecutionResult.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool.base;
+
+import java.util.List;
+import org.springframework.lang.Nullable;
+
+/**
+ * Intermediate result from cursor-backed tool execution before final response building.
+ *
+ * @param <T> item type
+ * @param items page items
+ * @param nextCursor opaque continuation token returned by the backend, or null
+ * @param hasMore true when another page can be fetched
+ */
+public record CursorExecutionResult<T>(
+    List<T> items, @Nullable String nextCursor, boolean hasMore) {
+
+  public CursorExecutionResult {
+    items = items != null ? List.copyOf(items) : List.of();
+  }
+
+  public static <T> CursorExecutionResult<T> of(
+      List<T> items, @Nullable String nextCursor, boolean hasMore) {
+    return new CursorExecutionResult<>(items, nextCursor, hasMore);
+  }
+
+  public static <T> CursorExecutionResult<T> empty() {
+    return new CursorExecutionResult<>(List.of(), null, false);
+  }
+}

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2025 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool.base;
+
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.MAX_PAGE_SIZE;
+
+import com.contrastsecurity.exceptions.HttpResponseException;
+import com.contrastsecurity.exceptions.ResourceNotFoundException;
+import com.contrastsecurity.exceptions.UnauthorizedException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.lang.Nullable;
+
+/**
+ * Abstract base class for cursor/keyset-backed MCP list tools. Subclasses must treat cursor values
+ * as opaque pass-through continuation tokens.
+ *
+ * @param <P> tool parameter type
+ * @param <R> result item type
+ */
+@Slf4j
+public abstract class CursorPaginatedTool<P extends ToolParams, R> extends BaseTool {
+
+  private static final int REQUEST_ID_PREFIX_LENGTH = 8;
+
+  /**
+   * Returns the maximum page size for this tool. Override for narrower endpoint limits.
+   *
+   * @return maximum page size
+   */
+  protected int getMaxPageSize() {
+    return MAX_PAGE_SIZE;
+  }
+
+  protected final CursorToolResponse<R> executePipeline(
+      @Nullable String cursor, @Nullable Integer pageSize, Supplier<P> paramsSupplier) {
+    return executePipeline(cursor, pageSize, paramsSupplier, null);
+  }
+
+  protected final CursorToolResponse<R> executePipeline(
+      @Nullable String cursor,
+      @Nullable Integer pageSize,
+      Supplier<P> paramsSupplier,
+      @Nullable ToolContext toolContext) {
+
+    var requestId = UUID.randomUUID().toString().substring(0, REQUEST_ID_PREFIX_LENGTH);
+    long startTime = System.currentTimeMillis();
+
+    var pagination = CursorPaginationParams.of(cursor, pageSize, getMaxPageSize());
+    var params = paramsSupplier.get();
+    var collector = WarningCollector.forContext(Map.of(LoggingKeys.REQUEST_ID, requestId));
+    pagination.warnings().forEach(collector::warn);
+    params.warnings().forEach(collector::warn);
+
+    if (!params.isValid()) {
+      logValidationError(requestId, params.errors(), pagination.cursorPresence());
+      return CursorToolResponse.validationError(pagination.pageSize(), params.errors());
+    }
+
+    try (var ignored = authenticate(toolContext)) {
+      var result = doExecute(pagination, params, collector);
+      var duration = System.currentTimeMillis() - startTime;
+
+      return buildSuccessResponse(result, pagination, collector, duration, requestId);
+
+    } catch (UnauthorizedException e) {
+      return handleException(e, pagination, requestId, mapHttpErrorCode(401));
+    } catch (ResourceNotFoundException e) {
+      return handleException(e, pagination, requestId, "Resource not found");
+    } catch (HttpResponseException e) {
+      return handleHttpResponseException(e, pagination, requestId, collector);
+    } catch (IllegalArgumentException e) {
+      return handleException(e, pagination, requestId, e.getMessage());
+    } catch (Exception e) {
+      log.atError()
+          .addKeyValue(LoggingKeys.REQUEST_ID, requestId)
+          .addKeyValue(LoggingKeys.CURSOR, pagination.cursorPresence())
+          .addKeyValue(LoggingKeys.EXCEPTION_TYPE, e.getClass().getSimpleName())
+          .setMessage("Request failed unexpectedly")
+          .log();
+      return CursorToolResponse.error(
+          pagination.pageSize(), "An internal error occurred (ref: " + requestId + ")");
+    }
+  }
+
+  /**
+   * Subclasses implement cursor-backed execution.
+   *
+   * @param pagination validated cursor pagination params
+   * @param params validated tool-specific params
+   * @param collector warning accumulator
+   * @return cursor execution result
+   * @throws Exception from downstream clients or processing
+   */
+  protected abstract CursorExecutionResult<R> doExecute(
+      CursorPaginationParams pagination, P params, WarningCollector collector) throws Exception;
+
+  private CursorToolResponse<R> handleException(
+      Exception e, CursorPaginationParams pagination, String requestId, String userMessage) {
+    log.atWarn()
+        .addKeyValue(LoggingKeys.REQUEST_ID, requestId)
+        .addKeyValue(LoggingKeys.CURSOR, pagination.cursorPresence())
+        .addKeyValue(LoggingKeys.EXCEPTION_TYPE, e.getClass().getSimpleName())
+        .setMessage("Request failed")
+        .log();
+    return CursorToolResponse.error(pagination.pageSize(), userMessage);
+  }
+
+  private CursorToolResponse<R> handleHttpResponseException(
+      HttpResponseException e,
+      CursorPaginationParams pagination,
+      String requestId,
+      WarningCollector collector) {
+
+    String errorMessage = mapHttpErrorCode(e.getCode());
+
+    log.atWarn()
+        .addKeyValue(LoggingKeys.REQUEST_ID, requestId)
+        .addKeyValue(LoggingKeys.CURSOR, pagination.cursorPresence())
+        .addKeyValue(LoggingKeys.HTTP_STATUS, e.getCode())
+        .setMessage("API error")
+        .log();
+
+    return new CursorToolResponse<>(
+        List.of(),
+        pagination.pageSize(),
+        null,
+        false,
+        List.of(errorMessage),
+        collector.snapshot(),
+        null);
+  }
+
+  private CursorToolResponse<R> buildSuccessResponse(
+      CursorExecutionResult<R> result,
+      CursorPaginationParams pagination,
+      WarningCollector collector,
+      long duration,
+      String requestId) {
+
+    if (result.items().isEmpty() && !result.hasMore()) {
+      collector.warn("No results found matching the specified criteria.");
+    }
+
+    logSuccess(requestId, duration, result.items().size(), pagination.cursorPresence());
+
+    return CursorToolResponse.success(
+        result.items(),
+        pagination.pageSize(),
+        result.nextCursor(),
+        result.hasMore(),
+        collector.snapshot(),
+        duration);
+  }
+
+  private void logValidationError(String requestId, List<String> errors, String cursorPresence) {
+    log.atDebug()
+        .addKeyValue(LoggingKeys.REQUEST_ID, requestId)
+        .addKeyValue(LoggingKeys.CURSOR, cursorPresence)
+        .addKeyValue(LoggingKeys.ERROR_COUNT, errors.size())
+        .setMessage("Validation failed: {}")
+        .addArgument(String.join(", ", errors))
+        .log();
+  }
+
+  private void logSuccess(String requestId, long duration, int itemCount, String cursorPresence) {
+    log.atDebug()
+        .addKeyValue(LoggingKeys.REQUEST_ID, requestId)
+        .addKeyValue(LoggingKeys.CURSOR, cursorPresence)
+        .addKeyValue(LoggingKeys.DURATION_MS, duration)
+        .addKeyValue(LoggingKeys.ITEM_COUNT, itemCount)
+        .setMessage("Request completed successfully")
+        .log();
+  }
+}

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParams.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool.base;
+
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.DEFAULT_PAGE_SIZE;
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.MAX_PAGE_SIZE;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
+
+/**
+ * Cursor pagination parameters for keyset-backed tools. Cursor values are opaque continuation
+ * tokens and must be passed through without parsing, encoding, decoding, or logging.
+ *
+ * @param cursor opaque continuation token, or null for the first page
+ * @param pageSize validated page size
+ * @param limit same as pageSize, for downstream client clarity
+ * @param warnings validation warnings
+ */
+public record CursorPaginationParams(
+    @Nullable String cursor, int pageSize, int limit, List<String> warnings) {
+
+  private static final String CURSOR_PRESENT = "present";
+  private static final String CURSOR_ABSENT = "absent";
+
+  public CursorPaginationParams {
+    cursor = StringUtils.hasText(cursor) ? cursor : null;
+    warnings = warnings != null ? List.copyOf(warnings) : List.of();
+  }
+
+  /**
+   * Parse and validate cursor pagination parameters with default max page size.
+   *
+   * @param cursor opaque cursor, null or blank for first page
+   * @param pageSize requested page size, null defaults to 50
+   * @return validated cursor pagination params
+   */
+  public static CursorPaginationParams of(@Nullable String cursor, @Nullable Integer pageSize) {
+    return of(cursor, pageSize, MAX_PAGE_SIZE);
+  }
+
+  /**
+   * Parse and validate cursor pagination parameters with a tool-specific max page size.
+   *
+   * @param cursor opaque cursor, null or blank for first page
+   * @param pageSize requested page size, null defaults to 50 unless endpoint max is narrower
+   * @param maxPageSize tool-specific maximum page size
+   * @return validated cursor pagination params
+   */
+  public static CursorPaginationParams of(
+      @Nullable String cursor, @Nullable Integer pageSize, int maxPageSize) {
+    List<String> warnings = new ArrayList<>();
+    int defaultSize = Math.min(DEFAULT_PAGE_SIZE, maxPageSize);
+    int actualSize = pageSize != null && pageSize > 0 ? pageSize : defaultSize;
+
+    if (pageSize != null && pageSize < 1) {
+      warnings.add(String.format("Invalid pageSize %d, using default %d", pageSize, defaultSize));
+      actualSize = defaultSize;
+    } else if (pageSize != null && pageSize > maxPageSize) {
+      warnings.add(
+          String.format(
+              "Requested pageSize %d exceeds maximum %d, capped to %d",
+              pageSize, maxPageSize, maxPageSize));
+      actualSize = maxPageSize;
+    }
+
+    return new CursorPaginationParams(cursor, actualSize, actualSize, warnings);
+  }
+
+  /**
+   * Cursor pagination uses soft validation only; invalid page sizes are corrected with warnings.
+   *
+   * @return true always
+   */
+  public boolean isValid() {
+    return true;
+  }
+
+  /**
+   * Returns a sanitized cursor presence marker suitable for logs and metrics.
+   *
+   * @return "present" when a cursor was supplied, otherwise "absent"
+   */
+  public String cursorPresence() {
+    return cursor == null ? CURSOR_ABSENT : CURSOR_PRESENT;
+  }
+}

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorToolResponse.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorToolResponse.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool.base;
+
+import java.util.List;
+import org.springframework.lang.Nullable;
+
+/**
+ * Response wrapper for cursor-backed MCP list tools. It intentionally exposes only cursor
+ * continuation metadata, not random-access pagination metadata.
+ *
+ * @param <T> item type
+ * @param items page items
+ * @param pageSize page size used
+ * @param nextCursor opaque continuation token, or null when absent
+ * @param hasMore true when another page can be fetched
+ * @param errors validation or execution errors
+ * @param warnings non-fatal warnings
+ * @param durationMs execution duration in milliseconds
+ */
+public record CursorToolResponse<T>(
+    List<T> items,
+    int pageSize,
+    @Nullable String nextCursor,
+    boolean hasMore,
+    List<String> errors,
+    List<String> warnings,
+    @Nullable Long durationMs) {
+
+  public CursorToolResponse {
+    items = items != null ? List.copyOf(items) : List.of();
+    errors = errors != null ? List.copyOf(errors) : List.of();
+    warnings = warnings != null ? List.copyOf(warnings) : List.of();
+  }
+
+  /**
+   * Returns true if there are no errors.
+   *
+   * @return true if successful
+   */
+  public boolean isSuccess() {
+    return errors.isEmpty();
+  }
+
+  public static <T> CursorToolResponse<T> success(
+      List<T> items,
+      int pageSize,
+      @Nullable String nextCursor,
+      boolean hasMore,
+      List<String> warnings,
+      @Nullable Long durationMs) {
+    return new CursorToolResponse<>(
+        items, pageSize, nextCursor, hasMore, List.of(), warnings, durationMs);
+  }
+
+  public static <T> CursorToolResponse<T> validationError(int pageSize, List<String> errors) {
+    return new CursorToolResponse<>(List.of(), pageSize, null, false, errors, List.of(), null);
+  }
+
+  public static <T> CursorToolResponse<T> error(int pageSize, String errorMessage) {
+    return new CursorToolResponse<>(
+        List.of(), pageSize, null, false, List.of(errorMessage), List.of(), null);
+  }
+}

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/LoggingKeys.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/LoggingKeys.java
@@ -29,6 +29,7 @@ import lombok.NoArgsConstructor;
 public final class LoggingKeys {
 
   public static final String APP_ID = "appId";
+  public static final String CURSOR = "cursor";
   public static final String DURATION_MS = "durationMs";
   public static final String ERROR_COUNT = "errorCount";
   public static final String EXCEPTION_TYPE = "exceptionType";

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2025 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool.base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.contrastsecurity.exceptions.HttpResponseException;
+import com.contrastsecurity.exceptions.ResourceNotFoundException;
+import com.contrastsecurity.exceptions.UnauthorizedException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CursorPaginatedToolTest {
+
+  private static final String AUTH_OR_NOT_FOUND_MESSAGE =
+      "Authentication failed or resource not found. Verify credentials and that the resource ID"
+          + " is correct.";
+  private static final String OPAQUE_CURSOR = "opaque.cursor/with+symbols==";
+
+  private TestCursorTool tool;
+
+  @BeforeEach
+  void setUp() {
+    tool = new TestCursorTool();
+  }
+
+  @Test
+  void executePipeline_should_call_doExecute_with_absent_cursor_for_first_page() {
+    var capturedPagination = new AtomicReference<CursorPaginationParams>();
+
+    tool.setDoExecuteHandler(
+        (pagination, params, collector) -> {
+          capturedPagination.set(pagination);
+          return CursorExecutionResult.of(List.of("item1"), "next-token", true);
+        });
+
+    var result = tool.executePipeline(null, null, TestParams::valid);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(capturedPagination.get().cursor()).isNull();
+    assertThat(capturedPagination.get().cursorPresence()).isEqualTo("absent");
+    assertThat(result.pageSize()).isEqualTo(50);
+    assertThat(result.nextCursor()).isEqualTo("next-token");
+    assertThat(result.hasMore()).isTrue();
+  }
+
+  @Test
+  void executePipeline_should_pass_continuation_cursor_without_parsing() {
+    var capturedCursor = new AtomicReference<String>();
+
+    tool.setDoExecuteHandler(
+        (pagination, params, collector) -> {
+          capturedCursor.set(pagination.cursor());
+          return CursorExecutionResult.of(List.of("item2"), null, false);
+        });
+
+    var result = tool.executePipeline(OPAQUE_CURSOR, 25, TestParams::valid);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(capturedCursor.get()).isEqualTo(OPAQUE_CURSOR);
+    assertThat(result.pageSize()).isEqualTo(25);
+    assertThat(result.nextCursor()).isNull();
+    assertThat(result.hasMore()).isFalse();
+  }
+
+  @Test
+  void executePipeline_should_not_execute_when_params_are_invalid() {
+    var executed = new AtomicBoolean(false);
+    tool.setDoExecuteHandler(
+        (pagination, params, collector) -> {
+          executed.set(true);
+          return CursorExecutionResult.of(List.of("item"), null, false);
+        });
+
+    var result =
+        tool.executePipeline(OPAQUE_CURSOR, 25, () -> TestParams.invalid("issueId is required"));
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors()).containsExactly("issueId is required");
+    assertThat(result.errors()).noneMatch(error -> error.contains(OPAQUE_CURSOR));
+    assertThat(result.pageSize()).isEqualTo(25);
+    assertThat(executed).isFalse();
+  }
+
+  @Test
+  void executePipeline_should_include_page_size_warnings_without_cursor_value() {
+    tool.setDoExecuteHandler(
+        (pagination, params, collector) -> CursorExecutionResult.of(List.of("item"), null, false));
+
+    var result = tool.executePipeline(OPAQUE_CURSOR, 0, TestParams::valid);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.pageSize()).isEqualTo(50);
+    assertThat(result.warnings())
+        .singleElement()
+        .satisfies(warning -> assertThat(warning).contains("Invalid pageSize 0"));
+    assertThat(result.warnings()).noneMatch(warning -> warning.contains(OPAQUE_CURSOR));
+  }
+
+  @Test
+  void executePipeline_should_preserve_warnings_when_http_response_exception_occurs() {
+    tool.setDoExecuteHandler(
+        (pagination, params, collector) -> {
+          collector.warn("Warning added before exception");
+          throw new HttpResponseException("Expired cursor", "GET", "/api/test", 400, "Bad Request");
+        });
+
+    var result =
+        tool.executePipeline(OPAQUE_CURSOR, 25, () -> TestParams.withWarning("Initial warning"));
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors()).containsExactly("API error (HTTP 400)");
+    assertThat(result.errors()).noneMatch(error -> error.contains(OPAQUE_CURSOR));
+    assertThat(result.warnings())
+        .containsExactlyInAnyOrder("Initial warning", "Warning added before exception");
+    assertThat(result.warnings()).noneMatch(warning -> warning.contains(OPAQUE_CURSOR));
+  }
+
+  @Test
+  void executePipeline_should_handle_unauthorized_exception_without_cursor_value() {
+    tool.setDoExecuteHandler(
+        (pagination, params, collector) -> {
+          throw new UnauthorizedException(
+              "Invalid credentials", "GET", "/api/test", 401, "Unauthorized");
+        });
+
+    var result = tool.executePipeline(OPAQUE_CURSOR, 25, TestParams::valid);
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors()).containsExactly(AUTH_OR_NOT_FOUND_MESSAGE);
+    assertThat(result.errors()).noneMatch(error -> error.contains(OPAQUE_CURSOR));
+  }
+
+  @Test
+  void executePipeline_should_handle_resource_not_found_without_cursor_value() {
+    tool.setDoExecuteHandler(
+        (pagination, params, collector) -> {
+          throw new ResourceNotFoundException("Not found", "GET", "/api/test", "Not Found");
+        });
+
+    var result = tool.executePipeline(OPAQUE_CURSOR, 25, TestParams::valid);
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors()).containsExactly("Resource not found");
+    assertThat(result.errors()).noneMatch(error -> error.contains(OPAQUE_CURSOR));
+  }
+
+  @Test
+  void executePipeline_should_not_expose_generic_exception_message_or_cursor_value() {
+    tool.setDoExecuteHandler(
+        (pagination, params, collector) -> {
+          throw new RuntimeException("sensitive cursor " + OPAQUE_CURSOR + " at /api/ng/org");
+        });
+
+    var result = tool.executePipeline(OPAQUE_CURSOR, 25, TestParams::valid);
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors())
+        .singleElement()
+        .satisfies(
+            error -> {
+              assertThat(error).startsWith("An internal error occurred (ref: ");
+              assertThat(error).doesNotContain(OPAQUE_CURSOR);
+              assertThat(error).doesNotContain("/api/ng/");
+              assertThat(error).doesNotContain("org");
+            });
+  }
+
+  @Test
+  void executePipeline_should_track_duration() {
+    tool.setDoExecuteHandler(
+        (pagination, params, collector) -> CursorExecutionResult.of(List.of("item"), null, false));
+
+    var result = tool.executePipeline(null, 25, TestParams::valid);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.durationMs()).isNotNull();
+    assertThat(result.durationMs()).isGreaterThanOrEqualTo(0);
+  }
+
+  private static class TestCursorTool extends CursorPaginatedTool<TestParams, String> {
+    private DoExecuteHandler handler;
+
+    void setDoExecuteHandler(DoExecuteHandler handler) {
+      this.handler = handler;
+    }
+
+    @Override
+    protected CursorExecutionResult<String> doExecute(
+        CursorPaginationParams pagination, TestParams params, WarningCollector collector)
+        throws Exception {
+      if (handler != null) {
+        return handler.execute(pagination, params, collector);
+      }
+      return CursorExecutionResult.empty();
+    }
+
+    @FunctionalInterface
+    interface DoExecuteHandler {
+      CursorExecutionResult<String> execute(
+          CursorPaginationParams pagination, TestParams params, WarningCollector collector)
+          throws Exception;
+    }
+  }
+
+  private record TestParams(boolean isValid, List<String> errors, List<String> warnings)
+      implements ToolParams {
+
+    static TestParams valid() {
+      return new TestParams(true, List.of(), List.of());
+    }
+
+    static TestParams invalid(String error) {
+      return new TestParams(false, List.of(error), List.of());
+    }
+
+    static TestParams withWarning(String warning) {
+      return new TestParams(true, List.of(), List.of(warning));
+    }
+  }
+}

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParamsTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool.base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+class CursorPaginationParamsTest {
+
+  private static final String OPAQUE_CURSOR = "opaque.cursor/with+symbols==";
+
+  @Test
+  void of_should_default_page_size_and_absent_cursor_when_inputs_null() {
+    var params = CursorPaginationParams.of(null, null);
+
+    assertThat(params.cursor()).isNull();
+    assertThat(params.pageSize()).isEqualTo(50);
+    assertThat(params.limit()).isEqualTo(50);
+    assertThat(params.cursorPresence()).isEqualTo("absent");
+    assertThat(params.warnings()).isEmpty();
+    assertThat(params.isValid()).isTrue();
+  }
+
+  @Test
+  void of_should_preserve_opaque_cursor_without_parsing() {
+    var params = CursorPaginationParams.of(OPAQUE_CURSOR, 25);
+
+    assertThat(params.cursor()).isEqualTo(OPAQUE_CURSOR);
+    assertThat(params.cursorPresence()).isEqualTo("present");
+    assertThat(params.pageSize()).isEqualTo(25);
+    assertThat(params.limit()).isEqualTo(25);
+    assertThat(params.warnings()).isEmpty();
+  }
+
+  @Test
+  void of_should_treat_blank_cursor_as_absent() {
+    var params = CursorPaginationParams.of("   ", 25);
+
+    assertThat(params.cursor()).isNull();
+    assertThat(params.cursorPresence()).isEqualTo("absent");
+  }
+
+  @Test
+  void of_should_default_invalid_page_size_without_exposing_cursor() {
+    var params = CursorPaginationParams.of(OPAQUE_CURSOR, 0);
+
+    assertThat(params.pageSize()).isEqualTo(50);
+    assertThat(params.warnings())
+        .singleElement()
+        .satisfies(warning -> assertThat(warning).contains("Invalid pageSize 0"));
+    assertThat(params.warnings()).noneMatch(warning -> warning.contains(OPAQUE_CURSOR));
+  }
+
+  @Test
+  void of_should_cap_page_size_at_default_max_without_exposing_cursor() {
+    var params = CursorPaginationParams.of(OPAQUE_CURSOR, 200);
+
+    assertThat(params.pageSize()).isEqualTo(100);
+    assertThat(params.warnings())
+        .singleElement()
+        .satisfies(
+            warning -> assertThat(warning).contains("Requested pageSize 200 exceeds maximum 100"));
+    assertThat(params.warnings()).noneMatch(warning -> warning.contains(OPAQUE_CURSOR));
+  }
+
+  @Test
+  void of_should_support_narrower_endpoint_max_page_size() {
+    var params = CursorPaginationParams.of(OPAQUE_CURSOR, 100, 50);
+
+    assertThat(params.pageSize()).isEqualTo(50);
+    assertThat(params.warnings())
+        .singleElement()
+        .satisfies(
+            warning -> assertThat(warning).contains("Requested pageSize 100 exceeds maximum 50"));
+  }
+
+  @Test
+  void record_components_should_not_expose_random_access_pagination_fields() {
+    var componentNames =
+        Arrays.stream(CursorPaginationParams.class.getRecordComponents())
+            .map(component -> component.getName())
+            .toList();
+
+    assertThat(componentNames)
+        .containsExactly("cursor", "pageSize", "limit", "warnings")
+        .doesNotContain("page", "offset", "totalPages", "totalItems");
+  }
+
+  @Test
+  void warnings_should_be_immutable() {
+    var params = CursorPaginationParams.of(null, -1);
+
+    assertThatThrownBy(() -> params.warnings().add("mutated"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+}

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorToolResponseTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorToolResponseTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool.base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CursorToolResponseTest {
+
+  @Test
+  void success_should_include_cursor_pagination_metadata_only() {
+    var response =
+        CursorToolResponse.success(List.of("item1"), 50, "next-opaque-token", true, List.of(), 10L);
+
+    assertThat(response.items()).containsExactly("item1");
+    assertThat(response.pageSize()).isEqualTo(50);
+    assertThat(response.nextCursor()).isEqualTo("next-opaque-token");
+    assertThat(response.hasMore()).isTrue();
+    assertThat(response.errors()).isEmpty();
+    assertThat(response.warnings()).isEmpty();
+    assertThat(response.durationMs()).isEqualTo(10L);
+    assertThat(response.isSuccess()).isTrue();
+  }
+
+  @Test
+  void validationError_should_create_error_without_page_fields() {
+    var response = CursorToolResponse.validationError(50, List.of("issueId is required"));
+
+    assertThat(response.items()).isEmpty();
+    assertThat(response.pageSize()).isEqualTo(50);
+    assertThat(response.nextCursor()).isNull();
+    assertThat(response.hasMore()).isFalse();
+    assertThat(response.errors()).containsExactly("issueId is required");
+    assertThat(response.durationMs()).isNull();
+    assertThat(response.isSuccess()).isFalse();
+  }
+
+  @Test
+  void error_should_create_single_error_response() {
+    var response = CursorToolResponse.error(25, "Invalid cursor");
+
+    assertThat(response.items()).isEmpty();
+    assertThat(response.pageSize()).isEqualTo(25);
+    assertThat(response.nextCursor()).isNull();
+    assertThat(response.hasMore()).isFalse();
+    assertThat(response.errors()).containsExactly("Invalid cursor");
+    assertThat(response.warnings()).isEmpty();
+  }
+
+  @Test
+  void compact_constructor_should_copy_lists() {
+    var mutableItems = new ArrayList<String>();
+    mutableItems.add("item1");
+
+    var response =
+        new CursorToolResponse<>(mutableItems, 50, null, false, List.of(), List.of(), null);
+    mutableItems.add("item2");
+
+    assertThat(response.items()).containsExactly("item1");
+  }
+
+  @Test
+  void record_components_should_exclude_total_and_random_access_page_fields() {
+    var componentNames =
+        Arrays.stream(CursorToolResponse.class.getRecordComponents())
+            .map(component -> component.getName())
+            .toList();
+
+    assertThat(componentNames)
+        .containsExactly(
+            "items", "pageSize", "nextCursor", "hasMore", "errors", "warnings", "durationMs")
+        .doesNotContain("page", "offset", "totalPages", "totalItems", "hasMorePages");
+  }
+}

--- a/docs/pr-walkthrough/pr-131-cursor-pagination-core-abstraction.html
+++ b/docs/pr-walkthrough/pr-131-cursor-pagination-core-abstraction.html
@@ -1,0 +1,1514 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PR #131 Walkthrough: Add Cursor Pagination Core Abstraction</title>
+<style>
+  :root {
+    --bg: #0d1117;
+    --surface: #161b22;
+    --surface-raised: #1c2128;
+    --border: #30363d;
+    --text: #e6edf3;
+    --text-muted: #8b949e;
+    --text-subtle: #6e7681;
+    --accent: #58a6ff;
+    --accent-soft: rgba(88,166,255,0.15);
+    --green: #3fb950;
+    --green-bg: rgba(63,185,80,0.15);
+    --green-border: rgba(63,185,80,0.4);
+    --red: #f85149;
+    --red-bg: rgba(248,81,73,0.10);
+    --yellow: #d29922;
+    --yellow-bg: rgba(210,153,34,0.15);
+    --purple: #bc8cff;
+    --purple-bg: rgba(188,140,255,0.12);
+    --orange: #f0883e;
+    --line-num: #484f58;
+    --diff-add-bg: rgba(63,185,80,0.10);
+    --diff-add-text: #aff5b4;
+    --diff-add-marker: #3fb950;
+    --diff-del-bg: rgba(248,81,73,0.10);
+    --diff-del-text: #ffa198;
+    --diff-del-marker: #f85149;
+    --diff-context-bg: transparent;
+    --code-bg: #0d1117;
+    --nav-bg: rgba(13,17,23,0.95);
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    overflow-x: hidden;
+  }
+
+  .hero {
+    background: linear-gradient(135deg, #0d1117 0%, #161b22 40%, #1a1e2e 70%, #161b22 100%);
+    border-bottom: 1px solid var(--border);
+    padding: 3rem 2rem 2.5rem;
+    text-align: center;
+  }
+  .hero-badge {
+    display: inline-block;
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-size: 0.8rem;
+    font-weight: 600;
+    padding: 0.3rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid rgba(88,166,255,0.3);
+    margin-bottom: 1rem;
+    letter-spacing: 0.03em;
+  }
+  .hero h1 {
+    font-size: 2.2rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin-bottom: 0.6rem;
+    background: linear-gradient(135deg, var(--text) 0%, var(--accent) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+  .hero .subtitle {
+    color: var(--text-muted);
+    font-size: 1.1rem;
+    max-width: 700px;
+    margin: 0 auto;
+  }
+  .hero-meta {
+    display: flex;
+    justify-content: center;
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+    flex-wrap: wrap;
+  }
+  .hero-meta-item {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+  }
+  .hero-meta-item strong { color: var(--text); }
+
+  nav {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: var(--nav-bg);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border);
+    padding: 0.6rem 2rem;
+    overflow-x: auto;
+  }
+  nav ol {
+    display: flex;
+    gap: 0.3rem;
+    list-style: none;
+    max-width: 1100px;
+    margin: 0 auto;
+    font-size: 0.82rem;
+    align-items: center;
+  }
+  nav li a {
+    color: var(--text-muted);
+    text-decoration: none;
+    padding: 0.35rem 0.7rem;
+    border-radius: 6px;
+    transition: all 0.15s;
+    white-space: nowrap;
+  }
+  nav li a:hover { color: var(--accent); background: var(--accent-soft); }
+  nav .nav-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.4em;
+    height: 1.4em;
+    border-radius: 50%;
+    background: var(--surface-raised);
+    border: 1px solid var(--border);
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    margin-right: 0.4em;
+  }
+  nav .nav-sep { color: var(--text-subtle); font-size: 0.75rem; }
+
+  main {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 2rem 2rem 6rem;
+  }
+
+  .chapter {
+    margin-bottom: 3.5rem;
+    scroll-margin-top: 4rem;
+  }
+  .chapter-header {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.8rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .chapter-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.2rem;
+    height: 2.2rem;
+    border-radius: 50%;
+    font-size: 1rem;
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+  .chapter-number.blue { background: var(--accent-soft); color: var(--accent); border: 1px solid rgba(88,166,255,0.3); }
+  .chapter-number.green { background: var(--green-bg); color: var(--green); border: 1px solid var(--green-border); }
+  .chapter-number.purple { background: var(--purple-bg); color: var(--purple); border: 1px solid rgba(188,140,255,0.3); }
+  .chapter-number.yellow { background: var(--yellow-bg); color: var(--yellow); border: 1px solid rgba(210,153,34,0.3); }
+  .chapter-number.orange { background: rgba(240,136,62,0.12); color: var(--orange); border: 1px solid rgba(240,136,62,0.3); }
+
+  .narrative {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    line-height: 1.75;
+    margin-bottom: 1.5rem;
+  }
+  .narrative strong { color: var(--text); font-weight: 600; }
+  .narrative code {
+    background: var(--surface-raised);
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+    font-size: 0.88em;
+    color: var(--accent);
+    border: 1px solid var(--border);
+  }
+
+  .callout {
+    border-radius: 8px;
+    padding: 1rem 1.2rem;
+    margin-bottom: 1.5rem;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    border: 1px solid;
+  }
+  .callout.why {
+    background: var(--accent-soft);
+    border-color: rgba(88,166,255,0.25);
+    color: var(--text);
+  }
+  .callout.why .callout-label { color: var(--accent); }
+  .callout.security {
+    background: var(--red-bg);
+    border-color: rgba(248,81,73,0.25);
+  }
+  .callout.security .callout-label { color: var(--red); }
+  .callout.note {
+    background: var(--yellow-bg);
+    border-color: rgba(210,153,34,0.25);
+  }
+  .callout.note .callout-label { color: var(--yellow); }
+  .callout.future {
+    background: var(--purple-bg);
+    border-color: rgba(188,140,255,0.25);
+  }
+  .callout.future .callout-label { color: var(--purple); }
+  .callout-label {
+    font-weight: 700;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 0.3rem;
+    display: block;
+  }
+
+  .diff-block {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+    margin-bottom: 1.5rem;
+  }
+  .diff-header {
+    display: flex;
+    align-items: center;
+    padding: 0.6rem 1rem;
+    background: var(--surface-raised);
+    border-bottom: 1px solid var(--border);
+    font-size: 0.82rem;
+    color: var(--text-muted);
+    gap: 0.5rem;
+  }
+  .diff-header .file-icon {
+    width: 16px; height: 16px;
+    fill: var(--text-subtle);
+    flex-shrink: 0;
+  }
+  .diff-header .filename {
+    color: var(--text);
+    font-weight: 600;
+    font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', monospace;
+    font-size: 0.82rem;
+  }
+  .diff-header .badge {
+    margin-left: auto;
+    font-size: 0.72rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    font-weight: 600;
+  }
+  .badge-new { background: var(--green-bg); color: var(--green); border: 1px solid var(--green-border); }
+  .badge-modified { background: var(--yellow-bg); color: var(--yellow); border: 1px solid rgba(210,153,34,0.3); }
+
+  .diff-body {
+    overflow-x: auto;
+  }
+  .diff-body pre {
+    margin: 0;
+    padding: 0.4rem 0;
+    font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', monospace;
+    font-size: 0.82rem;
+    line-height: 1.3;
+    display: flex;
+    flex-direction: column;
+  }
+  .diff-line {
+    display: flex;
+    padding: 0 1rem;
+    min-height: 1.3em;
+  }
+  .diff-line.add { background: var(--diff-add-bg); }
+  .diff-line.del { background: var(--diff-del-bg); }
+  .diff-line.context { background: var(--diff-context-bg); }
+  .diff-line .marker {
+    width: 1.2em;
+    flex-shrink: 0;
+    color: var(--text-subtle);
+    user-select: none;
+    text-align: center;
+  }
+  .diff-line.add .marker { color: var(--diff-add-marker); }
+  .diff-line.del .marker { color: var(--diff-del-marker); }
+  .diff-line .ln {
+    width: 3.5em;
+    flex-shrink: 0;
+    color: var(--line-num);
+    text-align: right;
+    padding-right: 1em;
+    user-select: none;
+  }
+  .diff-line .code {
+    flex: 1;
+    white-space: pre;
+  }
+  .diff-line .code .kw { color: #ff7b72; }
+  .diff-line .code .str { color: #a5d6ff; }
+  .diff-line .code .ann { color: #d2a8ff; }
+  .diff-line .code .type { color: #79c0ff; }
+  .diff-line .code .comment { color: var(--text-subtle); font-style: italic; }
+  .diff-line .code .prop { color: #7ee787; }
+  .diff-line .code .val { color: #a5d6ff; }
+  .diff-line .code .num { color: #79c0ff; }
+  .diff-line .code .param { color: #ffa657; }
+
+  .annotation {
+    background: var(--surface-raised);
+    border-left: 3px solid var(--accent);
+    padding: 0.7rem 1rem;
+    margin: 0 1rem 0.3rem 1rem;
+    border-radius: 0 6px 6px 0;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    line-height: 1.55;
+  }
+  .annotation strong { color: var(--text); }
+  .annotation code {
+    background: rgba(88,166,255,0.1);
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+    font-size: 0.88em;
+    color: var(--accent);
+  }
+  .annotation.security-note { border-left-color: var(--red); }
+  .annotation.future-note { border-left-color: var(--purple); }
+
+  .diagram { margin-bottom: 1.5rem; }
+  .diagram svg { width: 100%; height: auto; display: block; }
+  .diagram-container {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.5rem;
+    overflow-x: auto;
+  }
+  .diagram-title {
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+    margin-bottom: 0.8rem;
+    text-align: center;
+  }
+
+  .slice-columns {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.2rem;
+    margin-bottom: 1.5rem;
+  }
+  @media (max-width: 768px) { .slice-columns { grid-template-columns: 1fr; } }
+  .slice-col {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.2rem 1.4rem;
+  }
+  .slice-col.this-pr { border-color: var(--green-border); }
+  .slice-col.future-col { border-color: var(--border); opacity: 0.7; }
+  .slice-col .slice-title {
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 0.8rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .slice-col.this-pr .slice-title { color: var(--green); }
+  .slice-col.future-col .slice-title { color: var(--text-subtle); }
+  .slice-item {
+    position: relative;
+    padding: 0.3rem 0 0.3rem 1rem;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+  }
+  .slice-item .dot {
+    position: absolute;
+    left: 0;
+    top: 0.65rem;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+  }
+  .slice-col.this-pr .dot { background: var(--green); }
+  .slice-col.future-col .dot { background: var(--text-subtle); }
+  .slice-item strong { color: var(--text); font-weight: 500; }
+
+  .roadmap-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1.5rem;
+    font-size: 0.85rem;
+  }
+  .roadmap-table th {
+    text-align: left;
+    padding: 0.55rem 0.8rem;
+    background: var(--surface-raised);
+    color: var(--text-muted);
+    font-weight: 600;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid var(--border);
+  }
+  .roadmap-table td {
+    padding: 0.45rem 0.8rem;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-muted);
+    vertical-align: top;
+  }
+  .roadmap-table tr:last-child td { border-bottom: none; }
+  .roadmap-table .jira-link {
+    font-family: 'SF Mono', monospace;
+    font-size: 0.8rem;
+    color: var(--accent);
+    text-decoration: none;
+  }
+  .roadmap-table .jira-link:hover { text-decoration: underline; }
+  .roadmap-table .slice-name { color: var(--text); font-weight: 500; }
+  .roadmap-table .current-row td {
+    background: var(--green-bg);
+    border-bottom-color: var(--green-border);
+  }
+  .roadmap-table .current-row .slice-name { color: var(--green); font-weight: 600; }
+  .roadmap-table .current-badge {
+    display: inline-block;
+    font-size: 0.68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    background: var(--green-bg);
+    color: var(--green);
+    border: 1px solid var(--green-border);
+    padding: 0.1rem 0.4rem;
+    border-radius: 999px;
+    margin-left: 0.4rem;
+    vertical-align: middle;
+  }
+
+  .file-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1.5rem;
+    font-size: 0.85rem;
+  }
+  .file-table th {
+    text-align: left;
+    padding: 0.6rem 1rem;
+    background: var(--surface-raised);
+    color: var(--text-muted);
+    font-weight: 600;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid var(--border);
+  }
+  .file-table td {
+    padding: 0.55rem 1rem;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-muted);
+  }
+  .file-table td:first-child {
+    font-family: 'SF Mono', monospace;
+    font-size: 0.82rem;
+    color: var(--accent);
+  }
+  .file-table tr:last-child td { border-bottom: none; }
+  .file-table .addition { color: var(--green); }
+  .file-table .deletion { color: var(--red); }
+
+  .standard-pattern {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    margin-bottom: 1.5rem;
+    overflow: hidden;
+  }
+  .standard-pattern summary {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.7rem 1rem;
+    cursor: pointer;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    background: var(--surface-raised);
+    border-bottom: 1px solid transparent;
+    list-style: none;
+    transition: background 0.15s;
+  }
+  .standard-pattern summary::-webkit-details-marker { display: none; }
+  .standard-pattern summary::before {
+    content: '\25B6';
+    font-size: 0.65rem;
+    color: var(--text-subtle);
+    transition: transform 0.15s;
+    flex-shrink: 0;
+  }
+  .standard-pattern[open] summary::before { transform: rotate(90deg); }
+  .standard-pattern[open] summary { border-bottom-color: var(--border); }
+  .standard-pattern summary:hover { background: rgba(88,166,255,0.06); }
+  .standard-pattern .sp-icon {
+    width: 16px; height: 16px;
+    fill: var(--text-subtle);
+    flex-shrink: 0;
+  }
+  .standard-pattern .sp-title {
+    color: var(--text);
+    font-weight: 600;
+    flex: 1;
+  }
+  .standard-pattern .sp-files {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 0.78rem;
+    color: var(--text-subtle);
+  }
+  .standard-pattern .sp-ref {
+    font-size: 0.78rem;
+    color: var(--text-subtle);
+    margin-left: auto;
+    white-space: nowrap;
+  }
+  .badge-standard {
+    background: rgba(139,148,158,0.15);
+    color: var(--text-muted);
+    border: 1px solid rgba(139,148,158,0.3);
+    font-size: 0.68rem;
+    font-weight: 600;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    letter-spacing: 0.03em;
+    white-space: nowrap;
+  }
+  .standard-pattern .sp-body {
+    padding: 0.8rem 1rem;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    line-height: 1.6;
+  }
+  .standard-pattern .sp-body code {
+    background: var(--surface-raised);
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+    font-size: 0.88em;
+    color: var(--accent);
+    border: 1px solid var(--border);
+  }
+
+  .file-table .novelty { text-align: center; }
+  .novelty-badge {
+    display: inline-block;
+    font-size: 0.68rem;
+    font-weight: 600;
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    letter-spacing: 0.02em;
+  }
+  .novelty-badge.novel { background: var(--accent-soft); color: var(--accent); border: 1px solid rgba(88,166,255,0.3); }
+  .novelty-badge.standard { background: rgba(139,148,158,0.12); color: var(--text-subtle); border: 1px solid rgba(139,148,158,0.25); }
+  .novelty-badge.pattern { background: var(--yellow-bg); color: var(--yellow); border: 1px solid rgba(210,153,34,0.3); }
+
+  footer {
+    text-align: center;
+    padding: 2rem;
+    color: var(--text-subtle);
+    font-size: 0.8rem;
+    border-top: 1px solid var(--border);
+    margin-top: 3rem;
+  }
+
+  @media (max-width: 768px) {
+    .hero { padding: 2rem 1rem; }
+    .hero h1 { font-size: 1.6rem; }
+    main { padding: 1.5rem 1rem 4rem; }
+    nav ol { gap: 0; }
+  }
+</style>
+</head>
+<body>
+
+<!-- ===== HERO ===== -->
+<div class="hero">
+  <span class="hero-badge">PR #131 &middot; AIML-763</span>
+  <h1>Cursor Pagination Core Abstraction</h1>
+  <p class="subtitle">
+    Adds a parallel pagination type hierarchy to <code>contrast-mcp-core</code> for dataplatform tools backed by cursor/keyset APIs &mdash; opaque continuation tokens, not page numbers.
+  </p>
+  <div class="hero-meta">
+    <span class="hero-meta-item"><strong>Branch:</strong> AIML-763-s9-expand-dataplatform-tools</span>
+    <span class="hero-meta-item"><strong>Stacked on:</strong> #130 (AIML-762)</span>
+    <span class="hero-meta-item"><strong>Files:</strong> 9 changed</span>
+    <span class="hero-meta-item"><strong>Lines:</strong> +968</span>
+  </div>
+</div>
+
+<!-- ===== NAV ===== -->
+<nav>
+  <ol>
+    <li><a href="#context"><span class="nav-number">1</span>Context</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#problem"><span class="nav-number">2</span>The Problem</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#approach"><span class="nav-number">3</span>Approach</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#params"><span class="nav-number">4</span>Params &amp; Result</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#pipeline"><span class="nav-number">5</span>Pipeline</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#response"><span class="nav-number">6</span>Response</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#tests"><span class="nav-number">7</span>Tests</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#gate"><span class="nav-number">8</span>Diagnostic Gate</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#summary"><span class="nav-number">9</span>Summary</a></li>
+  </ol>
+</nav>
+
+<!-- ===== MAIN ===== -->
+<main>
+
+<!-- ────────────────────────────────────────────────────── -->
+<!-- CHAPTER 1: Context -->
+<!-- ────────────────────────────────────────────────────── -->
+<section class="chapter" id="context">
+  <div class="chapter-header">
+    <span class="chapter-number blue">1</span>
+    <h2>Where This PR Fits</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>This PR is the fourth child bead (S9D) of Slice 9 &mdash; the slice that ports all remaining dataplatform tools to the Contrast MCP platform.</strong>
+    The AIML-110 initiative is building a hosted MCP server that gives AI agents access to Contrast Security's vulnerability, library, and compliance data. The work has been progressing through numbered slices, each one extending the architecture a little further:
+  </p>
+
+  <table class="roadmap-table">
+    <thead><tr><th>Ticket</th><th>Slice</th><th>What It Did</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><a class="jira-link" href="https://contrast.atlassian.net/browse/AIML-757">AIML-757</a></td>
+        <td><span class="slice-name">S3 &ndash; Build &amp; Core</span></td>
+        <td>Migrated to Gradle, published <code>contrast-mcp-core</code>, aligned public CI</td>
+      </tr>
+      <tr>
+        <td><a class="jira-link" href="https://contrast.atlassian.net/browse/AIML-758">AIML-758</a></td>
+        <td><span class="slice-name">S4 &ndash; Shared Client</span></td>
+        <td>Auth boundary, first shared tool, proved local parity</td>
+      </tr>
+      <tr>
+        <td><a class="jira-link" href="https://contrast.atlassian.net/browse/AIML-761">AIML-761</a></td>
+        <td><span class="slice-name">S7 &ndash; Error Handling</span></td>
+        <td>Hardened error messages and 401 guidance across all tools</td>
+      </tr>
+      <tr>
+        <td><a class="jira-link" href="https://contrast.atlassian.net/browse/AIML-762">AIML-762</a></td>
+        <td><span class="slice-name">S8 &ndash; Shared Tools</span></td>
+        <td>Migrated all 12 shared tools family-by-family to core (PR #130, parent of this PR)</td>
+      </tr>
+      <tr class="current-row">
+        <td><a class="jira-link" href="https://contrast.atlassian.net/browse/AIML-763">AIML-763</a></td>
+        <td><span class="slice-name">S9 &ndash; Dataplatform</span><span class="current-badge">This PR</span></td>
+        <td>Cursor pagination abstraction for observation-list tools (S9D)</td>
+      </tr>
+      <tr>
+        <td><a class="jira-link" href="https://contrast.atlassian.net/browse/AIML-766">AIML-766</a></td>
+        <td><span class="slice-name">S12 &ndash; Parity &amp; Release</span></td>
+        <td>Full parity gate, release hardening, privacy evidence</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p class="narrative">
+    <strong>Slice 9 itself is broken into six child beads (S9A&ndash;S9F) that port dataplatform tools by workflow.</strong>
+    The first three (S9A&ndash;S9C) port issue search, issue detail, and incident read workflows to the hosted server in <code>aiml-services</code> &mdash; all using conventional offset-based pagination. This PR, S9D, adds the cursor pagination types to <code>contrast-mcp-core</code> in the public repo, which S9E then consumes in the hosted server to register the cursor-backed observation tools. S9F adds mutation tools behind a Security approval gate.
+  </p>
+
+  <div class="diagram">
+    <div class="diagram-title">Slice 9 child bead dependency chain</div>
+    <div class="diagram-container">
+      <svg viewBox="0 0 900 200" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+        <!-- Bead boxes -->
+        <rect x="10" y="70" width="110" height="60" rx="8" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
+        <text x="65" y="95" text-anchor="middle" fill="#8b949e" font-size="11" font-weight="600">S9A</text>
+        <text x="65" y="112" text-anchor="middle" fill="#6e7681" font-size="9">Issue Search</text>
+
+        <rect x="155" y="70" width="110" height="60" rx="8" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
+        <text x="210" y="95" text-anchor="middle" fill="#8b949e" font-size="11" font-weight="600">S9B</text>
+        <text x="210" y="112" text-anchor="middle" fill="#6e7681" font-size="9">Issue Detail</text>
+
+        <rect x="300" y="70" width="110" height="60" rx="8" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
+        <text x="355" y="95" text-anchor="middle" fill="#8b949e" font-size="11" font-weight="600">S9C</text>
+        <text x="355" y="112" text-anchor="middle" fill="#6e7681" font-size="9">Incident Read</text>
+
+        <!-- Current bead (highlighted) -->
+        <rect x="445" y="70" width="130" height="60" rx="8" fill="rgba(63,185,80,0.15)" stroke="#3fb950" stroke-width="2"/>
+        <text x="510" y="95" text-anchor="middle" fill="#3fb950" font-size="11" font-weight="700">S9D (This PR)</text>
+        <text x="510" y="112" text-anchor="middle" fill="#3fb950" font-size="9">Cursor Abstraction</text>
+
+        <rect x="610" y="70" width="130" height="60" rx="8" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
+        <text x="675" y="95" text-anchor="middle" fill="#8b949e" font-size="11" font-weight="600">S9E</text>
+        <text x="675" y="112" text-anchor="middle" fill="#6e7681" font-size="9">Observation Tools</text>
+
+        <rect x="775" y="70" width="110" height="60" rx="8" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
+        <text x="830" y="95" text-anchor="middle" fill="#8b949e" font-size="11" font-weight="600">S9F</text>
+        <text x="830" y="112" text-anchor="middle" fill="#6e7681" font-size="9">Mutations (gated)</text>
+
+        <!-- Arrows -->
+        <line x1="120" y1="100" x2="155" y2="100" stroke="#30363d" stroke-width="1.5" marker-end="url(#arrow)"/>
+        <line x1="265" y1="100" x2="300" y2="100" stroke="#30363d" stroke-width="1.5" marker-end="url(#arrow)"/>
+        <line x1="410" y1="100" x2="445" y2="100" stroke="#3fb950" stroke-width="1.5" marker-end="url(#arrowGreen)"/>
+        <line x1="575" y1="100" x2="610" y2="100" stroke="#30363d" stroke-width="1.5" marker-end="url(#arrow)"/>
+        <line x1="740" y1="100" x2="775" y2="100" stroke="#30363d" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+        <!-- Repo labels -->
+        <text x="210" y="160" text-anchor="middle" fill="#6e7681" font-size="10" font-style="italic">aiml-services (hosted)</text>
+        <line x1="10" y1="148" x2="420" y2="148" stroke="#30363d" stroke-width="0.5" stroke-dasharray="4"/>
+        <text x="510" y="160" text-anchor="middle" fill="#3fb950" font-size="10" font-style="italic">mcp-contrast (public)</text>
+        <line x1="445" y1="148" x2="575" y2="148" stroke="rgba(63,185,80,0.4)" stroke-width="0.5" stroke-dasharray="4"/>
+        <text x="752" y="160" text-anchor="middle" fill="#6e7681" font-size="10" font-style="italic">aiml-services (hosted)</text>
+        <line x1="610" y1="148" x2="885" y2="148" stroke="#30363d" stroke-width="0.5" stroke-dasharray="4"/>
+
+        <!-- Arrow markers -->
+        <defs>
+          <marker id="arrow" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#30363d"/>
+          </marker>
+          <marker id="arrowGreen" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#3fb950"/>
+          </marker>
+        </defs>
+      </svg>
+    </div>
+  </div>
+
+  <div class="callout note">
+    <span class="callout-label">Note</span>
+    <strong>S9A&ndash;S9C and S9E&ndash;S9F are implemented in <code>aiml-services</code> (the private hosted repo).</strong> This PR &mdash; S9D &mdash; is the only Slice 9 child that touches the public <code>mcp-contrast</code> repo. It adds the cursor pagination types that S9E depends on when it registers <code>list_issue_observations</code> and <code>list_incident_observations</code> on the hosted server.
+  </div>
+</section>
+
+<!-- ────────────────────────────────────────────────────── -->
+<!-- CHAPTER 2: The Problem -->
+<!-- ────────────────────────────────────────────────────── -->
+<section class="chapter" id="problem">
+  <div class="chapter-header">
+    <span class="chapter-number yellow">2</span>
+    <h2>The Problem: Two Incompatible Pagination Models</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>The dataplatform observation APIs use cursor/keyset pagination, but the MCP server's existing <code>PaginatedTool</code> only knows about offset-based page numbers.</strong>
+    To understand why this matters, imagine an AI agent asking "show me the next page of issue observations." With offset pagination, the agent says <code>page=2</code> and the server calculates <code>offset = (2 - 1) &times; 50 = 50</code>. Simple arithmetic. But the dataplatform's observation endpoints don't work this way &mdash; they return an opaque continuation token (a cursor) that encodes the position in the result set. The agent must pass that token back verbatim to get the next page.
+  </p>
+
+  <p class="narrative">
+    <strong>These are fundamentally different contracts, not just different parameter names.</strong> Offset pagination exposes <code>page</code>, <code>pageSize</code>, <code>totalPages</code>, and <code>totalItems</code> &mdash; the agent can jump to any page. Cursor pagination exposes <code>cursor</code>, <code>pageSize</code>, <code>nextCursor</code>, and <code>hasMore</code> &mdash; the agent can only go forward. Trying to shoehorn cursor semantics into the existing <code>PaginatedTool</code> would mean either:
+  </p>
+
+  <div class="slice-columns">
+    <div class="slice-col this-pr">
+      <div class="slice-title">Option A: Force-fit into PaginatedTool</div>
+      <div class="slice-item"><span class="dot"></span>Expose <code>page</code> and <code>totalPages</code> that don't actually work</div>
+      <div class="slice-item"><span class="dot"></span>Fake <code>page=1</code> on every request, breaking agent expectations</div>
+      <div class="slice-item"><span class="dot"></span>Hide cursor tokens in response metadata, confusing the AI</div>
+    </div>
+    <div class="slice-col future-col">
+      <div class="slice-title">Option B: Parallel type hierarchy (chosen)</div>
+      <div class="slice-item"><span class="dot"></span>Clean contract: <code>cursor</code>/<code>pageSize</code> in, <code>nextCursor</code>/<code>hasMore</code> out</div>
+      <div class="slice-item"><span class="dot"></span>No random-access fields that would mislead the agent</div>
+      <div class="slice-item"><span class="dot"></span>Cursor values treated as opaque &mdash; never parsed or logged</div>
+    </div>
+  </div>
+
+  <div class="callout security">
+    <span class="callout-label">Security consideration</span>
+    <strong>Cursor values can contain backend search mechanics.</strong> The dataplatform's older <code>sortAfter</code> mechanism embeds typed field values. Logging, parsing, or exposing these in error messages would leak backend internals to AI agents. The PRD's CursorPaginationContract invariant explicitly requires that cursors are treated as opaque continuation tokens throughout.
+  </div>
+
+  <p class="narrative">
+    <strong>There's also a gate to satisfy.</strong> The PRD defines a "cursor-client gate" that says <code>list_issue_observations</code> and <code>list_incident_observations</code> cannot be registered unless the client can actually pass an opaque cursor and receive <code>nextCursor</code>/<code>hasMore</code> back. First-page-only implementations are explicitly forbidden. This PR builds the foundation that makes it possible to satisfy that gate.
+  </p>
+</section>
+
+<!-- ────────────────────────────────────────────────────── -->
+<!-- CHAPTER 3: Approach -->
+<!-- ────────────────────────────────────────────────────── -->
+<section class="chapter" id="approach">
+  <div class="chapter-header">
+    <span class="chapter-number green">3</span>
+    <h2>Approach: Mirror, Don't Merge</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>The design creates a parallel type hierarchy alongside the existing offset pagination types.</strong>
+    Rather than trying to generalize <code>PaginatedTool</code> (which would require every existing offset tool to handle nullable cursor fields), the PR adds four new types that mirror the structure of their offset counterparts while enforcing cursor semantics. Here's how the types map:
+  </p>
+
+  <div class="diagram">
+    <div class="diagram-title">Offset vs. Cursor type hierarchy</div>
+    <div class="diagram-container">
+      <svg viewBox="0 0 900 340" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+        <!-- Headers -->
+        <text x="225" y="30" text-anchor="middle" fill="#8b949e" font-size="13" font-weight="700" text-decoration="underline">Offset Pagination (existing)</text>
+        <text x="675" y="30" text-anchor="middle" fill="#3fb950" font-size="13" font-weight="700" text-decoration="underline">Cursor Pagination (this PR)</text>
+
+        <!-- Divider -->
+        <line x1="450" y1="10" x2="450" y2="330" stroke="#30363d" stroke-width="1" stroke-dasharray="6"/>
+
+        <!-- BaseTool (shared) -->
+        <rect x="350" y="50" width="200" height="40" rx="6" fill="rgba(188,140,255,0.12)" stroke="rgba(188,140,255,0.3)" stroke-width="1.5"/>
+        <text x="450" y="75" text-anchor="middle" fill="#bc8cff" font-size="12" font-weight="600">BaseTool</text>
+        <text x="450" y="100" text-anchor="middle" fill="#6e7681" font-size="9">authenticate() &bull; mapHttpErrorCode()</text>
+
+        <!-- Offset side -->
+        <rect x="80" y="120" width="200" height="44" rx="6" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
+        <text x="180" y="140" text-anchor="middle" fill="#58a6ff" font-size="11" font-weight="600">PaginatedTool&lt;P, R&gt;</text>
+        <text x="180" y="155" text-anchor="middle" fill="#6e7681" font-size="9">executePipeline(page, pageSize, ...)</text>
+
+        <rect x="80" y="185" width="200" height="36" rx="6" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
+        <text x="180" y="207" text-anchor="middle" fill="#8b949e" font-size="11">PaginationParams</text>
+
+        <rect x="80" y="240" width="200" height="36" rx="6" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
+        <text x="180" y="262" text-anchor="middle" fill="#8b949e" font-size="11">ExecutionResult&lt;T&gt;</text>
+
+        <rect x="80" y="295" width="200" height="36" rx="6" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
+        <text x="180" y="317" text-anchor="middle" fill="#8b949e" font-size="11">PaginatedToolResponse&lt;T&gt;</text>
+
+        <!-- Cursor side -->
+        <rect x="620" y="120" width="230" height="44" rx="6" fill="rgba(63,185,80,0.12)" stroke="rgba(63,185,80,0.4)" stroke-width="1.5"/>
+        <text x="735" y="140" text-anchor="middle" fill="#3fb950" font-size="11" font-weight="600">CursorPaginatedTool&lt;P, R&gt;</text>
+        <text x="735" y="155" text-anchor="middle" fill="#3fb950" font-size="9">executePipeline(cursor, pageSize, ...)</text>
+
+        <rect x="620" y="185" width="230" height="36" rx="6" fill="rgba(63,185,80,0.12)" stroke="rgba(63,185,80,0.4)" stroke-width="1.5"/>
+        <text x="735" y="207" text-anchor="middle" fill="#3fb950" font-size="11">CursorPaginationParams</text>
+
+        <rect x="620" y="240" width="230" height="36" rx="6" fill="rgba(63,185,80,0.12)" stroke="rgba(63,185,80,0.4)" stroke-width="1.5"/>
+        <text x="735" y="262" text-anchor="middle" fill="#3fb950" font-size="11">CursorExecutionResult&lt;T&gt;</text>
+
+        <rect x="620" y="295" width="230" height="36" rx="6" fill="rgba(63,185,80,0.12)" stroke="rgba(63,185,80,0.4)" stroke-width="1.5"/>
+        <text x="735" y="317" text-anchor="middle" fill="#3fb950" font-size="11">CursorToolResponse&lt;T&gt;</text>
+
+        <!-- Inheritance arrows -->
+        <line x1="350" y1="70" x2="280" y2="120" stroke="#30363d" stroke-width="1"/>
+        <line x1="550" y1="70" x2="620" y2="120" stroke="rgba(63,185,80,0.4)" stroke-width="1"/>
+
+        <!-- Field labels (offset) -->
+        <text x="325" y="202" text-anchor="end" fill="#6e7681" font-size="9">page, pageSize, offset, limit</text>
+        <text x="325" y="259" text-anchor="end" fill="#6e7681" font-size="9">items, totalItems</text>
+        <text x="325" y="314" text-anchor="end" fill="#6e7681" font-size="9">page, totalItems, hasMorePages</text>
+
+        <!-- Field labels (cursor) -->
+        <text x="580" y="202" text-anchor="end" fill="#3fb950" font-size="9">cursor, pageSize, limit</text>
+        <text x="580" y="259" text-anchor="end" fill="#3fb950" font-size="9">items, nextCursor, hasMore</text>
+        <text x="580" y="314" text-anchor="end" fill="#3fb950" font-size="9">nextCursor, hasMore (no page/total)</text>
+      </svg>
+    </div>
+  </div>
+
+  <p class="narrative">
+    <strong>Both hierarchies inherit from <code>BaseTool</code>, sharing the auth strategy and error mapping.</strong>
+    The four new cursor types are deliberately shaped like their offset counterparts &mdash; same generic patterns, same <code>final executePipeline()</code> template method, same exception-to-user-message mapping &mdash; so a reviewer who knows <code>PaginatedTool</code> will instantly recognize the structure. The key differences are:
+  </p>
+
+  <p class="narrative">
+    &bull; <strong><code>CursorPaginationParams</code></strong> accepts <code>cursor</code> + <code>pageSize</code> instead of <code>page</code> + <code>pageSize</code>. No <code>offset</code>, no <code>page</code> field.<br/>
+    &bull; <strong><code>CursorExecutionResult</code></strong> carries <code>nextCursor</code> + <code>hasMore</code> instead of <code>totalItems</code>. No server-side count.<br/>
+    &bull; <strong><code>CursorToolResponse</code></strong> exposes <code>nextCursor</code> + <code>hasMore</code> to the AI agent. No <code>page</code>, <code>totalPages</code>, or <code>totalItems</code>.<br/>
+    &bull; <strong><code>CursorPaginatedTool</code></strong> logs <code>cursorPresence()</code> (&ldquo;present&rdquo; or &ldquo;absent&rdquo;) instead of the actual cursor value.
+  </p>
+</section>
+
+<!-- ────────────────────────────────────────────────────── -->
+<!-- CHAPTER 4: Params & Result -->
+<!-- ────────────────────────────────────────────────────── -->
+<section class="chapter" id="params">
+  <div class="chapter-header">
+    <span class="chapter-number blue">4</span>
+    <h2>CursorPaginationParams &amp; CursorExecutionResult</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>The params record validates input and the result record bridges <code>doExecute()</code> output to response building &mdash; both enforce opaque cursor semantics.</strong>
+    Let's walk through each one.
+  </p>
+
+  <!-- CursorPaginationParams -->
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">contrast-mcp-core/.../tool/base/CursorPaginationParams.java</span>
+      <span class="badge badge-new">NEW</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">35</span><span class="code"><span class="kw">public record</span> <span class="type">CursorPaginationParams</span>(</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">36</span><span class="code">    <span class="ann">@Nullable</span> <span class="type">String</span> <span class="param">cursor</span>, <span class="kw">int</span> <span class="param">pageSize</span>, <span class="kw">int</span> <span class="param">limit</span>, <span class="type">List</span>&lt;<span class="type">String</span>&gt; <span class="param">warnings</span>) {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">37</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">38</span><span class="code">  <span class="kw">private static final</span> <span class="type">String</span> CURSOR_PRESENT = <span class="str">"present"</span>;</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">39</span><span class="code">  <span class="kw">private static final</span> <span class="type">String</span> CURSOR_ABSENT = <span class="str">"absent"</span>;</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">40</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">41</span><span class="code">  <span class="kw">public</span> <span class="type">CursorPaginationParams</span> {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">42</span><span class="code">    cursor = <span class="type">StringUtils</span>.hasText(cursor) ? cursor : <span class="kw">null</span>;</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">43</span><span class="code">    warnings = warnings != <span class="kw">null</span> ? <span class="type">List</span>.copyOf(warnings) : <span class="type">List</span>.of();</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">44</span><span class="code">  }</span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>The compact constructor normalizes blank cursors to <code>null</code>.</strong> An agent that sends <code>cursor: "   "</code> (whitespace) gets treated as a first-page request rather than a continuation. This prevents blank strings from leaking into downstream API calls where they'd trigger errors.
+    </div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">CursorPaginationParams.java &mdash; factory method</span>
+      <span class="badge badge-new">NEW</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">65</span><span class="code">  <span class="kw">public static</span> <span class="type">CursorPaginationParams</span> of(</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">66</span><span class="code">      <span class="ann">@Nullable</span> <span class="type">String</span> <span class="param">cursor</span>, <span class="ann">@Nullable</span> <span class="type">Integer</span> <span class="param">pageSize</span>, <span class="kw">int</span> <span class="param">maxPageSize</span>) {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">67</span><span class="code">    <span class="type">List</span>&lt;<span class="type">String</span>&gt; warnings = <span class="kw">new</span> <span class="type">ArrayList</span>&lt;&gt;();</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">68</span><span class="code">    <span class="kw">int</span> defaultSize = <span class="type">Math</span>.min(DEFAULT_PAGE_SIZE, maxPageSize);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">69</span><span class="code">    <span class="kw">int</span> actualSize = pageSize != <span class="kw">null</span> &amp;&amp; pageSize &gt; <span class="num">0</span> ? pageSize : defaultSize;</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">70</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">71</span><span class="code">    <span class="kw">if</span> (pageSize != <span class="kw">null</span> &amp;&amp; pageSize &lt; <span class="num">1</span>) {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">72</span><span class="code">      warnings.add(<span class="type">String</span>.format(<span class="str">"Invalid pageSize %d, using default %d"</span>, pageSize, defaultSize));</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">73</span><span class="code">      actualSize = defaultSize;</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">74</span><span class="code">    } <span class="kw">else if</span> (pageSize != <span class="kw">null</span> &amp;&amp; pageSize &gt; maxPageSize) {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">75</span><span class="code">      warnings.add(<span class="type">String</span>.format(</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">76</span><span class="code">          <span class="str">"Requested pageSize %d exceeds maximum %d, capped to %d"</span>,</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">77</span><span class="code">          pageSize, maxPageSize, maxPageSize));</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">78</span><span class="code">      actualSize = maxPageSize;</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">79</span><span class="code">    }</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">80</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">81</span><span class="code">    <span class="kw">return new</span> <span class="type">CursorPaginationParams</span>(cursor, actualSize, actualSize, warnings);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">82</span><span class="code">  }</span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>Soft validation: invalid page sizes are corrected with warnings, never rejected.</strong> This matches the UX pattern established by <code>PaginationParams.of()</code> in the offset family. The agent gets a warning like "Requested pageSize 200 exceeds maximum 100, capped to 100" rather than an error. The <code>maxPageSize</code> parameter lets individual tools set narrower limits (e.g., 50 instead of 100) when the backend API is more restrictive.
+    </div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">CursorPaginationParams.java &mdash; cursorPresence()</span>
+      <span class="badge badge-new">NEW</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">98</span><span class="code">  <span class="kw">public</span> <span class="type">String</span> cursorPresence() {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">99</span><span class="code">    <span class="kw">return</span> cursor == <span class="kw">null</span> ? CURSOR_ABSENT : CURSOR_PRESENT;</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">100</span><span class="code">  }</span></span>
+    </pre></div>
+    <div class="annotation security-note">
+      <strong>This is the security enforcement point for cursor logging.</strong> Instead of logging the raw cursor value (which might contain <code>sortAfter</code> internals, field values, or position markers), every call site logs <code>cursorPresence()</code> &mdash; the string "present" or "absent". The diagnostic gate asserts no call site in <code>CursorPaginatedTool</code> ever logs the actual cursor.
+    </div>
+  </div>
+
+  <!-- CursorExecutionResult -->
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">contrast-mcp-core/.../tool/base/CursorExecutionResult.java</span>
+      <span class="badge badge-new">NEW</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">29</span><span class="code"><span class="kw">public record</span> <span class="type">CursorExecutionResult</span>&lt;<span class="type">T</span>&gt;(</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">30</span><span class="code">    <span class="type">List</span>&lt;<span class="type">T</span>&gt; <span class="param">items</span>, <span class="ann">@Nullable</span> <span class="type">String</span> <span class="param">nextCursor</span>, <span class="kw">boolean</span> <span class="param">hasMore</span>) {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">31</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">32</span><span class="code">  <span class="kw">public</span> <span class="type">CursorExecutionResult</span> {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">33</span><span class="code">    items = items != <span class="kw">null</span> ? <span class="type">List</span>.copyOf(items) : <span class="type">List</span>.of();</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">34</span><span class="code">  }</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">35</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">36</span><span class="code">  <span class="kw">public static</span> &lt;<span class="type">T</span>&gt; <span class="type">CursorExecutionResult</span>&lt;<span class="type">T</span>&gt; of(</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">37</span><span class="code">      <span class="type">List</span>&lt;<span class="type">T</span>&gt; <span class="param">items</span>, <span class="ann">@Nullable</span> <span class="type">String</span> <span class="param">nextCursor</span>, <span class="kw">boolean</span> <span class="param">hasMore</span>) {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">38</span><span class="code">    <span class="kw">return new</span> <span class="type">CursorExecutionResult</span>&lt;&gt;(items, nextCursor, hasMore);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">39</span><span class="code">  }</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">40</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">41</span><span class="code">  <span class="kw">public static</span> &lt;<span class="type">T</span>&gt; <span class="type">CursorExecutionResult</span>&lt;<span class="type">T</span>&gt; empty() {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">42</span><span class="code">    <span class="kw">return new</span> <span class="type">CursorExecutionResult</span>&lt;&gt;(<span class="type">List</span>.of(), <span class="kw">null</span>, <span class="kw">false</span>);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">43</span><span class="code">  }</span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>This is the intermediate result type that <code>doExecute()</code> returns.</strong> Subclasses call the backend API and wrap the response in a <code>CursorExecutionResult</code>. The base class then uses this to build the final <code>CursorToolResponse</code>. Notice it has <code>nextCursor</code> + <code>hasMore</code> instead of the offset family's <code>totalItems</code> &mdash; cursor backends typically don't know the total count.
+    </div>
+  </div>
+</section>
+
+<!-- ────────────────────────────────────────────────────── -->
+<!-- CHAPTER 5: Pipeline -->
+<!-- ────────────────────────────────────────────────────── -->
+<section class="chapter" id="pipeline">
+  <div class="chapter-header">
+    <span class="chapter-number purple">5</span>
+    <h2>CursorPaginatedTool &mdash; The Pipeline</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>The heart of this PR is the <code>executePipeline()</code> method &mdash; a <code>final</code> template method that enforces a consistent processing sequence.</strong>
+    If you've reviewed any of the existing tools (from PR #124 onward), you'll recognize this pattern from <code>PaginatedTool</code>. The stages are identical: validate &rarr; authenticate &rarr; execute &rarr; respond. But the cursor version adds cursor-specific logging and never exposes the cursor value in any error path.
+  </p>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">contrast-mcp-core/.../tool/base/CursorPaginatedTool.java</span>
+      <span class="badge badge-new">NEW</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">38</span><span class="code"><span class="ann">@Slf4j</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">39</span><span class="code"><span class="kw">public abstract class</span> <span class="type">CursorPaginatedTool</span>&lt;<span class="type">P</span> <span class="kw">extends</span> <span class="type">ToolParams</span>, <span class="type">R</span>&gt; <span class="kw">extends</span> <span class="type">BaseTool</span> {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">40</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">41</span><span class="code">  <span class="kw">private static final int</span> REQUEST_ID_PREFIX_LENGTH = <span class="num">8</span>;</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">42</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">43</span><span class="code">  <span class="kw">protected int</span> getMaxPageSize() {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">44</span><span class="code">    <span class="kw">return</span> MAX_PAGE_SIZE;</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">45</span><span class="code">  }</span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>The <code>getMaxPageSize()</code> hook lets individual tools set narrower limits.</strong> For example, if a dataplatform observation endpoint limits pages to 50 items, a subclass overrides this to return 50 and the param validation automatically caps the agent's request. Default is 100 (from <code>ValidationConstants.MAX_PAGE_SIZE</code>).
+    </div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">CursorPaginatedTool.java &mdash; executePipeline()</span>
+      <span class="badge badge-new">NEW</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">57</span><span class="code">  <span class="kw">protected final</span> <span class="type">CursorToolResponse</span>&lt;<span class="type">R</span>&gt; executePipeline(</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">58</span><span class="code">      <span class="ann">@Nullable</span> <span class="type">String</span> <span class="param">cursor</span>,</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">59</span><span class="code">      <span class="ann">@Nullable</span> <span class="type">Integer</span> <span class="param">pageSize</span>,</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">60</span><span class="code">      <span class="type">Supplier</span>&lt;<span class="type">P</span>&gt; <span class="param">paramsSupplier</span>,</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">61</span><span class="code">      <span class="ann">@Nullable</span> <span class="type">ToolContext</span> <span class="param">toolContext</span>) {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">62</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">63</span><span class="code">    <span class="kw">var</span> requestId = <span class="type">UUID</span>.randomUUID().toString().substring(<span class="num">0</span>, REQUEST_ID_PREFIX_LENGTH);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">64</span><span class="code">    <span class="kw">long</span> startTime = <span class="type">System</span>.currentTimeMillis();</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">65</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">66</span><span class="code">    <span class="kw">var</span> pagination = <span class="type">CursorPaginationParams</span>.of(cursor, pageSize, getMaxPageSize());</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">67</span><span class="code">    <span class="kw">var</span> params = paramsSupplier.get();</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">68</span><span class="code">    <span class="kw">var</span> collector = <span class="type">WarningCollector</span>.forContext(<span class="type">Map</span>.of(<span class="type">LoggingKeys</span>.REQUEST_ID, requestId));</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">69</span><span class="code">    pagination.warnings().forEach(collector::warn);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">70</span><span class="code">    params.warnings().forEach(collector::warn);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">71</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">72</span><span class="code">    <span class="kw">if</span> (!params.isValid()) {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">73</span><span class="code">      logValidationError(requestId, params.errors(), pagination.cursorPresence());</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">74</span><span class="code">      <span class="kw">return</span> <span class="type">CursorToolResponse</span>.validationError(pagination.pageSize(), params.errors());</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">75</span><span class="code">    }</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">76</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">77</span><span class="code">    <span class="kw">try</span> (<span class="kw">var</span> ignored = authenticate(toolContext)) {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">78</span><span class="code">      <span class="kw">var</span> result = doExecute(pagination, params, collector);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">79</span><span class="code">      <span class="kw">var</span> duration = <span class="type">System</span>.currentTimeMillis() - startTime;</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">80</span><span class="code">      <span class="kw">return</span> buildSuccessResponse(result, pagination, collector, duration, requestId);</span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>The pipeline follows the same five-stage sequence as <code>PaginatedTool</code>:</strong> (1) parse pagination, (2) parse tool params, (3) collect warnings, (4) validate, (5) authenticate + execute. The <code>authenticate(toolContext)</code> call uses the inherited <code>BaseTool.authenticate()</code> &mdash; on the hosted server it binds the bearer token context, on local stdio it's a no-op. The try-with-resources pattern ensures the auth scope is cleaned up even if <code>doExecute</code> throws.
+    </div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">CursorPaginatedTool.java &mdash; exception handling</span>
+      <span class="badge badge-new">NEW</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">83</span><span class="code">    } <span class="kw">catch</span> (<span class="type">UnauthorizedException</span> e) {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">84</span><span class="code">      <span class="kw">return</span> handleException(e, pagination, requestId, mapHttpErrorCode(<span class="num">401</span>));</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">85</span><span class="code">    } <span class="kw">catch</span> (<span class="type">ResourceNotFoundException</span> e) {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">86</span><span class="code">      <span class="kw">return</span> handleException(e, pagination, requestId, <span class="str">"Resource not found"</span>);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">87</span><span class="code">    } <span class="kw">catch</span> (<span class="type">HttpResponseException</span> e) {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">88</span><span class="code">      <span class="kw">return</span> handleHttpResponseException(e, pagination, requestId, collector);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">89</span><span class="code">    } <span class="kw">catch</span> (<span class="type">IllegalArgumentException</span> e) {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">90</span><span class="code">      <span class="kw">return</span> handleException(e, pagination, requestId, e.getMessage());</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">91</span><span class="code">    } <span class="kw">catch</span> (<span class="type">Exception</span> e) {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">92</span><span class="code">      log.atError()</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">93</span><span class="code">          .addKeyValue(<span class="type">LoggingKeys</span>.REQUEST_ID, requestId)</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">94</span><span class="code">          .addKeyValue(<span class="type">LoggingKeys</span>.CURSOR, pagination.cursorPresence())</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">95</span><span class="code">          .addKeyValue(<span class="type">LoggingKeys</span>.EXCEPTION_TYPE, e.getClass().getSimpleName())</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">96</span><span class="code">          .setMessage(<span class="str">"Request failed unexpectedly"</span>)</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">97</span><span class="code">          .log();</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">98</span><span class="code">      <span class="kw">return</span> <span class="type">CursorToolResponse</span>.error(</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">99</span><span class="code">          pagination.pageSize(), <span class="str">"An internal error occurred (ref: "</span> + requestId + <span class="str">")"</span>);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">100</span><span class="code">    }</span></span>
+    </pre></div>
+    <div class="annotation security-note">
+      <strong>Notice that the generic <code>catch (Exception)</code> never includes the exception message in the response.</strong> If an internal exception happens to contain the cursor value (e.g., from a backend error message like "invalid sortAfter: eyJ..."), the agent sees only "An internal error occurred (ref: abc12345)" and the log records only <code>cursor=present</code> plus the exception type. The cursor value never leaks.
+    </div>
+  </div>
+</section>
+
+<!-- ────────────────────────────────────────────────────── -->
+<!-- CHAPTER 6: Response -->
+<!-- ────────────────────────────────────────────────────── -->
+<section class="chapter" id="response">
+  <div class="chapter-header">
+    <span class="chapter-number orange">6</span>
+    <h2>CursorToolResponse &amp; LoggingKeys</h2>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">contrast-mcp-core/.../tool/base/CursorToolResponse.java</span>
+      <span class="badge badge-new">NEW</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">34</span><span class="code"><span class="kw">public record</span> <span class="type">CursorToolResponse</span>&lt;<span class="type">T</span>&gt;(</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">35</span><span class="code">    <span class="type">List</span>&lt;<span class="type">T</span>&gt; <span class="param">items</span>,</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">36</span><span class="code">    <span class="kw">int</span> <span class="param">pageSize</span>,</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">37</span><span class="code">    <span class="ann">@Nullable</span> <span class="type">String</span> <span class="param">nextCursor</span>,</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">38</span><span class="code">    <span class="kw">boolean</span> <span class="param">hasMore</span>,</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">39</span><span class="code">    <span class="type">List</span>&lt;<span class="type">String</span>&gt; <span class="param">errors</span>,</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">40</span><span class="code">    <span class="type">List</span>&lt;<span class="type">String</span>&gt; <span class="param">warnings</span>,</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">41</span><span class="code">    <span class="ann">@Nullable</span> <span class="type">Long</span> <span class="param">durationMs</span>) {</span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>Compare this to <code>PaginatedToolResponse</code> which has <code>page</code>, <code>pageSize</code>, <code>totalItems</code>, and <code>hasMorePages</code>.</strong> The cursor version deliberately omits <code>page</code>, <code>totalItems</code>, and <code>totalPages</code>. The field <code>hasMore</code> (not <code>hasMorePages</code>) aligns with cursor API conventions. <code>nextCursor</code> is the only cursor-related field &mdash; and it's the opaque token the agent passes back for the next page.
+    </div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">CursorToolResponse.java &mdash; factory methods</span>
+      <span class="badge badge-new">NEW</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">58</span><span class="code">  <span class="kw">public static</span> &lt;<span class="type">T</span>&gt; <span class="type">CursorToolResponse</span>&lt;<span class="type">T</span>&gt; success(</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">59</span><span class="code">      <span class="type">List</span>&lt;<span class="type">T</span>&gt; <span class="param">items</span>, <span class="kw">int</span> <span class="param">pageSize</span>, <span class="ann">@Nullable</span> <span class="type">String</span> <span class="param">nextCursor</span>,</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">60</span><span class="code">      <span class="kw">boolean</span> <span class="param">hasMore</span>, <span class="type">List</span>&lt;<span class="type">String</span>&gt; <span class="param">warnings</span>, <span class="ann">@Nullable</span> <span class="type">Long</span> <span class="param">durationMs</span>) {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">61</span><span class="code">    <span class="kw">return new</span> <span class="type">CursorToolResponse</span>&lt;&gt;(</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">62</span><span class="code">        items, pageSize, nextCursor, hasMore, <span class="type">List</span>.of(), warnings, durationMs);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">63</span><span class="code">  }</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">64</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">65</span><span class="code">  <span class="kw">public static</span> &lt;<span class="type">T</span>&gt; <span class="type">CursorToolResponse</span>&lt;<span class="type">T</span>&gt; validationError(<span class="kw">int</span> <span class="param">pageSize</span>, <span class="type">List</span>&lt;<span class="type">String</span>&gt; <span class="param">errors</span>) {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">66</span><span class="code">    <span class="kw">return new</span> <span class="type">CursorToolResponse</span>&lt;&gt;(<span class="type">List</span>.of(), pageSize, <span class="kw">null</span>, <span class="kw">false</span>, errors, <span class="type">List</span>.of(), <span class="kw">null</span>);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">67</span><span class="code">  }</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">68</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">69</span><span class="code">  <span class="kw">public static</span> &lt;<span class="type">T</span>&gt; <span class="type">CursorToolResponse</span>&lt;<span class="type">T</span>&gt; error(<span class="kw">int</span> <span class="param">pageSize</span>, <span class="type">String</span> <span class="param">errorMessage</span>) {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">70</span><span class="code">    <span class="kw">return new</span> <span class="type">CursorToolResponse</span>&lt;&gt;(</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">71</span><span class="code">        <span class="type">List</span>.of(), pageSize, <span class="kw">null</span>, <span class="kw">false</span>, <span class="type">List</span>.of(errorMessage), <span class="type">List</span>.of(), <span class="kw">null</span>);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">72</span><span class="code">  }</span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>Three factory methods cover the three response scenarios.</strong> <code>success()</code> includes items and pagination metadata. <code>validationError()</code> is for param validation failures (before any API call). <code>error()</code> is for runtime/auth/HTTP failures. In all error cases, <code>nextCursor</code> is null, <code>hasMore</code> is false, and items is empty &mdash; a clean terminal state.
+    </div>
+  </div>
+
+  <!-- LoggingKeys (standard pattern) -->
+  <details class="standard-pattern">
+    <summary>
+      <svg class="sp-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill="currentColor" opacity=".3"/></svg>
+      <span class="sp-title">LoggingKeys.java &mdash; New CURSOR Constant</span>
+      <span class="badge-standard">Standard Pattern</span>
+      <span class="sp-files">+1 line</span>
+      <span class="sp-ref">Follows: existing APP_ID, REQUEST_ID, etc.</span>
+    </summary>
+    <div class="sp-body">
+      Adds <code>public static final String CURSOR = "cursor";</code> to the existing structured log key registry. This is the same pattern as all other constants in the file &mdash; one-line addition following the established convention.
+    </div>
+    <div class="diff-block">
+      <div class="diff-header">
+        <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+        <span class="filename">contrast-mcp-core/.../tool/base/LoggingKeys.java</span>
+        <span class="badge badge-modified">MODIFIED</span>
+      </div>
+      <div class="diff-body"><pre>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">31</span><span class="code">  <span class="kw">public static final</span> <span class="type">String</span> APP_ID = <span class="str">"appId"</span>;</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">32</span><span class="code">  <span class="kw">public static final</span> <span class="type">String</span> CURSOR = <span class="str">"cursor"</span>;</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">33</span><span class="code">  <span class="kw">public static final</span> <span class="type">String</span> DURATION_MS = <span class="str">"durationMs"</span>;</span></span>
+      </pre></div>
+    </div>
+  </details>
+</section>
+
+<!-- ────────────────────────────────────────────────────── -->
+<!-- CHAPTER 7: Tests -->
+<!-- ────────────────────────────────────────────────────── -->
+<section class="chapter" id="tests">
+  <div class="chapter-header">
+    <span class="chapter-number green">7</span>
+    <h2>Test Coverage: 22 Tests Across 3 Classes</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>Every test in this PR checks two things: the functional behavior, and that cursor values don't leak into errors or warnings.</strong>
+    The test classes use a constant <code>OPAQUE_CURSOR = "opaque.cursor/with+symbols=="</code> &mdash; a deliberately gnarly string that would be conspicuous if it appeared in an error message. Every test that passes this cursor also asserts the cursor value is absent from the response.
+  </p>
+
+  <div class="callout why">
+    <span class="callout-label">Why this pattern matters</span>
+    <strong>The opaque cursor test constant is intentionally ugly.</strong> If any code path accidentally includes the cursor in a log message, error string, or warning, the assertion <code>noneMatch(msg -&gt; msg.contains(OPAQUE_CURSOR))</code> catches it. This dual-assertion pattern (functional correctness + leak detection) runs on every single test.
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">CursorPaginatedToolTest.java &mdash; first page test</span>
+      <span class="badge badge-new">NEW</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">44</span><span class="code">  <span class="ann">@Test</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">45</span><span class="code">  <span class="kw">void</span> executePipeline_should_call_doExecute_with_absent_cursor_for_first_page() {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">46</span><span class="code">    <span class="kw">var</span> capturedPagination = <span class="kw">new</span> <span class="type">AtomicReference</span>&lt;<span class="type">CursorPaginationParams</span>&gt;();</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">47</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">48</span><span class="code">    tool.setDoExecuteHandler((pagination, params, collector) -&gt; {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">49</span><span class="code">      capturedPagination.set(pagination);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">50</span><span class="code">      <span class="kw">return</span> <span class="type">CursorExecutionResult</span>.of(<span class="type">List</span>.of(<span class="str">"item1"</span>), <span class="str">"next-token"</span>, <span class="kw">true</span>);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">51</span><span class="code">    });</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">52</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">53</span><span class="code">    <span class="kw">var</span> result = tool.executePipeline(<span class="kw">null</span>, <span class="kw">null</span>, <span class="type">TestParams</span>::valid);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">54</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">55</span><span class="code">    assertThat(result.isSuccess()).isTrue();</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">56</span><span class="code">    assertThat(capturedPagination.get().cursor()).isNull();</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">57</span><span class="code">    assertThat(capturedPagination.get().cursorPresence()).isEqualTo(<span class="str">"absent"</span>);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">58</span><span class="code">    assertThat(result.pageSize()).isEqualTo(<span class="num">50</span>);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">59</span><span class="code">    assertThat(result.nextCursor()).isEqualTo(<span class="str">"next-token"</span>);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">60</span><span class="code">    assertThat(result.hasMore()).isTrue();</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">61</span><span class="code">  }</span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>First-page scenario: no cursor in, <code>nextCursor</code> out.</strong> The test captures the <code>CursorPaginationParams</code> passed to <code>doExecute</code> and verifies the cursor is null and <code>cursorPresence()</code> returns "absent". The response includes a <code>nextCursor</code> token the agent can use for page 2.
+    </div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">CursorPaginatedToolTest.java &mdash; opaque pass-through</span>
+      <span class="badge badge-new">NEW</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">64</span><span class="code">  <span class="ann">@Test</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">65</span><span class="code">  <span class="kw">void</span> executePipeline_should_pass_continuation_cursor_without_parsing() {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">66</span><span class="code">    <span class="kw">var</span> capturedCursor = <span class="kw">new</span> <span class="type">AtomicReference</span>&lt;<span class="type">String</span>&gt;();</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">67</span><span class="code">    tool.setDoExecuteHandler((pagination, params, collector) -&gt; {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">68</span><span class="code">      capturedCursor.set(pagination.cursor());</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">69</span><span class="code">      <span class="kw">return</span> <span class="type">CursorExecutionResult</span>.of(<span class="type">List</span>.of(<span class="str">"item2"</span>), <span class="kw">null</span>, <span class="kw">false</span>);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">70</span><span class="code">    });</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">71</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">72</span><span class="code">    <span class="kw">var</span> result = tool.executePipeline(OPAQUE_CURSOR, <span class="num">25</span>, <span class="type">TestParams</span>::valid);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">73</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">74</span><span class="code">    assertThat(result.isSuccess()).isTrue();</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">75</span><span class="code">    assertThat(capturedCursor.get()).isEqualTo(OPAQUE_CURSOR);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">76</span><span class="code">    assertThat(result.nextCursor()).isNull();</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">77</span><span class="code">    assertThat(result.hasMore()).isFalse();</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">78</span><span class="code">  }</span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>Continuation-page scenario: cursor in, passed through byte-for-byte to <code>doExecute</code>.</strong> The test proves the pipeline doesn't decode, parse, URL-encode, or transform the cursor. The backend returns <code>null</code> for <code>nextCursor</code> and <code>false</code> for <code>hasMore</code> &mdash; this is the last page.
+    </div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">CursorPaginatedToolTest.java &mdash; cursor value not exposed in errors</span>
+      <span class="badge badge-new">NEW</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">165</span><span class="code">  <span class="ann">@Test</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">166</span><span class="code">  <span class="kw">void</span> executePipeline_should_not_expose_generic_exception_message_or_cursor_value() {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">167</span><span class="code">    tool.setDoExecuteHandler((pagination, params, collector) -&gt; {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">168</span><span class="code">      <span class="kw">throw new</span> <span class="type">RuntimeException</span>(</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">169</span><span class="code">          <span class="str">"sensitive cursor "</span> + OPAQUE_CURSOR + <span class="str">" at /api/ng/org"</span>);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">170</span><span class="code">    });</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">171</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">172</span><span class="code">    <span class="kw">var</span> result = tool.executePipeline(OPAQUE_CURSOR, <span class="num">25</span>, <span class="type">TestParams</span>::valid);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">173</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">174</span><span class="code">    assertThat(result.errors()).singleElement().satisfies(error -&gt; {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">175</span><span class="code">      assertThat(error).startsWith(<span class="str">"An internal error occurred (ref: "</span>);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">176</span><span class="code">      assertThat(error).doesNotContain(OPAQUE_CURSOR);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">177</span><span class="code">      assertThat(error).doesNotContain(<span class="str">"/api/ng/"</span>);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">178</span><span class="code">    });</span></span>
+    </pre></div>
+    <div class="annotation security-note">
+      <strong>This is the key leak-prevention test.</strong> It deliberately constructs a <code>RuntimeException</code> whose message contains the cursor value and an internal API path. The test proves neither appears in the agent-visible error response. The agent sees only the sanitized "An internal error occurred (ref: abc12345)" message.
+    </div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">CursorPaginationParamsTest.java &mdash; record surface assertion</span>
+      <span class="badge badge-new">NEW</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">94</span><span class="code">  <span class="ann">@Test</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">95</span><span class="code">  <span class="kw">void</span> record_components_should_not_expose_random_access_pagination_fields() {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">96</span><span class="code">    <span class="kw">var</span> componentNames =</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">97</span><span class="code">        <span class="type">Arrays</span>.stream(<span class="type">CursorPaginationParams</span>.class.getRecordComponents())</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">98</span><span class="code">            .map(component -&gt; component.getName()).toList();</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">99</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">100</span><span class="code">    assertThat(componentNames)</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">101</span><span class="code">        .containsExactly(<span class="str">"cursor"</span>, <span class="str">"pageSize"</span>, <span class="str">"limit"</span>, <span class="str">"warnings"</span>)</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">102</span><span class="code">        .doesNotContain(<span class="str">"page"</span>, <span class="str">"offset"</span>, <span class="str">"totalPages"</span>, <span class="str">"totalItems"</span>);</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">103</span><span class="code">  }</span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>Compile-time structural guard via reflection.</strong> Both <code>CursorPaginationParams</code> and <code>CursorToolResponse</code> have these tests. They use Java's record component reflection to assert the exact set of fields and prove no random-access fields (<code>page</code>, <code>offset</code>, <code>totalPages</code>, <code>totalItems</code>) were accidentally added. If someone adds a <code>page</code> field to the cursor params record, this test fails immediately.
+    </div>
+  </div>
+
+  <p class="narrative">
+    <strong>The test classes also cover edge cases: blank cursor normalization, invalid page sizes, immutability of warning lists, defensive list copying in responses, and duration tracking.</strong> See the full test matrix below:
+  </p>
+
+  <table class="roadmap-table">
+    <thead><tr><th>Test Class</th><th>#</th><th>Key Scenarios</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><span class="slice-name">CursorPaginatedToolTest</span></td>
+        <td>9</td>
+        <td>First page, cursor pass-through, validation short-circuit, page size warnings, HTTP/auth/not-found/generic exceptions, cursor redaction</td>
+      </tr>
+      <tr>
+        <td><span class="slice-name">CursorPaginationParamsTest</span></td>
+        <td>8</td>
+        <td>Defaults, opaque preservation, blank normalization, invalid/oversized page caps, narrower endpoint max, record surface, immutability</td>
+      </tr>
+      <tr>
+        <td><span class="slice-name">CursorToolResponseTest</span></td>
+        <td>5</td>
+        <td>Success metadata, validation/execution errors, defensive copying, record surface</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ────────────────────────────────────────────────────── -->
+<!-- CHAPTER 8: Diagnostic Gate -->
+<!-- ────────────────────────────────────────────────────── -->
+<section class="chapter" id="gate">
+  <div class="chapter-header">
+    <span class="chapter-number yellow">8</span>
+    <h2>Diagnostic Gate Script</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>The script <code>hack/verify-s9d-cursor-pagination.sh</code> is a comprehensive diagnostic gate that validates both runtime behavior and source-level invariants.</strong>
+    It runs the focused cursor tests, scans the Gradle output for forbidden secrets/cursor values, then performs static assertions on the source files. This is the same pattern used by previous slice gates (S4A, S4B, S4C, S8).
+  </p>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">hack/verify-s9d-cursor-pagination.sh &mdash; test runner + leak scan</span>
+      <span class="badge badge-new">NEW</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">69</span><span class="code">COMMAND=(</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">70</span><span class="code">  ./gradlew --no-daemon</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">71</span><span class="code">  :contrast-mcp-core:test</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">72</span><span class="code">  --tests <span class="str">'*Cursor*'</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">73</span><span class="code">)</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">74</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">75</span><span class="code"><span class="comment"># ... runs tests, then scans output for forbidden patterns:</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">80</span><span class="code"><span class="kw">if</span> grep -Eiq <span class="str">'eyJ[A-Za-z0-9._-]*|bearer[[:space:]]+[A-Za-z0-9._-]+|</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">81</span><span class="code"><span class="str">  api[_-]?key|service[_-]?key|opaque\.cursor/with\+symbols=='</span> ...</span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>The leak scan catches both real secrets and the test's own opaque cursor constant.</strong> If any test accidentally logs the cursor value (instead of <code>cursorPresence()</code>), the grep pattern <code>opaque\.cursor/with\+symbols==</code> matches it in the Gradle output. The scan also watches for JWT tokens, bearer strings, and API keys.
+    </div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">verify-s9d-cursor-pagination.sh &mdash; source-level assertions</span>
+      <span class="badge badge-new">NEW</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">98</span><span class="code">assert_contains <span class="str">"cursor_tool_uses_final_pipeline"</span> "$CURSOR_TOOL" \</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">99</span><span class="code">  <span class="str">'protected final CursorToolResponse&lt;R&gt; executePipeline'</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">100</span><span class="code">assert_contains <span class="str">"cursor_tool_logs_presence_marker"</span> "$CURSOR_TOOL" \</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">101</span><span class="code">  <span class="str">'LoggingKeys\.CURSOR, pagination\.cursorPresence\(\)'</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">102</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">106</span><span class="code">assert_not_contains <span class="str">"cursor_tool_does_not_log_cursor_value"</span> "$CURSOR_TOOL" \</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">107</span><span class="code">  <span class="str">'LoggingKeys\.CURSOR, (cursor([^A-Za-z]|$)|pagination\.cursor()'</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">108</span><span class="code">assert_not_contains <span class="str">"cursor_response_excludes_random_access_fields"</span> \</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">109</span><span class="code">  "$CURSOR_RESPONSE" <span class="str">'totalPages|hasMorePages|totalItems|offset'</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">110</span><span class="code">assert_not_contains <span class="str">"stdio_app_does_not_register_observation_cursor_tools"</span> \</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">111</span><span class="code">  "$STDIO_APP" <span class="str">'list_issue_observations|list_incident_observations'</span></span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>The gate enforces three categories of source-level properties:</strong>
+      (1) <em>Pipeline integrity</em> &mdash; <code>executePipeline</code> is <code>final</code>, uses <code>cursorPresence()</code> for logging.
+      (2) <em>No leaks</em> &mdash; no call site logs the raw cursor value, no <code>sortAfter</code> in params, no random-access fields in response.
+      (3) <em>Registration gate</em> &mdash; the local stdio app (<code>McpContrastApplication.java</code>) doesn't register <code>list_issue_observations</code> or <code>list_incident_observations</code>.
+    </div>
+  </div>
+</section>
+
+<!-- ────────────────────────────────────────────────────── -->
+<!-- CHAPTER 9: Summary -->
+<!-- ────────────────────────────────────────────────────── -->
+<section class="chapter" id="summary">
+  <div class="chapter-header">
+    <span class="chapter-number blue">9</span>
+    <h2>Summary &amp; What's Next</h2>
+  </div>
+
+  <div class="slice-columns">
+    <div class="slice-col this-pr">
+      <div class="slice-title">This PR (S9D)</div>
+      <div class="slice-item"><span class="dot"></span><strong>CursorPaginatedTool</strong> &mdash; abstract base with <code>final executePipeline()</code></div>
+      <div class="slice-item"><span class="dot"></span><strong>CursorPaginationParams</strong> &mdash; opaque cursor + pageSize validation</div>
+      <div class="slice-item"><span class="dot"></span><strong>CursorExecutionResult</strong> &mdash; intermediate result with nextCursor/hasMore</div>
+      <div class="slice-item"><span class="dot"></span><strong>CursorToolResponse</strong> &mdash; agent-visible response without page/total fields</div>
+      <div class="slice-item"><span class="dot"></span><strong>22 tests</strong> covering cursor lifecycle, leak prevention, and record surfaces</div>
+      <div class="slice-item"><span class="dot"></span><strong>Diagnostic gate</strong> with test runner + leak scan + source assertions</div>
+    </div>
+    <div class="slice-col future-col">
+      <div class="slice-title">S9E (Next: observation tools in aiml-services)</div>
+      <div class="slice-item"><span class="dot"></span><code>get_observation</code> &mdash; SingleTool detail lookup by observationId</div>
+      <div class="slice-item"><span class="dot"></span><code>list_issue_observations</code> &mdash; cursor-backed, using this PR's types</div>
+      <div class="slice-item"><span class="dot"></span><code>list_incident_observations</code> &mdash; cursor-backed, using this PR's types</div>
+      <div class="slice-item"><span class="dot"></span>CAG-routed observation client with opaque cursor pass-through</div>
+      <div class="slice-item"><span class="dot"></span>Generated schema assertions proving no hidden auth/org/cursor internals</div>
+    </div>
+  </div>
+
+  <div class="callout future">
+    <span class="callout-label">Future work</span>
+    <strong>S9F adds mutation tools (<code>update_issue_status</code>, <code>update_incident_status</code>) but keeps them unregistered</strong> until the Security approval gate (<code>mcp-9fqo.2</code>) is complete. After all of Slice 9, Slice 12 runs the full parity and release hardening gates.
+  </div>
+
+  <table class="file-table">
+    <thead><tr><th>File</th><th>Purpose</th><th>Lines</th><th>Novelty</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>CursorPaginatedTool.java</td>
+        <td>Abstract base class with final executePipeline for cursor tools</td>
+        <td class="addition">+192</td>
+        <td class="novelty"><span class="novelty-badge novel">Novel</span></td>
+      </tr>
+      <tr>
+        <td>CursorPaginationParams.java</td>
+        <td>Opaque cursor + pageSize validation record</td>
+        <td class="addition">+102</td>
+        <td class="novelty"><span class="novelty-badge novel">Novel</span></td>
+      </tr>
+      <tr>
+        <td>CursorToolResponse.java</td>
+        <td>Response wrapper without random-access page fields</td>
+        <td class="addition">+77</td>
+        <td class="novelty"><span class="novelty-badge pattern">Pattern</span></td>
+      </tr>
+      <tr>
+        <td>CursorExecutionResult.java</td>
+        <td>Intermediate result bridging doExecute to response</td>
+        <td class="addition">+44</td>
+        <td class="novelty"><span class="novelty-badge pattern">Pattern</span></td>
+      </tr>
+      <tr>
+        <td>LoggingKeys.java</td>
+        <td>Added CURSOR constant</td>
+        <td class="addition">+1</td>
+        <td class="novelty"><span class="novelty-badge standard">Standard</span></td>
+      </tr>
+      <tr>
+        <td>CursorPaginatedToolTest.java</td>
+        <td>9 tests: pipeline, exceptions, cursor redaction</td>
+        <td class="addition">+237</td>
+        <td class="novelty"><span class="novelty-badge novel">Novel</span></td>
+      </tr>
+      <tr>
+        <td>CursorPaginationParamsTest.java</td>
+        <td>8 tests: defaults, caps, opaque preservation, record surface</td>
+        <td class="addition">+112</td>
+        <td class="novelty"><span class="novelty-badge novel">Novel</span></td>
+      </tr>
+      <tr>
+        <td>CursorToolResponseTest.java</td>
+        <td>5 tests: success, errors, defensive copying, record surface</td>
+        <td class="addition">+91</td>
+        <td class="novelty"><span class="novelty-badge pattern">Pattern</span></td>
+      </tr>
+      <tr>
+        <td>verify-s9d-cursor-pagination.sh</td>
+        <td>Diagnostic gate: tests + leak scan + source assertions</td>
+        <td class="addition">+112</td>
+        <td class="novelty"><span class="novelty-badge pattern">Pattern</span></td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+</main>
+
+<footer>
+  PR #131 &middot; AIML-763 &middot; Contrast-Security-OSS/mcp-contrast
+</footer>
+
+</body>
+</html>

--- a/hack/verify-s9d-cursor-pagination.sh
+++ b/hack/verify-s9d-cursor-pagination.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GATE_NAME="S9D-CURSOR-PAGINATION"
+TOOLS="list_issue_observations,list_incident_observations"
+OUTPUT_FILE="$(mktemp)"
+START_SECONDS="$(date +%s)"
+
+cleanup() {
+  rm -f "${OUTPUT_FILE}"
+}
+trap cleanup EXIT
+
+log() {
+  printf '[s9d-cursor-pagination] %s\n' "$*"
+}
+
+duration_ms() {
+  local now_seconds
+  now_seconds="$(date +%s)"
+  printf '%s' "$(((now_seconds - START_SECONDS) * 1000))"
+}
+
+fail_with_tail() {
+  local assertion_summary="$1"
+  log "gate=${GATE_NAME} status=failed command='<redacted-gradle-command>' environmentTarget=local-core requestId=<redacted> traceId=<redacted> toolName=${TOOLS} authOutcome=local-noop httpStatus=not-applicable mcpStatus=failed durationMs=$(duration_ms) downstreamStatus=mocked downstreamCategory=cursor-client-gate retryRefresh=not-applicable cursor=present assertionSummary=\"${assertion_summary}\" credentials=<redacted> bearerToken=<redacted> apiKey=<redacted> serviceKey=<redacted> principal=<redacted> responseBody=<redacted>"
+  sed "s#${ROOT_DIR}#<repo-root>#g" "${OUTPUT_FILE}" | tail -80
+  exit 1
+}
+
+assert_file_exists() {
+  local assertion="$1"
+  local file="$2"
+
+  if [[ ! -f "${file}" ]]; then
+    log "gate=${GATE_NAME} assertion=${assertion} status=failed file=<repo-root>/${file#${ROOT_DIR}/} requestId=<redacted> traceId=<redacted> cursor=absent"
+    exit 1
+  fi
+  log "gate=${GATE_NAME} assertion=${assertion} status=passed file=<repo-root>/${file#${ROOT_DIR}/} requestId=<redacted> traceId=<redacted> cursor=absent"
+}
+
+assert_contains() {
+  local assertion="$1"
+  local file="$2"
+  local pattern="$3"
+
+  if ! grep -E -q "${pattern}" "${file}"; then
+    log "gate=${GATE_NAME} assertion=${assertion} status=failed file=<repo-root>/${file#${ROOT_DIR}/} pattern=<redacted> requestId=<redacted> traceId=<redacted> cursor=absent"
+    exit 1
+  fi
+  log "gate=${GATE_NAME} assertion=${assertion} status=passed file=<repo-root>/${file#${ROOT_DIR}/} requestId=<redacted> traceId=<redacted> cursor=absent"
+}
+
+assert_not_contains() {
+  local assertion="$1"
+  local file="$2"
+  local pattern="$3"
+
+  if grep -E -q "${pattern}" "${file}"; then
+    log "gate=${GATE_NAME} assertion=${assertion} status=failed file=<repo-root>/${file#${ROOT_DIR}/} pattern=<redacted> requestId=<redacted> traceId=<redacted> cursor=absent"
+    exit 1
+  fi
+  log "gate=${GATE_NAME} assertion=${assertion} status=passed file=<repo-root>/${file#${ROOT_DIR}/} requestId=<redacted> traceId=<redacted> cursor=absent"
+}
+
+cd "${ROOT_DIR}"
+
+COMMAND=(
+  ./gradlew --no-daemon
+  :contrast-mcp-core:test
+  --tests '*Cursor*'
+)
+
+log "gate=${GATE_NAME} status=start command='./gradlew --no-daemon <focused cursor tests>' environmentTarget=local-core requestId=<redacted> traceId=<redacted> toolName=${TOOLS} authOutcome=local-noop httpStatus=not-applicable mcpStatus=not-started durationMs=0 downstreamStatus=mocked downstreamCategory=cursor-client-gate retryRefresh=not-applicable cursor=absent credentials=<redacted> bearerToken=<redacted> apiKey=<redacted> serviceKey=<redacted> principal=<redacted> responseBody=<redacted>"
+
+if ! "${COMMAND[@]}" >"${OUTPUT_FILE}" 2>&1; then
+  fail_with_tail "focused cursor tests failed"
+fi
+
+if grep -Eiq 'eyJ[A-Za-z0-9._-]*|bearer[[:space:]]+[A-Za-z0-9._-]+|api[_-]?key[[:space:]]*[=:]|service[_-]?key[[:space:]]*[=:]|raw-token-value|local-org-id-should-not-serialize|AuthenticatedMcpPrincipal|BearerTokenContext|McpTransportContext|responseBodySecret|opaque\.cursor/with\+symbols==' "${OUTPUT_FILE}"; then
+  fail_with_tail "focused checks passed but Gradle output contained a forbidden secret, context, path, cursor, or response-body marker"
+fi
+
+BASE_DIR="${ROOT_DIR}/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base"
+CURSOR_TOOL="${BASE_DIR}/CursorPaginatedTool.java"
+CURSOR_PARAMS="${BASE_DIR}/CursorPaginationParams.java"
+CURSOR_RESULT="${BASE_DIR}/CursorExecutionResult.java"
+CURSOR_RESPONSE="${BASE_DIR}/CursorToolResponse.java"
+LOGGING_KEYS="${BASE_DIR}/LoggingKeys.java"
+STDIO_APP="${ROOT_DIR}/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/McpContrastApplication.java"
+
+assert_file_exists "cursor_paginated_tool_exists" "${CURSOR_TOOL}"
+assert_file_exists "cursor_pagination_params_exists" "${CURSOR_PARAMS}"
+assert_file_exists "cursor_execution_result_exists" "${CURSOR_RESULT}"
+assert_file_exists "cursor_tool_response_exists" "${CURSOR_RESPONSE}"
+
+assert_contains "cursor_tool_uses_final_pipeline" "${CURSOR_TOOL}" 'protected final CursorToolResponse<R> executePipeline'
+assert_contains "cursor_tool_accepts_opaque_cursor" "${CURSOR_TOOL}" '@Nullable String cursor'
+assert_contains "cursor_tool_returns_next_cursor" "${CURSOR_TOOL}" 'result\.nextCursor\(\)'
+assert_contains "cursor_tool_logs_presence_marker" "${CURSOR_TOOL}" 'LoggingKeys\.CURSOR, pagination\.cursorPresence\(\)'
+assert_contains "cursor_logging_key_registered" "${LOGGING_KEYS}" 'public static final String CURSOR = "cursor";'
+assert_contains "cursor_params_defaults_to_shared_page_size" "${CURSOR_PARAMS}" 'DEFAULT_PAGE_SIZE'
+assert_contains "cursor_params_caps_to_shared_max" "${CURSOR_PARAMS}" 'MAX_PAGE_SIZE'
+
+assert_not_contains "cursor_tool_does_not_log_cursor_value" "${CURSOR_TOOL}" 'LoggingKeys\.CURSOR, (cursor([^A-Za-z0-9_]|$)|pagination\.cursor\(\)|result\.nextCursor\(\))'
+assert_not_contains "cursor_main_surface_excludes_sort_after" "${BASE_DIR}/CursorPaginationParams.java" 'sortAfter|sort_after'
+assert_not_contains "cursor_response_excludes_random_access_fields" "${CURSOR_RESPONSE}" 'totalPages|hasMorePages|totalItems|offset'
+assert_not_contains "cursor_params_excludes_random_access_fields" "${CURSOR_PARAMS}" 'totalPages|hasMorePages|totalItems|offset'
+assert_not_contains "stdio_app_does_not_register_observation_cursor_tools" "${STDIO_APP}" 'list_issue_observations|list_incident_observations|ListIssueObservations|ListIncidentObservations'
+
+log "gate=${GATE_NAME} status=passed command='./gradlew --no-daemon <focused cursor tests>' environmentTarget=local-core requestId=<redacted> traceId=<redacted> toolName=${TOOLS} authOutcome=local-noop httpStatus=not-applicable mcpStatus=passed durationMs=$(duration_ms) downstreamStatus=mocked downstreamCategory=cursor-client-gate retryRefresh=not-applicable cursor=present assertionSummary=\"CursorPaginatedTool, CursorPaginationParams, CursorExecutionResult, and CursorToolResponse expose opaque cursor/pageSize semantics, omit random-access page fields, keep observation cursor tools unregistered in stdio, and avoid cursor values, sortAfter internals, credentials, principal context, stack traces, internal paths, and response-body secrets in verification artifacts\" credentials=<redacted> bearerToken=<redacted> apiKey=<redacted> serviceKey=<redacted> principal=<redacted> responseBody=<redacted>"


### PR DESCRIPTION
<!-- pr-tools:stacked:v1 -->
<!-- pr-tools:parent-pr=130 -->
<!-- pr-tools:parent-branch=AIML-762-s8-expand-shared-tools -->
<!-- pr-tools:parent-base=AIML-761-s7-error-handling-core -->
<!-- pr-tools:boundary-commit=ca6c84caeecfc29817dbcc694b6778a45a7d03b1 -->
<!-- pr-tools:managed:start -->
> ⚠️ **DO NOT MERGE** - This PR is stacked on #130. Merge that first.
>
> **Stack Context**
> - Parent PR: #130
> - Parent branch: `AIML-762-s8-expand-shared-tools`
> - Promotion target: `AIML-761-s7-error-handling-core`
<!-- pr-tools:managed:end -->

> **Reviewer walkthrough:** Run this to open the interactive walkthrough in your browser:
> ```
> gh api 'repos/Contrast-Security-OSS/mcp-contrast/contents/docs/pr-walkthrough/pr-131-cursor-pagination-core-abstraction.html?ref=AIML-763-s9-expand-dataplatform-tools' -H "Accept: application/vnd.github.raw" > /tmp/pr-131-walkthrough.html && (open /tmp/pr-131-walkthrough.html || xdg-open /tmp/pr-131-walkthrough.html)
> ```
> Guided narrative covering the cursor pagination type hierarchy, opaque token security model, and how S9D fits into the Slice 9 dataplatform tools initiative.

**Jira:** [AIML-763](https://contrast.atlassian.net/browse/AIML-763)

## Summary
Adds the cursor/keyset pagination abstraction to `contrast-mcp-core` so that dataplatform observation-list tools can expose opaque continuation tokens instead of random-access page numbers.

- New `CursorPaginatedTool` base class enforces opaque cursor pass-through, sanitized logging, and consistent error handling
- `CursorPaginationParams`, `CursorExecutionResult`, and `CursorToolResponse` records form the cursor pagination type system — no page/offset/totalPages fields by design
- Observation cursor tools (`list_issue_observations`, `list_incident_observations`) remain unregistered in stdio until hosted opaque cursor client support is wired

## Why This Change Exists
- Dataplatform observation endpoints use cursor/keyset pagination, not offset-based paging. The existing `PaginatedTool` base exposes 1-based `page`/`pageSize` which doesn't fit cursor-backed APIs.
- Exposing `sortAfter` internals or random-access page fields in the MCP schema would leak backend search mechanics and typed value lists to AI agents, violating the opaque cursor contract.
- Without this abstraction, each cursor-backed tool would need to independently implement cursor handling, validation, logging sanitization, and error mapping.

## Approach
- Created a parallel type hierarchy (`CursorPaginatedTool` alongside `PaginatedTool`) rather than trying to generalize the existing paginated base. The two pagination models have fundamentally different contracts — cursor tools expose `cursor`/`nextCursor`/`hasMore` while offset tools expose `page`/`totalPages`.
- Cursor values are treated as opaque strings throughout: never parsed, decoded, logged, or included in error messages. Logging uses `cursorPresence()` markers (`"present"`/`"absent"`) instead.
- `CursorPaginationParams` uses soft validation — invalid page sizes are corrected with warnings rather than hard errors, matching the UX pattern of existing offset pagination.
- The `executePipeline` method mirrors the template method pattern from `PaginatedTool` and `SingleTool`: validate → authenticate → execute → respond, with consistent exception mapping.

## What Changed
### `contrast-mcp-core/src/main/java/.../tool/base/`
- `CursorPaginatedTool.java` — Abstract base class with `executePipeline()` template method handling auth, validation, cursor pass-through, error mapping, and sanitized logging. Supports overridable `getMaxPageSize()` for narrower endpoint limits.
- `CursorPaginationParams.java` — Immutable record validating `cursor`/`pageSize` with default 50 and max 100 (or tool-specific cap). Provides `cursorPresence()` for safe logging.
- `CursorExecutionResult.java` — Intermediate result record bridging `doExecute()` output to response building. Carries items, nextCursor, and hasMore.
- `CursorToolResponse.java` — Response wrapper with `items`/`pageSize`/`nextCursor`/`hasMore`/`errors`/`warnings`/`durationMs`. Intentionally excludes `page`, `offset`, `totalPages`, `totalItems`.
- `LoggingKeys.java` — Added `CURSOR` constant for structured log key.

### Tests
- `CursorPaginatedToolTest.java` — 9 tests covering first-page, continuation cursor pass-through, validation short-circuit, page size warnings, HTTP/auth/not-found/generic exception handling, and cursor value redaction in errors.
- `CursorPaginationParamsTest.java` — 8 tests covering defaults, opaque cursor preservation, blank cursor normalization, invalid/oversized page size capping, narrower endpoint max, record surface assertion (no random-access fields), and immutability.
- `CursorToolResponseTest.java` — 5 tests covering success metadata, validation/execution errors, defensive list copying, and record surface assertion (no random-access fields).

### Diagnostic gate
- `hack/verify-s9d-cursor-pagination.sh` — Runs focused cursor tests, scans Gradle output for forbidden secrets/cursor values, and asserts source-level properties (opaque cursor semantics, no sortAfter, no random-access fields, observation tools unregistered in stdio).

## Testing
- 22 new unit tests across 3 test classes with full cursor lifecycle coverage
- `make check-test` passes (775 tests, 0 failures)
- `make verify` passes (967 tests, 0 failures, 8 skipped)
- `hack/verify-s9d-cursor-pagination.sh` gate passes — confirms no credential/cursor/secret leaks in test output and validates source-level cursor design constraints


[AIML-763]: https://contrast.atlassian.net/browse/AIML-763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ