### PR TITLE
[STACKED] AIML-764: Fix Ralph human-bead filtering and stacked-branch commit detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ test-plans-archive/
 ### Local tools ###
 .abacus/
 .cass/
+.gemini/
+opencode.json
 compound-engineering.local.md
 decisions/
 docs/brainstorms/

--- a/docs/pr-walkthrough/pr-132-s10-validate-oauth-staging.html
+++ b/docs/pr-walkthrough/pr-132-s10-validate-oauth-staging.html
@@ -1,0 +1,1298 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PR #132 Walkthrough: Validate OAuth Staging</title>
+<style>
+  :root {
+    --bg: #0d1117;
+    --surface: #161b22;
+    --surface-raised: #1c2128;
+    --border: #30363d;
+    --text: #e6edf3;
+    --text-muted: #8b949e;
+    --text-subtle: #6e7681;
+    --accent: #58a6ff;
+    --accent-soft: rgba(88,166,255,0.15);
+    --green: #3fb950;
+    --green-bg: rgba(63,185,80,0.15);
+    --green-border: rgba(63,185,80,0.4);
+    --red: #f85149;
+    --red-bg: rgba(248,81,73,0.10);
+    --yellow: #d29922;
+    --yellow-bg: rgba(210,153,34,0.15);
+    --purple: #bc8cff;
+    --purple-bg: rgba(188,140,255,0.12);
+    --orange: #f0883e;
+    --line-num: #484f58;
+    --diff-add-bg: rgba(63,185,80,0.10);
+    --diff-add-text: #aff5b4;
+    --diff-add-marker: #3fb950;
+    --diff-del-bg: rgba(248,81,73,0.10);
+    --diff-del-text: #ffa198;
+    --diff-del-marker: #f85149;
+    --diff-context-bg: transparent;
+    --code-bg: #0d1117;
+    --nav-bg: rgba(13,17,23,0.95);
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    overflow-x: hidden;
+  }
+
+  .hero {
+    background: linear-gradient(135deg, #0d1117 0%, #161b22 40%, #1a1e2e 70%, #161b22 100%);
+    border-bottom: 1px solid var(--border);
+    padding: 3rem 2rem 2.5rem;
+    text-align: center;
+  }
+  .hero-badge {
+    display: inline-block;
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-size: 0.8rem;
+    font-weight: 600;
+    padding: 0.3rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid rgba(88,166,255,0.3);
+    margin-bottom: 1rem;
+    letter-spacing: 0.03em;
+  }
+  .hero h1 {
+    font-size: 2.2rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin-bottom: 0.6rem;
+    background: linear-gradient(135deg, var(--text) 0%, var(--accent) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+  .hero .subtitle {
+    color: var(--text-muted);
+    font-size: 1.1rem;
+    max-width: 600px;
+    margin: 0 auto;
+  }
+  .hero-meta {
+    display: flex;
+    justify-content: center;
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+    flex-wrap: wrap;
+  }
+  .hero-meta-item {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+  }
+  .hero-meta-item strong { color: var(--text); }
+
+  nav {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: var(--nav-bg);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border);
+    padding: 0.6rem 2rem;
+    overflow-x: auto;
+  }
+  nav ol {
+    display: flex;
+    gap: 0.3rem;
+    list-style: none;
+    max-width: 1100px;
+    margin: 0 auto;
+    font-size: 0.82rem;
+    align-items: center;
+  }
+  nav li a {
+    color: var(--text-muted);
+    text-decoration: none;
+    padding: 0.35rem 0.7rem;
+    border-radius: 6px;
+    transition: all 0.15s;
+    white-space: nowrap;
+  }
+  nav li a:hover { color: var(--accent); background: var(--accent-soft); }
+  nav .nav-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.4em;
+    height: 1.4em;
+    border-radius: 50%;
+    background: var(--surface-raised);
+    border: 1px solid var(--border);
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    margin-right: 0.4em;
+  }
+  nav .nav-sep { color: var(--text-subtle); font-size: 0.75rem; }
+
+  main {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 2rem 2rem 6rem;
+  }
+
+  .chapter {
+    margin-bottom: 3.5rem;
+    scroll-margin-top: 4rem;
+  }
+  .chapter-header {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.8rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .chapter-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.2rem;
+    height: 2.2rem;
+    border-radius: 50%;
+    font-size: 1rem;
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+  .chapter-number.blue { background: var(--accent-soft); color: var(--accent); border: 1px solid rgba(88,166,255,0.3); }
+  .chapter-number.green { background: var(--green-bg); color: var(--green); border: 1px solid var(--green-border); }
+  .chapter-number.purple { background: var(--purple-bg); color: var(--purple); border: 1px solid rgba(188,140,255,0.3); }
+  .chapter-number.yellow { background: var(--yellow-bg); color: var(--yellow); border: 1px solid rgba(210,153,34,0.3); }
+  .chapter-number.orange { background: rgba(240,136,62,0.12); color: var(--orange); border: 1px solid rgba(240,136,62,0.3); }
+
+  .narrative {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    line-height: 1.75;
+    margin-bottom: 1.5rem;
+  }
+  .narrative strong { color: var(--text); font-weight: 600; }
+  .narrative code {
+    background: var(--surface-raised);
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+    font-size: 0.88em;
+    color: var(--accent);
+    border: 1px solid var(--border);
+  }
+
+  .callout {
+    border-radius: 8px;
+    padding: 1rem 1.2rem;
+    margin-bottom: 1.5rem;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    border: 1px solid;
+  }
+  .callout.why {
+    background: var(--accent-soft);
+    border-color: rgba(88,166,255,0.25);
+    color: var(--text);
+  }
+  .callout.why .callout-label { color: var(--accent); }
+  .callout.security {
+    background: var(--red-bg);
+    border-color: rgba(248,81,73,0.25);
+  }
+  .callout.security .callout-label { color: var(--red); }
+  .callout.note {
+    background: var(--yellow-bg);
+    border-color: rgba(210,153,34,0.25);
+  }
+  .callout.note .callout-label { color: var(--yellow); }
+  .callout.future {
+    background: var(--purple-bg);
+    border-color: rgba(188,140,255,0.25);
+  }
+  .callout.future .callout-label { color: var(--purple); }
+  .callout-label {
+    font-weight: 700;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 0.3rem;
+    display: block;
+  }
+
+  .diff-block {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+    margin-bottom: 1.5rem;
+  }
+  .diff-header {
+    display: flex;
+    align-items: center;
+    padding: 0.6rem 1rem;
+    background: var(--surface-raised);
+    border-bottom: 1px solid var(--border);
+    font-size: 0.82rem;
+    color: var(--text-muted);
+    gap: 0.5rem;
+  }
+  .diff-header .file-icon {
+    width: 16px; height: 16px;
+    fill: var(--text-subtle);
+    flex-shrink: 0;
+  }
+  .diff-header .filename {
+    color: var(--text);
+    font-weight: 600;
+    font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', monospace;
+    font-size: 0.82rem;
+  }
+  .diff-header .badge {
+    margin-left: auto;
+    font-size: 0.72rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    font-weight: 600;
+  }
+  .badge-new { background: var(--green-bg); color: var(--green); border: 1px solid var(--green-border); }
+  .badge-modified { background: var(--yellow-bg); color: var(--yellow); border: 1px solid rgba(210,153,34,0.3); }
+  .badge-deleted { background: var(--red-bg); color: var(--red); border: 1px solid rgba(248,81,73,0.3); }
+  .badge-renamed { background: var(--purple-bg); color: var(--purple); border: 1px solid rgba(188,140,255,0.3); }
+
+  .diff-body {
+    overflow-x: auto;
+  }
+  .diff-body pre {
+    margin: 0;
+    padding: 0.4rem 0;
+    font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', monospace;
+    font-size: 0.82rem;
+    line-height: 1.3;
+    display: flex;
+    flex-direction: column;
+  }
+  .diff-line {
+    display: flex;
+    padding: 0 1rem;
+    min-height: 1.3em;
+  }
+  .diff-line.add { background: var(--diff-add-bg); }
+  .diff-line.del { background: var(--diff-del-bg); }
+  .diff-line.context { background: var(--diff-context-bg); }
+  .diff-line .marker {
+    width: 1.2em;
+    flex-shrink: 0;
+    color: var(--text-subtle);
+    user-select: none;
+    text-align: center;
+  }
+  .diff-line.add .marker { color: var(--diff-add-marker); }
+  .diff-line.del .marker { color: var(--diff-del-marker); }
+  .diff-line .ln {
+    width: 3.5em;
+    flex-shrink: 0;
+    color: var(--line-num);
+    text-align: right;
+    padding-right: 1em;
+    user-select: none;
+  }
+  .diff-line .code {
+    flex: 1;
+    white-space: pre;
+  }
+  .diff-line .code .kw { color: #ff7b72; }
+  .diff-line .code .str { color: #a5d6ff; }
+  .diff-line .code .ann { color: #d2a8ff; }
+  .diff-line .code .type { color: #79c0ff; }
+  .diff-line .code .comment { color: var(--text-subtle); font-style: italic; }
+  .diff-line .code .prop { color: #7ee787; }
+  .diff-line .code .val { color: #a5d6ff; }
+  .diff-line .code .num { color: #79c0ff; }
+  .diff-line .code .param { color: #ffa657; }
+
+  .annotation {
+    background: var(--surface-raised);
+    border-left: 3px solid var(--accent);
+    padding: 0.7rem 1rem;
+    margin: 0 1rem 0.3rem 1rem;
+    border-radius: 0 6px 6px 0;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    line-height: 1.55;
+  }
+  .annotation strong { color: var(--text); }
+  .annotation code {
+    background: rgba(88,166,255,0.1);
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+    font-size: 0.88em;
+    color: var(--accent);
+  }
+  .annotation.security-note { border-left-color: var(--red); }
+  .annotation.future-note { border-left-color: var(--purple); }
+
+  .diagram {
+    margin-bottom: 1.5rem;
+  }
+  .diagram svg {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+  .diagram-container {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.5rem;
+    overflow-x: auto;
+  }
+  .diagram-title {
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+    margin-bottom: 0.8rem;
+  }
+
+  .slice-columns {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.2rem;
+    margin-bottom: 1.5rem;
+  }
+  @media (max-width: 768px) { .slice-columns { grid-template-columns: 1fr; } }
+  .slice-col {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.2rem 1.4rem;
+  }
+  .slice-col.this-pr { border-color: var(--green-border); }
+  .slice-col.future-col { border-color: var(--border); opacity: 0.7; }
+  .slice-col .slice-title {
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 0.8rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .slice-col.this-pr .slice-title { color: var(--green); }
+  .slice-col.future-col .slice-title { color: var(--text-subtle); }
+  .slice-item {
+    position: relative;
+    padding: 0.3rem 0 0.3rem 1rem;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+  }
+  .slice-item .dot {
+    position: absolute;
+    left: 0;
+    top: 0.65rem;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+  }
+  .slice-col.this-pr .dot { background: var(--green); }
+  .slice-col.future-col .dot { background: var(--text-subtle); }
+  .slice-item strong { color: var(--text); font-weight: 500; }
+
+  .roadmap-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1.5rem;
+    font-size: 0.85rem;
+  }
+  .roadmap-table th {
+    text-align: left;
+    padding: 0.55rem 0.8rem;
+    background: var(--surface-raised);
+    color: var(--text-muted);
+    font-weight: 600;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid var(--border);
+  }
+  .roadmap-table td {
+    padding: 0.45rem 0.8rem;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-muted);
+    vertical-align: top;
+  }
+  .roadmap-table tr:last-child td { border-bottom: none; }
+  .roadmap-table .jira-link {
+    font-family: 'SF Mono', monospace;
+    font-size: 0.8rem;
+    color: var(--accent);
+    text-decoration: none;
+  }
+  .roadmap-table .jira-link:hover { text-decoration: underline; }
+  .roadmap-table .slice-name { color: var(--text); font-weight: 500; }
+  .roadmap-table .current-row td {
+    background: var(--green-bg);
+    border-bottom-color: var(--green-border);
+  }
+  .roadmap-table .current-row .slice-name { color: var(--green); font-weight: 600; }
+  .roadmap-table .current-badge {
+    display: inline-block;
+    font-size: 0.68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    background: var(--green-bg);
+    color: var(--green);
+    border: 1px solid var(--green-border);
+    padding: 0.1rem 0.4rem;
+    border-radius: 999px;
+    margin-left: 0.4rem;
+    vertical-align: middle;
+  }
+  .done-badge {
+    display: inline-block;
+    font-size: 0.68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    background: rgba(139,148,158,0.12);
+    color: var(--text-subtle);
+    border: 1px solid rgba(139,148,158,0.25);
+    padding: 0.1rem 0.4rem;
+    border-radius: 999px;
+    margin-left: 0.4rem;
+    vertical-align: middle;
+  }
+
+  .file-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1.5rem;
+    font-size: 0.85rem;
+  }
+  .file-table th {
+    text-align: left;
+    padding: 0.6rem 1rem;
+    background: var(--surface-raised);
+    color: var(--text-muted);
+    font-weight: 600;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid var(--border);
+  }
+  .file-table td {
+    padding: 0.55rem 1rem;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-muted);
+  }
+  .file-table td:first-child {
+    font-family: 'SF Mono', monospace;
+    font-size: 0.82rem;
+    color: var(--accent);
+  }
+  .file-table tr:last-child td { border-bottom: none; }
+  .file-table .addition { color: var(--green); }
+  .file-table .deletion { color: var(--red); }
+
+  .standard-pattern {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    margin-bottom: 1.5rem;
+    overflow: hidden;
+  }
+  .standard-pattern summary {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.7rem 1rem;
+    cursor: pointer;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    background: var(--surface-raised);
+    border-bottom: 1px solid transparent;
+    list-style: none;
+    transition: background 0.15s;
+  }
+  .standard-pattern summary::-webkit-details-marker { display: none; }
+  .standard-pattern summary::before {
+    content: '\25B6';
+    font-size: 0.65rem;
+    color: var(--text-subtle);
+    transition: transform 0.15s;
+    flex-shrink: 0;
+  }
+  .standard-pattern[open] summary::before { transform: rotate(90deg); }
+  .standard-pattern[open] summary { border-bottom-color: var(--border); }
+  .standard-pattern summary:hover { background: rgba(88,166,255,0.06); }
+  .standard-pattern .sp-icon {
+    width: 16px; height: 16px;
+    fill: var(--text-subtle);
+    flex-shrink: 0;
+  }
+  .standard-pattern .sp-title {
+    color: var(--text);
+    font-weight: 600;
+    flex: 1;
+  }
+  .standard-pattern .sp-files {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 0.78rem;
+    color: var(--text-subtle);
+  }
+  .standard-pattern .sp-ref {
+    font-size: 0.78rem;
+    color: var(--text-subtle);
+    margin-left: auto;
+    white-space: nowrap;
+  }
+  .badge-standard {
+    background: rgba(139,148,158,0.15);
+    color: var(--text-muted);
+    border: 1px solid rgba(139,148,158,0.3);
+    font-size: 0.68rem;
+    font-weight: 600;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    letter-spacing: 0.03em;
+    white-space: nowrap;
+  }
+  .standard-pattern .sp-body {
+    padding: 0.8rem 1rem;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    line-height: 1.6;
+  }
+  .standard-pattern .sp-body code {
+    background: var(--surface-raised);
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+    font-size: 0.88em;
+    color: var(--accent);
+    border: 1px solid var(--border);
+  }
+
+  .file-table .novelty { text-align: center; }
+  .novelty-badge {
+    display: inline-block;
+    font-size: 0.68rem;
+    font-weight: 600;
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    letter-spacing: 0.02em;
+  }
+  .novelty-badge.novel { background: var(--accent-soft); color: var(--accent); border: 1px solid rgba(88,166,255,0.3); }
+  .novelty-badge.standard { background: rgba(139,148,158,0.12); color: var(--text-subtle); border: 1px solid rgba(139,148,158,0.25); }
+  .novelty-badge.pattern { background: var(--yellow-bg); color: var(--yellow); border: 1px solid rgba(210,153,34,0.3); }
+
+  footer {
+    text-align: center;
+    padding: 2rem;
+    color: var(--text-subtle);
+    font-size: 0.8rem;
+    border-top: 1px solid var(--border);
+    margin-top: 3rem;
+  }
+
+  /* Client matrix table */
+  .matrix-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1.5rem;
+    font-size: 0.85rem;
+  }
+  .matrix-table th {
+    text-align: left;
+    padding: 0.55rem 0.8rem;
+    background: var(--surface-raised);
+    color: var(--text-muted);
+    font-weight: 600;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid var(--border);
+  }
+  .matrix-table td {
+    padding: 0.45rem 0.8rem;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-muted);
+    vertical-align: top;
+  }
+  .matrix-table tr:last-child td { border-bottom: none; }
+  .status-working { color: var(--green); font-weight: 600; }
+  .status-blocked { color: var(--red); font-weight: 600; }
+  .status-untested { color: var(--yellow); font-weight: 600; }
+
+  @media (max-width: 768px) {
+    .hero { padding: 2rem 1rem; }
+    .hero h1 { font-size: 1.6rem; }
+    main { padding: 1.5rem 1rem 4rem; }
+    nav ol { gap: 0; }
+  }
+</style>
+</head>
+<body>
+
+<!-- ===== HERO ===== -->
+<div class="hero">
+  <span class="hero-badge">PR #132 &middot; AIML-764</span>
+  <h1>Validate OAuth Staging</h1>
+  <p class="subtitle">
+    Slice 10 tested real staging infrastructure for the first time. The bulk of that work happened in aiml-services &mdash; this companion PR captures the operational learnings and tooling fixes that fed back into the public repo.
+  </p>
+  <div class="hero-meta">
+    <span class="hero-meta-item"><strong>Branch:</strong> AIML-764-s10-validate-oauth-staging</span>
+    <span class="hero-meta-item"><strong>Base:</strong> AIML-763-s9-expand-dataplatform-tools (stacked)</span>
+    <span class="hero-meta-item"><strong>Files:</strong> 4 changed</span>
+    <span class="hero-meta-item"><strong>Lines:</strong> +108 / &minus;1,549</span>
+  </div>
+</div>
+
+<!-- ===== NAV ===== -->
+<nav>
+  <ol>
+    <li><a href="#why"><span class="nav-number">1</span>Why This PR Exists</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#scope"><span class="nav-number">2</span>Scope</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#gitignore"><span class="nav-number">3</span>.gitignore</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#ralph"><span class="nav-number">4</span>Ralph Human Filter</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#next-bead"><span class="nav-number">5</span>Stacked-Branch Detection</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#whats-next"><span class="nav-number">6</span>What&rsquo;s Next</a></li>
+  </ol>
+</nav>
+
+<main>
+
+<!-- ===== CHAPTER 1: WHY THIS PR EXISTS ===== -->
+<section class="chapter" id="why">
+  <div class="chapter-header">
+    <span class="chapter-number blue">1</span>
+    <h2>Why This PR Exists</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>Slice 10 was the first time real staging infrastructure met real MCP clients.</strong>
+    For the first time in the AIML-110 project, browser-based OAuth login, bearer token relay through the Contrast API Gateway (CAG), and a matrix of seven different MCP clients were tested against a live staging environment. The bulk of that validation work &mdash; the OAuth gates, the Spring AI upgrade, the auth-on-initialize fix, and the client compatibility scripts &mdash; all happened in the <code>aiml-services</code> repo. This public-repo PR is the feedback loop: the operational learnings that surfaced during that staging validation and looped back into the shared tooling.
+  </p>
+
+  <p class="narrative">
+    <strong>Three concrete problems emerged during client matrix testing.</strong>
+    First, Gemini CLI and opencode left local config artifacts (<code>.gemini/</code> and <code>opencode.json</code>) in the working directory. Second, Ralph attempted to pick up beads labeled <code>ready-for-human</code> that required manual browser-based OAuth testing &mdash; work an AI agent cannot perform. Third, <code>ralph-next-bead</code> silently skipped PR creation for repos on stacked branches when the parent branch had not yet been pushed to origin. Each of these problems is addressed by one of the three commits in this PR.
+  </p>
+
+  <div class="diagram">
+    <div class="diagram-container">
+      <div class="diagram-title">Slice 10 Validation Architecture</div>
+      <svg viewBox="0 0 900 340" xmlns="http://www.w3.org/2000/svg" style="max-width:900px;">
+        <!-- Background regions -->
+        <rect x="10" y="60" width="240" height="260" rx="8" fill="rgba(88,166,255,0.06)" stroke="rgba(88,166,255,0.2)" stroke-dasharray="4"/>
+        <text x="130" y="85" text-anchor="middle" fill="#58a6ff" font-size="11" font-weight="600" font-family="system-ui">MCP CLIENTS (S10D)</text>
+
+        <rect x="290" y="60" width="160" height="260" rx="8" fill="rgba(63,185,80,0.06)" stroke="rgba(63,185,80,0.2)" stroke-dasharray="4"/>
+        <text x="370" y="85" text-anchor="middle" fill="#3fb950" font-size="11" font-weight="600" font-family="system-ui">OAUTH (S10A)</text>
+
+        <rect x="490" y="60" width="180" height="260" rx="8" fill="rgba(188,140,255,0.06)" stroke="rgba(188,140,255,0.2)" stroke-dasharray="4"/>
+        <text x="580" y="85" text-anchor="middle" fill="#bc8cff" font-size="11" font-weight="600" font-family="system-ui">aiml-services</text>
+
+        <rect x="710" y="60" width="170" height="260" rx="8" fill="rgba(210,153,34,0.06)" stroke="rgba(210,153,34,0.2)" stroke-dasharray="4"/>
+        <text x="795" y="85" text-anchor="middle" fill="#d29922" font-size="11" font-weight="600" font-family="system-ui">CONTRAST PLATFORM</text>
+
+        <!-- Title -->
+        <text x="450" y="35" text-anchor="middle" fill="#e6edf3" font-size="15" font-weight="700" font-family="system-ui">S10 End-to-End Validation Flow</text>
+
+        <!-- Client boxes -->
+        <rect x="30" y="105" width="200" height="28" rx="5" fill="#161b22" stroke="#3fb950" stroke-width="1.5"/>
+        <text x="130" y="124" text-anchor="middle" fill="#3fb950" font-size="11" font-family="monospace">Claude Code 2.1.150</text>
+
+        <rect x="30" y="140" width="200" height="28" rx="5" fill="#161b22" stroke="#3fb950" stroke-width="1.5"/>
+        <text x="130" y="159" text-anchor="middle" fill="#3fb950" font-size="11" font-family="monospace">Codex 0.132.0</text>
+
+        <rect x="30" y="175" width="200" height="28" rx="5" fill="#161b22" stroke="#3fb950" stroke-width="1.5"/>
+        <text x="130" y="194" text-anchor="middle" fill="#3fb950" font-size="11" font-family="monospace">Copilot CLI 1.0.51</text>
+
+        <rect x="30" y="210" width="200" height="28" rx="5" fill="#161b22" stroke="#3fb950" stroke-width="1.5"/>
+        <text x="130" y="229" text-anchor="middle" fill="#3fb950" font-size="11" font-family="monospace">opencode 1.15.10</text>
+
+        <rect x="30" y="250" width="200" height="28" rx="5" fill="#161b22" stroke="#f85149" stroke-width="1.5"/>
+        <text x="130" y="269" text-anchor="middle" fill="#f85149" font-size="11" font-family="monospace">Gemini CLI 0.43.0</text>
+
+        <rect x="30" y="285" width="200" height="28" rx="5" fill="#161b22" stroke="#f85149" stroke-width="1.5"/>
+        <text x="130" y="304" text-anchor="middle" fill="#f85149" font-size="11" font-family="monospace">VS Code Copilot</text>
+
+        <!-- OAuth box -->
+        <rect x="305" y="150" width="130" height="50" rx="6" fill="#161b22" stroke="#3fb950" stroke-width="1.5"/>
+        <text x="370" y="172" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600" font-family="system-ui">Browser OAuth</text>
+        <text x="370" y="188" text-anchor="middle" fill="#8b949e" font-size="10" font-family="system-ui">DCR + PKCE</text>
+
+        <!-- Hosted MCP box -->
+        <rect x="505" y="115" width="150" height="40" rx="6" fill="#161b22" stroke="#bc8cff" stroke-width="1.5"/>
+        <text x="580" y="140" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600" font-family="system-ui">Hosted MCP Server</text>
+
+        <!-- CAG box -->
+        <rect x="505" y="185" width="150" height="40" rx="6" fill="#161b22" stroke="#bc8cff" stroke-width="1.5"/>
+        <text x="580" y="210" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600" font-family="system-ui">CAG</text>
+
+        <!-- Backend boxes -->
+        <rect x="725" y="115" width="140" height="35" rx="6" fill="#161b22" stroke="#d29922" stroke-width="1.5"/>
+        <text x="795" y="138" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600" font-family="system-ui">TeamServer</text>
+
+        <rect x="725" y="175" width="140" height="35" rx="6" fill="#161b22" stroke="#d29922" stroke-width="1.5"/>
+        <text x="795" y="198" text-anchor="middle" fill="#e6edf3" font-size="11" font-weight="600" font-family="system-ui">Dataplatform</text>
+
+        <!-- Arrows -->
+        <defs>
+          <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+            <path d="M0,0 L8,3 L0,6" fill="#8b949e"/>
+          </marker>
+        </defs>
+
+        <!-- Clients to OAuth -->
+        <line x1="230" y1="175" x2="300" y2="175" stroke="#8b949e" stroke-width="1.2" marker-end="url(#arrow)"/>
+        <text x="265" y="168" text-anchor="middle" fill="#6e7681" font-size="9" font-family="system-ui">token</text>
+
+        <!-- OAuth to Hosted MCP -->
+        <line x1="435" y1="165" x2="500" y2="140" stroke="#8b949e" stroke-width="1.2" marker-end="url(#arrow)"/>
+        <text x="468" y="145" text-anchor="middle" fill="#6e7681" font-size="9" font-family="system-ui">bearer</text>
+
+        <!-- Hosted MCP to CAG -->
+        <line x1="580" y1="155" x2="580" y2="180" stroke="#8b949e" stroke-width="1.2" marker-end="url(#arrow)"/>
+
+        <!-- CAG to backends -->
+        <line x1="655" y1="195" x2="720" y2="140" stroke="#8b949e" stroke-width="1.2" marker-end="url(#arrow)"/>
+        <text x="700" y="155" text-anchor="middle" fill="#6e7681" font-size="9" font-family="system-ui">S10B</text>
+
+        <line x1="655" y1="205" x2="720" y2="195" stroke="#8b949e" stroke-width="1.2" marker-end="url(#arrow)"/>
+        <text x="700" y="215" text-anchor="middle" fill="#6e7681" font-size="9" font-family="system-ui">S10C</text>
+
+        <!-- This PR annotation -->
+        <rect x="30" y="260" width="14" height="14" rx="3" fill="none" stroke="#58a6ff" stroke-width="1" stroke-dasharray="3"/>
+        <text x="215" y="333" fill="#58a6ff" font-size="10" font-style="italic" font-family="system-ui">Gemini/opencode configs led to .gitignore update in this PR</text>
+      </svg>
+    </div>
+  </div>
+
+  <div class="callout why">
+    <span class="callout-label">Key insight</span>
+    The four working clients (Claude Code, Codex, Copilot CLI, opencode) and two blocked clients (Gemini CLI, VS Code Copilot) collectively surfaced every issue addressed in this PR: config file pollution, Ralph attempting human-only beads, and stacked-branch detection failures.
+  </div>
+
+  <p class="narrative">
+    <strong>The client matrix results drove the specific fixes.</strong>
+    During S10D certification, seven MCP clients were tested against the staging hosted MCP server. Four passed end-to-end: Claude Code 2.1.150, Codex 0.132.0, Copilot CLI 1.0.51 (after the auth-on-initialize fix in <code>aiml-services</code>), and opencode 1.15.10 (also after that fix). Gemini CLI 0.43.0 was blocked by a DCR empty-scope bug, VS Code Copilot by a DCR rejection, and Claude Desktop remains untested due to its HTTPS requirement. The artifacts left by Gemini CLI and opencode during testing led directly to the <code>.gitignore</code> update, while the human-only S10D testing beads exposed the Ralph filtering gap.
+  </p>
+</section>
+
+<!-- ===== CHAPTER 2: SCOPE ===== -->
+<section class="chapter" id="scope">
+  <div class="chapter-header">
+    <span class="chapter-number green">2</span>
+    <h2>Scope &mdash; What&rsquo;s Here vs. What&rsquo;s in aiml-services</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>This is the companion PR &mdash; small but necessary.</strong>
+    Slice 10 spans two repos, but the division of labor is heavily asymmetric. The <code>aiml-services</code> repo carries the weight: OAuth gate integration, Spring AI upgrade, the <code>auth-on-initialize</code> fix that unblocked Copilot CLI and opencode, and the client matrix test scripts. This public repo carries only the operational feedback that the staging validation surfaced: config hygiene, agent tooling robustness, and housekeeping.
+  </p>
+
+  <div class="slice-columns">
+    <div class="slice-col this-pr">
+      <div class="slice-title">This PR (mcp-contrast)</div>
+      <div class="slice-item"><span class="dot"></span><strong>.gitignore</strong> &mdash; ignore Gemini CLI and opencode config artifacts</div>
+      <div class="slice-item"><span class="dot"></span><strong>scripts/ralph</strong> &mdash; skip beads labeled <code>ready-for-human</code> or <code>needs-human-review</code></div>
+      <div class="slice-item"><span class="dot"></span><strong>scripts/ralph-next-bead</strong> &mdash; fix stacked-branch commit detection with multi-level fallback</div>
+      <div class="slice-item"><span class="dot"></span><strong>Walkthrough cleanup</strong> &mdash; remove orphaned PR #131 walkthrough HTML</div>
+    </div>
+    <div class="slice-col future-col">
+      <div class="slice-title">Companion work (aiml-services)</div>
+      <div class="slice-item"><span class="dot"></span><strong>OAuth gate</strong> &mdash; browser-based OAuth login with DCR + PKCE</div>
+      <div class="slice-item"><span class="dot"></span><strong>Bearer relay</strong> &mdash; token forwarding through CAG to TeamServer/Dataplatform</div>
+      <div class="slice-item"><span class="dot"></span><strong>Auth-on-initialize</strong> &mdash; require auth on all MCP POST requests (unblocked Copilot CLI + opencode)</div>
+      <div class="slice-item"><span class="dot"></span><strong>Spring AI upgrade</strong> &mdash; version bump for MCP spec compatibility</div>
+      <div class="slice-item"><span class="dot"></span><strong>Client matrix scripts</strong> &mdash; automated test harness for 7 MCP clients</div>
+    </div>
+  </div>
+
+  <div class="callout note">
+    <span class="callout-label">Context</span>
+    The Slice 10 sub-beads tell the full story: S10A validated browser OAuth with <code>get_user_info</code>, S10B proved the first shared-tool CAG call (<code>list_vulnerability_types</code>), S10C proved the first dataplatform CAG call (<code>get_issue_count</code>), S10D certified the client matrix, and S10-pre researched local Docker testing feasibility. All five sub-slices are now CLOSED.
+  </div>
+</section>
+
+<!-- ===== CHAPTER 3: .GITIGNORE ===== -->
+<section class="chapter" id="gitignore">
+  <div class="chapter-header">
+    <span class="chapter-number yellow">3</span>
+    <h2>MCP Client Config Artifacts</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>Client matrix testing left behind tool-specific config files.</strong>
+    When running <code>gemini mcp add</code> to register the hosted MCP server, Gemini CLI creates a <code>.gemini/</code> directory for its configuration. Similarly, opencode creates an <code>opencode.json</code> file in the project root. These are local tool configs that should never be committed &mdash; the same pattern already established for <code>.abacus/</code>, <code>.cass/</code>, and other local tool directories in this project&rsquo;s <code>.gitignore</code>.
+  </p>
+
+  <details class="standard-pattern">
+    <summary>
+      <svg class="sp-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 9 4.25V1.5Zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"/></svg>
+      <span class="sp-title">Standard Pattern: Ignore local tool configs</span>
+      <span class="sp-files">.gitignore</span>
+      <span class="badge-standard">STANDARD</span>
+    </summary>
+    <div class="sp-body">
+      <p>Follows the existing pattern of ignoring local MCP client and tool configuration directories. The <code>### Local tools ###</code> section already contained <code>.abacus/</code>, <code>.cass/</code>, and <code>compound-engineering.local.md</code>. These two additions extend that pattern for Gemini CLI and opencode.</p>
+
+      <div class="diff-block" style="margin-top: 1rem;">
+        <div class="diff-header">
+          <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 9 4.25V1.5Zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"/></svg>
+          <span class="filename">.gitignore</span>
+          <span class="badge badge-modified">MODIFIED</span>
+        </div>
+        <div class="diff-body">
+<pre>
+<span class="diff-line context"><span class="ln">64</span><span class="marker"> </span><span class="code"><span class="comment">### Local tools ###</span></span></span>
+<span class="diff-line context"><span class="ln">65</span><span class="marker"> </span><span class="code">.abacus/</span></span>
+<span class="diff-line context"><span class="ln">66</span><span class="marker"> </span><span class="code">.cass/</span></span>
+<span class="diff-line add"><span class="ln">67</span><span class="marker">+</span><span class="code">.gemini/</span></span>
+<span class="diff-line add"><span class="ln">68</span><span class="marker">+</span><span class="code">opencode.json</span></span>
+<span class="diff-line context"><span class="ln">69</span><span class="marker"> </span><span class="code">compound-engineering.local.md</span></span>
+</pre>
+        </div>
+      </div>
+    </div>
+  </details>
+</section>
+
+<!-- ===== CHAPTER 4: RALPH HUMAN FILTER ===== -->
+<section class="chapter" id="ralph">
+  <div class="chapter-header">
+    <span class="chapter-number purple">4</span>
+    <h2>Ralph Learns to Skip Human-Only Beads</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>Ralph cannot open a browser, but S10D had beads that required exactly that.</strong>
+    During Slice 10 validation, several sub-beads &mdash; like the client matrix certification bead <code>mcp-g4ot</code> &mdash; required manual browser-based OAuth testing. These beads were labeled <code>ready-for-human</code> or <code>needs-human-review</code> to signal that they need a human at the keyboard. Before this fix, Ralph would pick up those beads in its work loop, attempt to dispatch Codex on them, and either fail confusingly or produce meaningless results. The fix introduces a three-layer defense: filter at selection time, filter at resume time, and a hard guard at validation time.
+  </p>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 9 4.25V1.5Zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"/></svg>
+      <span class="filename">scripts/ralph</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body">
+<pre>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code"><span class="comment"># --- Layer 1: Filter function for new bead selection ---</span></span></span>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code"></span></span>
+<span class="diff-line add"><span class="ln">130</span><span class="marker">+</span><span class="code"><span class="prop">filter_agent_ready_json</span>() {</span></span>
+<span class="diff-line add"><span class="ln">131</span><span class="marker">+</span><span class="code">  jq <span class="str">'</span></span></span>
+<span class="diff-line add"><span class="ln">132</span><span class="marker">+</span><span class="code"><span class="str">    map(</span></span></span>
+<span class="diff-line add"><span class="ln">133</span><span class="marker">+</span><span class="code"><span class="str">      select(</span></span></span>
+<span class="diff-line add"><span class="ln">134</span><span class="marker">+</span><span class="code"><span class="str">        ((.labels // []) | any(. == "ready-for-human" or . == "needs-human-review"))</span></span></span>
+<span class="diff-line add"><span class="ln">135</span><span class="marker">+</span><span class="code"><span class="str">        | not</span></span></span>
+<span class="diff-line add"><span class="ln">136</span><span class="marker">+</span><span class="code"><span class="str">      )</span></span></span>
+<span class="diff-line add"><span class="ln">137</span><span class="marker">+</span><span class="code"><span class="str">    )</span></span></span>
+<span class="diff-line add"><span class="ln">138</span><span class="marker">+</span><span class="code"><span class="str">  '</span></span></span>
+<span class="diff-line add"><span class="ln">139</span><span class="marker">+</span><span class="code">}</span></span>
+</pre>
+    </div>
+    <div class="annotation">
+      <strong>Layer 1: Selection-time filter.</strong> Applied to the output of <code>ready_json_for_parent</code> in the main loop. Uses jq to remove any bead whose labels array contains either <code>ready-for-human</code> or <code>needs-human-review</code>. This prevents human-only beads from ever entering Ralph's candidate pool.
+    </div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 9 4.25V1.5Zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"/></svg>
+      <span class="filename">scripts/ralph</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body">
+<pre>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code"><span class="comment"># --- Layer 1b: Predicate for validation guard ---</span></span></span>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code"></span></span>
+<span class="diff-line add"><span class="ln">141</span><span class="marker">+</span><span class="code"><span class="prop">has_human_only_label</span>() {</span></span>
+<span class="diff-line add"><span class="ln">142</span><span class="marker">+</span><span class="code">  jq -e <span class="str">'</span></span></span>
+<span class="diff-line add"><span class="ln">143</span><span class="marker">+</span><span class="code"><span class="str">    (.[0].labels // []) | any(. == "ready-for-human" or . == "needs-human-review")</span></span></span>
+<span class="diff-line add"><span class="ln">144</span><span class="marker">+</span><span class="code"><span class="str">  '</span> &gt;/dev/null &lt;&lt;&lt;<span class="str">"$1"</span></span></span>
+<span class="diff-line add"><span class="ln">145</span><span class="marker">+</span><span class="code">}</span></span>
+</pre>
+    </div>
+    <div class="annotation">
+      <strong>Companion predicate.</strong> Used by the validation guard (Layer 3). Takes bead JSON as a here-string argument and returns success if the bead carries a human-only label. Separated from the filter function because the validation path needs a boolean check on a single bead, not a stream filter.
+    </div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 9 4.25V1.5Zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"/></svg>
+      <span class="filename">scripts/ralph</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body">
+<pre>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code"><span class="comment"># --- Layer 2: Resume-time filter (find_incomplete_bead rewrite) ---</span></span></span>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code"></span></span>
+<span class="diff-line del"><span class="ln"></span><span class="marker">-</span><span class="code">  count=<span class="str">"$(jq '.issues | length' &lt;&lt;&lt;"$incomplete_json")"</span></span></span>
+<span class="diff-line del"><span class="ln"></span><span class="marker">-</span><span class="code">  <span class="kw">if</span> [[ <span class="str">"$count"</span> -gt <span class="num">0</span> ]]; <span class="kw">then</span></span></span>
+<span class="diff-line del"><span class="ln"></span><span class="marker">-</span><span class="code">    jq -r <span class="str">'.issues[0].id'</span> &lt;&lt;&lt;<span class="str">"$incomplete_json"</span></span></span>
+<span class="diff-line del"><span class="ln"></span><span class="marker">-</span><span class="code">  <span class="kw">fi</span></span></span>
+<span class="diff-line add"><span class="ln">161</span><span class="marker">+</span><span class="code">  jq -r <span class="str">'</span></span></span>
+<span class="diff-line add"><span class="ln">162</span><span class="marker">+</span><span class="code"><span class="str">    .issues</span></span></span>
+<span class="diff-line add"><span class="ln">163</span><span class="marker">+</span><span class="code"><span class="str">    | map(</span></span></span>
+<span class="diff-line add"><span class="ln">164</span><span class="marker">+</span><span class="code"><span class="str">        select(</span></span></span>
+<span class="diff-line add"><span class="ln">165</span><span class="marker">+</span><span class="code"><span class="str">          ((.labels // []) | any(. == "ready-for-human" or . == "needs-human-review"))</span></span></span>
+<span class="diff-line add"><span class="ln">166</span><span class="marker">+</span><span class="code"><span class="str">          | not</span></span></span>
+<span class="diff-line add"><span class="ln">167</span><span class="marker">+</span><span class="code"><span class="str">        )</span></span></span>
+<span class="diff-line add"><span class="ln">168</span><span class="marker">+</span><span class="code"><span class="str">      )</span></span></span>
+<span class="diff-line add"><span class="ln">169</span><span class="marker">+</span><span class="code"><span class="str">    | .[0].id // empty</span></span></span>
+<span class="diff-line add"><span class="ln">170</span><span class="marker">+</span><span class="code"><span class="str">  '</span> &lt;&lt;&lt;<span class="str">"$incomplete_json"</span></span></span>
+</pre>
+    </div>
+    <div class="annotation">
+      <strong>Layer 2: Resume-time filter.</strong> The old <code>find_incomplete_bead</code> grabbed the first in-progress bead without checking labels. If Ralph had previously claimed a human-only bead (before this fix existed) and crashed, it would resume that bead on restart. The rewrite applies the same human-only filter when scanning for incomplete beads, using <code>// empty</code> to return nothing if all in-progress beads are human-only.
+    </div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 9 4.25V1.5Zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"/></svg>
+      <span class="filename">scripts/ralph</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body">
+<pre>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code"><span class="comment"># --- Layer 3: Validation guard in validate_bead_and_repo_label ---</span></span></span>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code"></span></span>
+<span class="diff-line context"><span class="ln">199</span><span class="marker"> </span><span class="code">  [[ <span class="str">"$status"</span> == <span class="str">"open"</span> || <span class="str">"$status"</span> == <span class="str">"in_progress"</span> ]] || die <span class="str">"$bead_id has unexpected status: $status"</span></span></span>
+<span class="diff-line add"><span class="ln">200</span><span class="marker">+</span><span class="code">  <span class="kw">if</span> has_human_only_label <span class="str">"$bead_json"</span>; <span class="kw">then</span></span></span>
+<span class="diff-line add"><span class="ln">201</span><span class="marker">+</span><span class="code">    die <span class="str">"$bead_id is labeled ready-for-human or needs-human-review; Ralph must not run human-only work"</span></span></span>
+<span class="diff-line add"><span class="ln">202</span><span class="marker">+</span><span class="code">  <span class="kw">fi</span></span></span>
+</pre>
+    </div>
+    <div class="annotation">
+      <strong>Layer 3: Hard guard.</strong> Defense-in-depth &mdash; even if Layers 1 and 2 somehow let a human-only bead through (e.g., a bead&rsquo;s label was added between selection and validation), this guard catches it with a fatal error and a clear message. The <code>die</code> call exits Ralph immediately, preventing Codex dispatch.
+    </div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 9 4.25V1.5Zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"/></svg>
+      <span class="filename">scripts/ralph</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body">
+<pre>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code"><span class="comment"># --- Main loop integration ---</span></span></span>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code"></span></span>
+<span class="diff-line context"><span class="ln">365</span><span class="marker"> </span><span class="code">      ready_json=<span class="str">"$(ready_json_for_parent "$parent" "$repo_filter")"</span></span></span>
+<span class="diff-line add"><span class="ln">366</span><span class="marker">+</span><span class="code">      ready_json=<span class="str">"$(filter_agent_ready_json &lt;&lt;&lt;"$ready_json")"</span></span></span>
+<span class="diff-line context"><span class="ln">367</span><span class="marker"> </span><span class="code">      ready_count=<span class="str">"$(jq 'length' &lt;&lt;&lt;"$ready_json")"</span></span></span>
+<span class="diff-line context"><span class="ln">368</span><span class="marker"> </span><span class="code">      <span class="kw">if</span> [[ <span class="str">"$ready_count"</span> == <span class="str">"0"</span> ]]; <span class="kw">then</span></span></span>
+<span class="diff-line del"><span class="ln"></span><span class="marker">-</span><span class="code">        printf <span class="str">'ralph: no ready work for parent %s\n'</span> <span class="str">"$parent"</span></span></span>
+<span class="diff-line add"><span class="ln">369</span><span class="marker">+</span><span class="code">        printf <span class="str">'ralph: no agent-ready work for parent %s\n'</span> <span class="str">"$parent"</span></span></span>
+</pre>
+    </div>
+    <div class="annotation">
+      <strong>Layer 1 integration point.</strong> The filter is applied immediately after fetching the ready JSON from <code>br ready</code>. The log message is also updated from "no ready work" to "no <em>agent-ready</em> work" &mdash; a subtle but important distinction. There might still be ready beads for the parent, but they are all human-only. The new message makes that visible to the operator.
+    </div>
+  </div>
+</section>
+
+<!-- ===== CHAPTER 5: STACKED-BRANCH DETECTION ===== -->
+<section class="chapter" id="next-bead">
+  <div class="chapter-header">
+    <span class="chapter-number orange">5</span>
+    <h2>Fixing Stacked-Branch Commit Detection</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>On stacked branches, the old <code>repo_has_commits</code> could silently report "no commits" and skip PR creation entirely.</strong>
+    The <code>ralph-next-bead</code> script orchestrates the transition between beads: creating PRs for completed work, generating walkthroughs, and setting up stacked branches for the next bead. Its <code>repo_has_commits</code> function determines whether a repo has work to PR. The old implementation relied on <code>stacked-pr-facts.sh detect-base-candidates</code> to find the base branch, then counted commits from <code>origin/&lt;base&gt;..HEAD</code>. The problem: on stacked branches where the parent has not yet been pushed to origin, <code>stacked-pr-facts.sh</code> fails and the function returned false &mdash; causing the entire PR creation + walkthrough pipeline to be skipped for a repo with real commits.
+  </p>
+
+  <p class="narrative">
+    <strong>The fix replaces the single-shot approach with a multi-level fallback cascade.</strong>
+    Each level degrades gracefully to the next, and diagnostic variables (<code>_RHC_BASE</code>, <code>_RHC_COUNT</code>, <code>_RHC_METHOD</code>) are exported at every step so the calling code can log exactly which detection strategy was used and what it found.
+  </p>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 9 4.25V1.5Zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"/></svg>
+      <span class="filename">scripts/ralph-next-bead</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body">
+<pre>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code"><span class="comment"># --- Diagnostic variables exported for logging ---</span></span></span>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code"></span></span>
+<span class="diff-line add"><span class="ln">98</span><span class="marker">+</span><span class="code"><span class="comment"># Exported by repo_has_commits for diagnostic logging.</span></span></span>
+<span class="diff-line add"><span class="ln">99</span><span class="marker">+</span><span class="code">_RHC_BASE=<span class="str">""</span></span></span>
+<span class="diff-line add"><span class="ln">100</span><span class="marker">+</span><span class="code">_RHC_COUNT=<span class="str">""</span></span></span>
+<span class="diff-line add"><span class="ln">101</span><span class="marker">+</span><span class="code">_RHC_METHOD=<span class="str">""</span></span></span>
+</pre>
+    </div>
+    <div class="annotation">
+      <strong>Diagnostic tracing.</strong> Three module-level variables that <code>repo_has_commits</code> populates on every invocation. <code>_RHC_BASE</code> records which base branch was used, <code>_RHC_COUNT</code> holds the commit count, and <code>_RHC_METHOD</code> identifies which detection strategy succeeded. The calling code in <code>process_repo</code> logs all three, making it trivial to diagnose why a repo was processed or skipped.
+    </div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 9 4.25V1.5Zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"/></svg>
+      <span class="filename">scripts/ralph-next-bead</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body">
+<pre>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code"><span class="comment"># --- repo_has_commits: multi-level fallback rewrite ---</span></span></span>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code"></span></span>
+<span class="diff-line add"><span class="ln">103</span><span class="marker">+</span><span class="code"><span class="prop">repo_has_commits</span>() {</span></span>
+<span class="diff-line add"><span class="ln">104</span><span class="marker">+</span><span class="code">  <span class="kw">local</span> repo_dir=<span class="str">"$1"</span></span></span>
+<span class="diff-line add"><span class="ln">105</span><span class="marker">+</span><span class="code">  <span class="kw">local</span> current_branch default_branch</span></span>
+<span class="diff-line add"><span class="ln">106</span><span class="marker">+</span><span class="code">  _RHC_BASE=<span class="str">""</span> ; _RHC_COUNT=<span class="str">""</span> ; _RHC_METHOD=<span class="str">""</span></span></span>
+<span class="diff-line add"><span class="ln">107</span><span class="marker">+</span><span class="code"></span></span>
+<span class="diff-line add"><span class="ln">108</span><span class="marker">+</span><span class="code">  current_branch=$(cd <span class="str">"$repo_dir"</span> &amp;&amp; git branch --show-current)</span></span>
+<span class="diff-line add"><span class="ln">109</span><span class="marker">+</span><span class="code">  default_branch=$(cd <span class="str">"$repo_dir"</span> &amp;&amp; git symbolic-ref --short refs/remotes/origin/HEAD <span class="num">2</span>&gt;/dev/null \</span></span>
+<span class="diff-line add"><span class="ln">110</span><span class="marker">+</span><span class="code">    | sed <span class="str">'s#^origin/##'</span> || echo <span class="str">"main"</span>)</span></span>
+<span class="diff-line add"><span class="ln">111</span><span class="marker">+</span><span class="code"></span></span>
+<span class="diff-line add"><span class="ln">112</span><span class="marker">+</span><span class="code">  <span class="kw">if</span> [[ <span class="str">"$current_branch"</span> == <span class="str">"$default_branch"</span> ]]; <span class="kw">then</span></span></span>
+<span class="diff-line add"><span class="ln">113</span><span class="marker">+</span><span class="code">    _RHC_METHOD=<span class="str">"on-default-branch"</span></span></span>
+<span class="diff-line add"><span class="ln">114</span><span class="marker">+</span><span class="code">    <span class="kw">return</span> <span class="num">1</span></span></span>
+<span class="diff-line add"><span class="ln">115</span><span class="marker">+</span><span class="code">  <span class="kw">fi</span></span></span>
+</pre>
+    </div>
+    <div class="annotation">
+      <strong>Early exit for default branch.</strong> If the repo is on <code>main</code> (or whatever the default branch is), there is no feature work to PR. The function returns false immediately with <code>_RHC_METHOD="on-default-branch"</code>.
+    </div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 9 4.25V1.5Zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"/></svg>
+      <span class="filename">scripts/ralph-next-bead</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body">
+<pre>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code"><span class="comment"># --- Level 1: Try stacked-pr-facts for precise base ---</span></span></span>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code"></span></span>
+<span class="diff-line add"><span class="ln">117</span><span class="marker">+</span><span class="code">  <span class="kw">local</span> facts base_branch=<span class="str">""</span> facts_err</span></span>
+<span class="diff-line add"><span class="ln">118</span><span class="marker">+</span><span class="code">  <span class="kw">if</span> facts_err=$(cd <span class="str">"$repo_dir"</span> &amp;&amp; bash <span class="str">"$PR_TOOLS_SCRIPTS/stacked-pr-facts.sh"</span> detect-base-candidates <span class="num">2</span>&gt;&amp;<span class="num">1</span>); <span class="kw">then</span></span></span>
+<span class="diff-line add"><span class="ln">119</span><span class="marker">+</span><span class="code">    base_branch=$(echo <span class="str">"$facts_err"</span> | jq -r <span class="str">'</span></span></span>
+<span class="diff-line add"><span class="ln">120</span><span class="marker">+</span><span class="code"><span class="str">      if .configuredParent != null and .configuredParent.branch != null then</span></span></span>
+<span class="diff-line add"><span class="ln">121</span><span class="marker">+</span><span class="code"><span class="str">        .configuredParent.branch</span></span></span>
+<span class="diff-line add"><span class="ln">122</span><span class="marker">+</span><span class="code"><span class="str">      else</span></span></span>
+<span class="diff-line add"><span class="ln">123</span><span class="marker">+</span><span class="code"><span class="str">        .defaultBranch</span></span></span>
+<span class="diff-line add"><span class="ln">124</span><span class="marker">+</span><span class="code"><span class="str">      end</span></span></span>
+<span class="diff-line add"><span class="ln">125</span><span class="marker">+</span><span class="code"><span class="str">    '</span> <span class="num">2</span>&gt;/dev/null) || <span class="kw">true</span></span></span>
+<span class="diff-line add"><span class="ln">126</span><span class="marker">+</span><span class="code">    _RHC_METHOD=<span class="str">"stacked-pr-facts"</span></span></span>
+<span class="diff-line add"><span class="ln">127</span><span class="marker">+</span><span class="code">  <span class="kw">else</span></span></span>
+<span class="diff-line add"><span class="ln">128</span><span class="marker">+</span><span class="code">    log <span class="str">"  detect-base-candidates failed (exit $?), falling back to default branch"</span></span></span>
+<span class="diff-line add"><span class="ln">129</span><span class="marker">+</span><span class="code">    _RHC_METHOD=<span class="str">"fallback-default"</span></span></span>
+<span class="diff-line add"><span class="ln">130</span><span class="marker">+</span><span class="code">  <span class="kw">fi</span></span></span>
+<span class="diff-line add"><span class="ln">131</span><span class="marker">+</span><span class="code"></span></span>
+<span class="diff-line add"><span class="ln">132</span><span class="marker">+</span><span class="code">  <span class="kw">if</span> [[ -z <span class="str">"$base_branch"</span> ]]; <span class="kw">then</span></span></span>
+<span class="diff-line add"><span class="ln">133</span><span class="marker">+</span><span class="code">    base_branch=<span class="str">"$default_branch"</span></span></span>
+<span class="diff-line add"><span class="ln">134</span><span class="marker">+</span><span class="code">    _RHC_METHOD=<span class="str">"fallback-default"</span></span></span>
+<span class="diff-line add"><span class="ln">135</span><span class="marker">+</span><span class="code">  <span class="kw">fi</span></span></span>
+<span class="diff-line add"><span class="ln">136</span><span class="marker">+</span><span class="code"></span></span>
+<span class="diff-line add"><span class="ln">137</span><span class="marker">+</span><span class="code">  _RHC_BASE=<span class="str">"$base_branch"</span></span></span>
+</pre>
+    </div>
+    <div class="annotation">
+      <strong>Level 1: Precise base via stacked-pr-facts.</strong> The best-case path. If <code>stacked-pr-facts.sh detect-base-candidates</code> succeeds, it returns JSON with the configured parent branch (for stacked PRs) or the default branch. The jq expression prefers <code>.configuredParent.branch</code> over <code>.defaultBranch</code>. If this command fails entirely (the old behavior&rsquo;s fatal flaw), execution falls through to the default branch instead of aborting.
+    </div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 9 4.25V1.5Zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"/></svg>
+      <span class="filename">scripts/ralph-next-bead</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body">
+<pre>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code"><span class="comment"># --- Levels 2-4: Commit count with cascading fallbacks ---</span></span></span>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code"></span></span>
+<span class="diff-line add"><span class="ln">142</span><span class="marker">+</span><span class="code">  <span class="kw">local</span> count</span></span>
+<span class="diff-line add"><span class="ln">143</span><span class="marker">+</span><span class="code">  <span class="kw">if</span> count=$(cd <span class="str">"$repo_dir"</span> &amp;&amp; git rev-list --count <span class="str">"origin/$base_branch..HEAD"</span> <span class="num">2</span>&gt;/dev/null); <span class="kw">then</span></span></span>
+<span class="diff-line add"><span class="ln">144</span><span class="marker">+</span><span class="code">    : <span class="comment"># success — count is set</span></span></span>
+<span class="diff-line add"><span class="ln">145</span><span class="marker">+</span><span class="code">  <span class="kw">elif</span> count=$(cd <span class="str">"$repo_dir"</span> &amp;&amp; git rev-list --count <span class="str">"origin/$default_branch..HEAD"</span> <span class="num">2</span>&gt;/dev/null); <span class="kw">then</span></span></span>
+<span class="diff-line add"><span class="ln">146</span><span class="marker">+</span><span class="code">    _RHC_BASE=<span class="str">"$default_branch (fallback — origin/$base_branch not found)"</span></span></span>
+<span class="diff-line add"><span class="ln">147</span><span class="marker">+</span><span class="code">    _RHC_METHOD=<span class="str">"fallback-origin-missing"</span></span></span>
+<span class="diff-line add"><span class="ln">148</span><span class="marker">+</span><span class="code">  <span class="kw">elif</span> count=$(cd <span class="str">"$repo_dir"</span> &amp;&amp; git log --oneline HEAD --not --remotes <span class="num">2</span>&gt;/dev/null | wc -l | tr -d <span class="str">' '</span>); <span class="kw">then</span></span></span>
+<span class="diff-line add"><span class="ln">149</span><span class="marker">+</span><span class="code">    _RHC_BASE=<span class="str">"(all remotes)"</span></span></span>
+<span class="diff-line add"><span class="ln">150</span><span class="marker">+</span><span class="code">    _RHC_METHOD=<span class="str">"fallback-no-remotes"</span></span></span>
+<span class="diff-line add"><span class="ln">151</span><span class="marker">+</span><span class="code">  <span class="kw">else</span></span></span>
+<span class="diff-line add"><span class="ln">152</span><span class="marker">+</span><span class="code">    count=<span class="str">"0"</span></span></span>
+<span class="diff-line add"><span class="ln">153</span><span class="marker">+</span><span class="code">    _RHC_METHOD=<span class="str">"all-methods-failed"</span></span></span>
+<span class="diff-line add"><span class="ln">154</span><span class="marker">+</span><span class="code">  <span class="kw">fi</span></span></span>
+<span class="diff-line add"><span class="ln">155</span><span class="marker">+</span><span class="code"></span></span>
+<span class="diff-line add"><span class="ln">156</span><span class="marker">+</span><span class="code">  _RHC_COUNT=<span class="str">"$count"</span></span></span>
+<span class="diff-line add"><span class="ln">157</span><span class="marker">+</span><span class="code">  [[ <span class="str">"$count"</span> -gt <span class="num">0</span> ]]</span></span>
+<span class="diff-line add"><span class="ln">158</span><span class="marker">+</span><span class="code">}</span></span>
+</pre>
+    </div>
+    <div class="annotation">
+      <strong>The commit-counting cascade.</strong> Level 2 tries <code>origin/&lt;base_branch&gt;..HEAD</code>. If <code>origin/&lt;base_branch&gt;</code> does not exist (the stacked parent has not been pushed yet), Level 3 falls back to <code>origin/&lt;default_branch&gt;..HEAD</code>, which will overcount (including the parent&rsquo;s commits) but correctly reports "yes, there are commits to PR." Level 4 is the last resort: <code>git log HEAD --not --remotes</code> counts all commits that have not been pushed to any remote. Only if every method fails does the count fall to zero. This cascade is what prevents the silent skip that plagued the old implementation.
+    </div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 9 4.25V1.5Zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"/></svg>
+      <span class="filename">scripts/ralph-next-bead</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body">
+<pre>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code"><span class="comment"># --- Improved diagnostic logging in process_repo ---</span></span></span>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code"></span></span>
+<span class="diff-line add"><span class="ln">181</span><span class="marker">+</span><span class="code">      log <span class="str">"$repo_name: $_RHC_COUNT commits ahead of $_RHC_BASE (method: $_RHC_METHOD)"</span></span></span>
+<span class="diff-line context"><span class="ln"></span><span class="marker"> </span><span class="code">      <span class="comment">...</span></span></span>
+<span class="diff-line del"><span class="ln"></span><span class="marker">-</span><span class="code">      log <span class="str">"$repo_name: No commits ahead of base — skipping PR and walkthrough"</span></span></span>
+<span class="diff-line add"><span class="ln">204</span><span class="marker">+</span><span class="code">      log <span class="str">"$repo_name: No commits ahead of $_RHC_BASE (count=$_RHC_COUNT, method=$_RHC_METHOD) — skipping PR and walkthrough"</span></span></span>
+</pre>
+    </div>
+    <div class="annotation">
+      <strong>Actionable diagnostics.</strong> Both the success and skip paths now log the base branch, commit count, and detection method. Before this change, the skip message was "No commits ahead of base" with no indication of <em>which</em> base or <em>how</em> it was determined. Now the operator sees exactly what happened: <code>mcp-contrast: 3 commits ahead of AIML-763-s9-expand-dataplatform-tools (method: stacked-pr-facts)</code> or <code>aiml-services: No commits ahead of main (fallback) (count=0, method=fallback-origin-missing)</code>.
+    </div>
+  </div>
+</section>
+
+<!-- ===== CHAPTER 6: WHAT'S NEXT ===== -->
+<section class="chapter" id="whats-next">
+  <div class="chapter-header">
+    <span class="chapter-number green">6</span>
+    <h2>What&rsquo;s Next</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>Slice 10 closes the validation gate; the project now moves to hardening.</strong>
+    With OAuth, CAG bearer relay, and client compatibility validated in staging, the next slice (AIML-765, Isolation and Load Tests) will stress-test the hosted MCP server under concurrent load and verify tenant isolation. Slice 12 follows with full feature parity and the production release.
+  </p>
+
+  <table class="roadmap-table">
+    <thead>
+      <tr>
+        <th>Slice</th>
+        <th>Jira</th>
+        <th>Name</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>S7</td>
+        <td><span class="jira-link">AIML-761</span></td>
+        <td class="slice-name">Harden error handling</td>
+        <td>Closed <span class="done-badge">DONE</span></td>
+      </tr>
+      <tr>
+        <td>S8</td>
+        <td><span class="jira-link">AIML-762</span></td>
+        <td class="slice-name">Expand shared tools</td>
+        <td>Closed <span class="done-badge">DONE</span></td>
+      </tr>
+      <tr>
+        <td>S9</td>
+        <td><span class="jira-link">AIML-763</span></td>
+        <td class="slice-name">Expand dataplatform tools</td>
+        <td>Closed <span class="done-badge">DONE</span></td>
+      </tr>
+      <tr class="current-row">
+        <td>S10</td>
+        <td><span class="jira-link">AIML-764</span></td>
+        <td class="slice-name">Validate OAuth staging <span class="current-badge">THIS PR</span></td>
+        <td>Closed</td>
+      </tr>
+      <tr>
+        <td>S11</td>
+        <td><span class="jira-link">AIML-765</span></td>
+        <td class="slice-name">Isolation and load tests</td>
+        <td>Open</td>
+      </tr>
+      <tr>
+        <td>S12</td>
+        <td><span class="jira-link">AIML-766</span></td>
+        <td class="slice-name">Full parity and release</td>
+        <td>Open</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p class="narrative">
+    <strong>The MCP client matrix informs what Slice 11 needs to verify under load.</strong>
+    The four working clients (Claude Code, Codex, Copilot CLI, opencode) established the compatibility baseline. Slice 11 will stress-test concurrent sessions from these clients, verify that tenant isolation holds under parallel requests, and confirm that the CAG bearer relay does not degrade under load. The two blocked clients (Gemini CLI, VS Code Copilot) are tracked as follow-up items contingent on upstream DCR bug fixes.
+  </p>
+
+  <h3 style="color: var(--text); margin-bottom: 1rem; font-size: 1rem;">File Summary</h3>
+
+  <table class="file-table">
+    <thead>
+      <tr>
+        <th>File</th>
+        <th>Change</th>
+        <th class="novelty">Novelty</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>.gitignore</td>
+        <td><span class="addition">+2</span></td>
+        <td class="novelty"><span class="novelty-badge standard">STANDARD</span></td>
+        <td>Ignore Gemini CLI and opencode config artifacts</td>
+      </tr>
+      <tr>
+        <td>docs/pr-walkthrough/pr-131-...html</td>
+        <td><span class="deletion">&minus;1,514</span></td>
+        <td class="novelty"><span class="novelty-badge standard">STANDARD</span></td>
+        <td>Remove orphaned walkthrough superseded by cursor pagination core gate</td>
+      </tr>
+      <tr>
+        <td>scripts/ralph</td>
+        <td><span class="addition">+43</span> / <span class="deletion">&minus;10</span></td>
+        <td class="novelty"><span class="novelty-badge novel">NOVEL</span></td>
+        <td>Three-layer defense preventing Ralph from picking up human-only beads</td>
+      </tr>
+      <tr>
+        <td>scripts/ralph-next-bead</td>
+        <td><span class="addition">+63</span> / <span class="deletion">&minus;25</span></td>
+        <td class="novelty"><span class="novelty-badge novel">NOVEL</span></td>
+        <td>Multi-level fallback for stacked-branch commit detection with diagnostics</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="callout future">
+    <span class="callout-label">Looking ahead</span>
+    Slice 11 (AIML-765) will be the next stacked branch on top of this one. It focuses on isolation and load testing of the hosted MCP server &mdash; verifying that the staging infrastructure validated in Slice 10 holds up under concurrent use. The Ralph improvements in this PR will be exercised immediately, as the S11 bead tree includes both agent-automatable and human-only verification beads.
+  </div>
+</section>
+
+</main>
+
+<footer>
+  PR #132 &middot; AIML-764 &middot; Slice 10: Validate OAuth Staging &middot; mcp-contrast
+</footer>
+
+</body>
+</html>

--- a/scripts/ralph
+++ b/scripts/ralph
@@ -37,6 +37,7 @@ Usage:
 Runs a small AIML-110 implementation loop:
   - resumes any incomplete bead from a previous run before selecting new work
   - uses br ready as executable truth for new bead selection
+  - skips beads labeled ready-for-human or needs-human-review
   - claims one ready bead
   - invokes one Codex worker in the selected repo
   - saves prompt/output under history/ralph-runs/
@@ -126,14 +127,30 @@ ready_json_for_parent() {
   fi
 }
 
+filter_agent_ready_json() {
+  jq '
+    map(
+      select(
+        ((.labels // []) | any(. == "ready-for-human" or . == "needs-human-review"))
+        | not
+      )
+    )
+  '
+}
+
+has_human_only_label() {
+  jq -e '
+    (.[0].labels // []) | any(. == "ready-for-human" or . == "needs-human-review")
+  ' >/dev/null <<<"$1"
+}
+
 # Check for a bead ralph previously claimed but didn't finish. Resume it
 # before selecting new work. br list doesn't support --parent, so we query
-# all of ralph's in_progress beads and take the first one (v1 is single-
-# threaded, so there should be at most one).
+# all of ralph's in_progress agent-runnable beads and take the first one
+# (v1 is single-threaded, so there should be at most one).
 find_incomplete_bead() {
   local repo_filter="$1"
   local incomplete_json
-  local count
 
   if [[ -n "$repo_filter" ]]; then
     incomplete_json="$(run_br list --status in_progress --assignee ralph --label "$repo_filter" --json)"
@@ -141,10 +158,16 @@ find_incomplete_bead() {
     incomplete_json="$(run_br list --status in_progress --assignee ralph --json)"
   fi
 
-  count="$(jq '.issues | length' <<<"$incomplete_json")"
-  if [[ "$count" -gt 0 ]]; then
-    jq -r '.issues[0].id' <<<"$incomplete_json"
-  fi
+  jq -r '
+    .issues
+    | map(
+        select(
+          ((.labels // []) | any(. == "ready-for-human" or . == "needs-human-review"))
+          | not
+        )
+      )
+    | .[0].id // empty
+  ' <<<"$incomplete_json"
 }
 
 # Pick the first ready bead sorted by priority, then creation time, then id.
@@ -174,6 +197,9 @@ validate_bead_and_repo_label() {
   acceptance_len="$(jq '([.[0].acceptance_criteria // ""] | .[0] | length)' <<<"$bead_json")"
 
   [[ "$status" == "open" || "$status" == "in_progress" ]] || die "$bead_id has unexpected status: $status"
+  if has_human_only_label "$bead_json"; then
+    die "$bead_id is labeled ready-for-human or needs-human-review; Ralph must not run human-only work"
+  fi
 
   case "$issue_type" in
     task | bug | feature) ;;
@@ -337,9 +363,10 @@ main() {
       printf 'ralph: resuming incomplete bead %s\n' "$bead_id"
     else
       ready_json="$(ready_json_for_parent "$parent" "$repo_filter")"
+      ready_json="$(filter_agent_ready_json <<<"$ready_json")"
       ready_count="$(jq 'length' <<<"$ready_json")"
       if [[ "$ready_count" == "0" ]]; then
-        printf 'ralph: no ready work for parent %s\n' "$parent"
+        printf 'ralph: no agent-ready work for parent %s\n' "$parent"
         exit 0
       fi
 

--- a/scripts/ralph-next-bead
+++ b/scripts/ralph-next-bead
@@ -95,35 +95,65 @@ run_claude() {
   rm -f "$tmpfile"
 }
 
+# Exported by repo_has_commits for diagnostic logging.
+_RHC_BASE=""
+_RHC_COUNT=""
+_RHC_METHOD=""
+
 repo_has_commits() {
   local repo_dir="$1"
-  local current_branch
-  current_branch=$(git -C "$repo_dir" branch --show-current)
+  local current_branch default_branch
+  _RHC_BASE="" ; _RHC_COUNT="" ; _RHC_METHOD=""
 
-  local default_branch
-  default_branch=$(git -C "$repo_dir" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || echo "main")
+  current_branch=$(cd "$repo_dir" && git branch --show-current)
+  default_branch=$(cd "$repo_dir" && git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || echo "main")
 
   if [[ "$current_branch" == "$default_branch" ]]; then
+    _RHC_METHOD="on-default-branch"
     return 1
   fi
 
-  local facts base_branch
-  facts=$(cd "$repo_dir" && bash "$PR_TOOLS_SCRIPTS/stacked-pr-facts.sh" detect-base-candidates 2>/dev/null) || return 1
-
-  base_branch=$(echo "$facts" | jq -r '
-    if .configuredParent != null and .configuredParent.branch != null then
-      .configuredParent.branch
-    else
-      .defaultBranch
-    end
-  ' 2>/dev/null)
+  # Try stacked-pr-facts for the precise base branch, but fall back gracefully.
+  local facts base_branch="" facts_err
+  if facts_err=$(cd "$repo_dir" && bash "$PR_TOOLS_SCRIPTS/stacked-pr-facts.sh" detect-base-candidates 2>&1); then
+    base_branch=$(echo "$facts_err" | jq -r '
+      if .configuredParent != null and .configuredParent.branch != null then
+        .configuredParent.branch
+      else
+        .defaultBranch
+      end
+    ' 2>/dev/null) || true
+    _RHC_METHOD="stacked-pr-facts"
+  else
+    log "  detect-base-candidates failed (exit $?), falling back to default branch"
+    _RHC_METHOD="fallback-default"
+  fi
 
   if [[ -z "$base_branch" ]]; then
     base_branch="$default_branch"
+    _RHC_METHOD="fallback-default"
   fi
 
+  _RHC_BASE="$base_branch"
+
+  # Try origin/<base>..HEAD first. If origin/<base> doesn't exist (branch not
+  # pushed yet), fall back to the default branch. If that also fails, fall back
+  # to checking whether the branch simply has any unique commits at all.
   local count
-  count=$(git -C "$repo_dir" rev-list --count "origin/$base_branch..HEAD" 2>/dev/null || echo "0")
+  if count=$(cd "$repo_dir" && git rev-list --count "origin/$base_branch..HEAD" 2>/dev/null); then
+    : # success — count is set
+  elif count=$(cd "$repo_dir" && git rev-list --count "origin/$default_branch..HEAD" 2>/dev/null); then
+    _RHC_BASE="$default_branch (fallback — origin/$base_branch not found)"
+    _RHC_METHOD="fallback-origin-missing"
+  elif count=$(cd "$repo_dir" && git log --oneline HEAD --not --remotes 2>/dev/null | wc -l | tr -d ' '); then
+    _RHC_BASE="(all remotes)"
+    _RHC_METHOD="fallback-no-remotes"
+  else
+    count="0"
+    _RHC_METHOD="all-methods-failed"
+  fi
+
+  _RHC_COUNT="$count"
   [[ "$count" -gt 0 ]]
 }
 
@@ -148,6 +178,7 @@ process_repo() {
 
   if [[ -n "$COMPLETED_BEAD_ID" ]]; then
     if repo_has_commits "$repo_dir"; then
+      log "$repo_name: $_RHC_COUNT commits ahead of $_RHC_BASE (method: $_RHC_METHOD)"
       log "$repo_name: Creating PR for $COMPLETED_BEAD_ID"
       echo ""
       echo "=== $repo_name: Creating PR for $COMPLETED_BEAD_ID ==="
@@ -170,7 +201,7 @@ process_repo() {
       )
       log "$repo_name: Walkthrough complete"
     else
-      log "$repo_name: No commits ahead of base — skipping PR and walkthrough"
+      log "$repo_name: No commits ahead of $_RHC_BASE (count=$_RHC_COUNT, method=$_RHC_METHOD) — skipping PR and walkthrough"
     fi
   fi
 


### PR DESCRIPTION
<!-- pr-tools:stacked:v1 -->
<!-- pr-tools:parent-pr=131 -->
<!-- pr-tools:parent-branch=AIML-763-s9-expand-dataplatform-tools -->
<!-- pr-tools:parent-base=AIML-762-s8-expand-shared-tools -->
<!-- pr-tools:boundary-commit=7ff4806652bf586ad50b96bcc4bc4fad8efe07a0 -->
<!-- pr-tools:managed:start -->
> ⚠️ **DO NOT MERGE** - This PR is stacked on #131. Merge that first.
>
> **Stack Context**
> - Parent PR: #131
> - Parent branch: `AIML-763-s9-expand-dataplatform-tools`
> - Promotion target: `AIML-762-s8-expand-shared-tools`
<!-- pr-tools:managed:end -->

**Jira:** [AIML-764](https://contrast.atlassian.net/browse/AIML-764)

## Summary

Fix Ralph (the autonomous agent runner) to skip human-only beads and correctly detect commits on stacked branches, plus gitignore MCP client config artifacts discovered during S10D client matrix testing.

- Ralph now filters out `ready-for-human` and `needs-human-review` beads before claiming work
- `ralph-next-bead` no longer silently skips repos where the stacked parent branch hasn't been pushed to origin
- `.gemini/` and `opencode.json` added to `.gitignore` from S10D client testing

## Why This Change Exists

- Ralph was picking up beads labeled for human review, wasting agent cycles on work it can't complete
- `ralph-next-bead` used a single `git rev-list origin/<base>..HEAD` check that silently returned 0 when `origin/<base>` didn't exist (common with stacked branches not yet pushed), causing it to skip PR creation for repos that actually had commits
- S10D client matrix testing created local config files (`.gemini/`, `opencode.json`) that shouldn't be tracked

## What Changed

### `scripts/ralph`
- Added `filter_agent_ready_json()` — filters bead lists to exclude `ready-for-human` / `needs-human-review` labels
- Added `has_human_only_label()` — guard check used in `validate_bead_and_repo_label()` to hard-fail if a human-only bead slips through
- Updated `find_incomplete_bead()` to apply the same filter when resuming in-progress work

### `scripts/ralph-next-bead`
- `repo_has_commits()` now has a fallback chain: try `origin/<base>`, then `origin/<default>`, then check against all remotes
- Added diagnostic variables (`_RHC_BASE`, `_RHC_COUNT`, `_RHC_METHOD`) and log lines so skipped repos are debuggable

### `.gitignore`
- Added `.gemini/` and `opencode.json`

### `docs/pr-walkthrough/`
- Added PR #132 walkthrough HTML for code reviewers

## Testing

- `bash -n scripts/ralph` and `bash -n scripts/ralph-next-bead` pass (syntax validation)
- `ralph-next-bead` diagnostic logging confirmed in real runs during S10D validation
- Human-bead filtering validated by running Ralph against a bead set containing `needs-human-review` beads


[AIML-764]: https://contrast.atlassian.net/browse/AIML-764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
