### PR TITLE
[STACKED] AIML-765: Add non-interactive instructions to ralph-next-bead prompts

### DIFF
--- a/docs/pr-walkthrough/pr-133-non-interactive-ralph-next-bead.html
+++ b/docs/pr-walkthrough/pr-133-non-interactive-ralph-next-bead.html
@@ -1,0 +1,926 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PR #133 Walkthrough: Non-Interactive Ralph-Next-Bead Prompts</title>
+<style>
+  :root {
+    --bg: #0d1117;
+    --surface: #161b22;
+    --surface-raised: #1c2128;
+    --border: #30363d;
+    --text: #e6edf3;
+    --text-muted: #8b949e;
+    --text-subtle: #6e7681;
+    --accent: #58a6ff;
+    --accent-soft: rgba(88,166,255,0.15);
+    --green: #3fb950;
+    --green-bg: rgba(63,185,80,0.15);
+    --green-border: rgba(63,185,80,0.4);
+    --red: #f85149;
+    --red-bg: rgba(248,81,73,0.10);
+    --yellow: #d29922;
+    --yellow-bg: rgba(210,153,34,0.15);
+    --purple: #bc8cff;
+    --purple-bg: rgba(188,140,255,0.12);
+    --orange: #f0883e;
+    --line-num: #484f58;
+    --diff-add-bg: rgba(63,185,80,0.10);
+    --diff-add-text: #aff5b4;
+    --diff-add-marker: #3fb950;
+    --diff-del-bg: rgba(248,81,73,0.10);
+    --diff-del-text: #ffa198;
+    --diff-del-marker: #f85149;
+    --diff-context-bg: transparent;
+    --code-bg: #0d1117;
+    --nav-bg: rgba(13,17,23,0.95);
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    overflow-x: hidden;
+  }
+
+  .hero {
+    background: linear-gradient(135deg, #0d1117 0%, #161b22 40%, #1a1e2e 70%, #161b22 100%);
+    border-bottom: 1px solid var(--border);
+    padding: 3rem 2rem 2.5rem;
+    text-align: center;
+  }
+  .hero-badge {
+    display: inline-block;
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-size: 0.8rem;
+    font-weight: 600;
+    padding: 0.3rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid rgba(88,166,255,0.3);
+    margin-bottom: 1rem;
+    letter-spacing: 0.03em;
+  }
+  .hero h1 {
+    font-size: 2.2rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin-bottom: 0.6rem;
+    background: linear-gradient(135deg, var(--text) 0%, var(--accent) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+  .hero .subtitle {
+    color: var(--text-muted);
+    font-size: 1.1rem;
+    max-width: 600px;
+    margin: 0 auto;
+  }
+  .hero-meta {
+    display: flex;
+    justify-content: center;
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+    flex-wrap: wrap;
+  }
+  .hero-meta-item {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+  }
+  .hero-meta-item strong { color: var(--text); }
+
+  nav {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: var(--nav-bg);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border);
+    padding: 0.6rem 2rem;
+    overflow-x: auto;
+  }
+  nav ol {
+    display: flex;
+    gap: 0.3rem;
+    list-style: none;
+    max-width: 1100px;
+    margin: 0 auto;
+    font-size: 0.82rem;
+    align-items: center;
+  }
+  nav li a {
+    color: var(--text-muted);
+    text-decoration: none;
+    padding: 0.35rem 0.7rem;
+    border-radius: 6px;
+    transition: all 0.15s;
+    white-space: nowrap;
+  }
+  nav li a:hover { color: var(--accent); background: var(--accent-soft); }
+  nav .nav-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.4em;
+    height: 1.4em;
+    border-radius: 50%;
+    background: var(--surface-raised);
+    border: 1px solid var(--border);
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    margin-right: 0.4em;
+  }
+  nav .nav-sep { color: var(--text-subtle); font-size: 0.75rem; }
+
+  main {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 2rem 2rem 6rem;
+  }
+
+  .chapter {
+    margin-bottom: 3.5rem;
+    scroll-margin-top: 4rem;
+  }
+  .chapter-header {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.8rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .chapter-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.2rem;
+    height: 2.2rem;
+    border-radius: 50%;
+    font-size: 1rem;
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+  .chapter-number.blue { background: var(--accent-soft); color: var(--accent); border: 1px solid rgba(88,166,255,0.3); }
+  .chapter-number.green { background: var(--green-bg); color: var(--green); border: 1px solid var(--green-border); }
+  .chapter-number.purple { background: var(--purple-bg); color: var(--purple); border: 1px solid rgba(188,140,255,0.3); }
+  .chapter-number.yellow { background: var(--yellow-bg); color: var(--yellow); border: 1px solid rgba(210,153,34,0.3); }
+  .chapter-number.orange { background: rgba(240,136,62,0.12); color: var(--orange); border: 1px solid rgba(240,136,62,0.3); }
+
+  .narrative {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    line-height: 1.75;
+    margin-bottom: 1.5rem;
+  }
+  .narrative strong { color: var(--text); font-weight: 600; }
+  .narrative code {
+    background: var(--surface-raised);
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+    font-size: 0.88em;
+    color: var(--accent);
+    border: 1px solid var(--border);
+  }
+
+  .callout {
+    border-radius: 8px;
+    padding: 1rem 1.2rem;
+    margin-bottom: 1.5rem;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    border: 1px solid;
+  }
+  .callout.why {
+    background: var(--accent-soft);
+    border-color: rgba(88,166,255,0.25);
+    color: var(--text);
+  }
+  .callout.why .callout-label { color: var(--accent); }
+  .callout.security {
+    background: var(--red-bg);
+    border-color: rgba(248,81,73,0.25);
+  }
+  .callout.security .callout-label { color: var(--red); }
+  .callout.note {
+    background: var(--yellow-bg);
+    border-color: rgba(210,153,34,0.25);
+  }
+  .callout.note .callout-label { color: var(--yellow); }
+  .callout.future {
+    background: var(--purple-bg);
+    border-color: rgba(188,140,255,0.25);
+  }
+  .callout.future .callout-label { color: var(--purple); }
+  .callout-label {
+    font-weight: 700;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 0.3rem;
+    display: block;
+  }
+
+  .diff-block {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+    margin-bottom: 1.5rem;
+  }
+  .diff-header {
+    display: flex;
+    align-items: center;
+    padding: 0.6rem 1rem;
+    background: var(--surface-raised);
+    border-bottom: 1px solid var(--border);
+    font-size: 0.82rem;
+    color: var(--text-muted);
+    gap: 0.5rem;
+  }
+  .diff-header .file-icon {
+    width: 16px; height: 16px;
+    fill: var(--text-subtle);
+    flex-shrink: 0;
+  }
+  .diff-header .filename {
+    color: var(--text);
+    font-weight: 600;
+    font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', monospace;
+    font-size: 0.82rem;
+  }
+  .diff-header .badge {
+    margin-left: auto;
+    font-size: 0.72rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    font-weight: 600;
+  }
+  .badge-new { background: var(--green-bg); color: var(--green); border: 1px solid var(--green-border); }
+  .badge-modified { background: var(--yellow-bg); color: var(--yellow); border: 1px solid rgba(210,153,34,0.3); }
+  .badge-deleted { background: var(--red-bg); color: var(--red); border: 1px solid rgba(248,81,73,0.3); }
+
+  .diff-body {
+    overflow-x: auto;
+  }
+  .diff-body pre {
+    margin: 0;
+    padding: 0.4rem 0;
+    font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', monospace;
+    font-size: 0.82rem;
+    line-height: 1.3;
+    display: flex;
+    flex-direction: column;
+  }
+  .diff-line {
+    display: flex;
+    padding: 0 1rem;
+    min-height: 1.3em;
+  }
+  .diff-line.add {
+    background: var(--diff-add-bg);
+  }
+  .diff-line.del {
+    background: var(--diff-del-bg);
+  }
+  .diff-line.context {
+    background: var(--diff-context-bg);
+  }
+  .diff-line .marker {
+    width: 1.2em;
+    flex-shrink: 0;
+    color: var(--text-subtle);
+    user-select: none;
+    text-align: center;
+  }
+  .diff-line.add .marker { color: var(--diff-add-marker); }
+  .diff-line.del .marker { color: var(--diff-del-marker); }
+  .diff-line .ln {
+    width: 3.5em;
+    flex-shrink: 0;
+    color: var(--line-num);
+    text-align: right;
+    padding-right: 1em;
+    user-select: none;
+  }
+  .diff-line .code {
+    flex: 1;
+    white-space: pre;
+  }
+  .diff-line .code .kw { color: #ff7b72; }
+  .diff-line .code .str { color: #a5d6ff; }
+  .diff-line .code .ann { color: #d2a8ff; }
+  .diff-line .code .type { color: #79c0ff; }
+  .diff-line .code .comment { color: var(--text-subtle); font-style: italic; }
+  .diff-line .code .prop { color: #7ee787; }
+  .diff-line .code .val { color: #a5d6ff; }
+  .diff-line .code .num { color: #79c0ff; }
+  .diff-line .code .param { color: #ffa657; }
+
+  .annotation {
+    background: var(--surface-raised);
+    border-left: 3px solid var(--accent);
+    padding: 0.7rem 1rem;
+    margin: 0 1rem 0.3rem 1rem;
+    border-radius: 0 6px 6px 0;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    line-height: 1.55;
+  }
+  .annotation strong { color: var(--text); }
+  .annotation code {
+    background: rgba(88,166,255,0.1);
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+    font-size: 0.88em;
+    color: var(--accent);
+  }
+  .annotation.security-note { border-left-color: var(--red); }
+  .annotation.future-note { border-left-color: var(--purple); }
+
+  .diagram {
+    margin-bottom: 1.5rem;
+  }
+  .diagram svg {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+  .diagram-container {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.5rem;
+    overflow-x: auto;
+  }
+
+  .slice-columns {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.2rem;
+    margin-bottom: 1.5rem;
+  }
+  @media (max-width: 768px) { .slice-columns { grid-template-columns: 1fr; } }
+  .slice-col {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.2rem 1.4rem;
+  }
+  .slice-col.this-pr { border-color: var(--green-border); }
+  .slice-col.future-col { border-color: var(--border); opacity: 0.7; }
+  .slice-col .slice-title {
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 0.8rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .slice-col.this-pr .slice-title { color: var(--green); }
+  .slice-col.future-col .slice-title { color: var(--text-subtle); }
+  .slice-item {
+    position: relative;
+    padding: 0.3rem 0 0.3rem 1rem;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+  }
+  .slice-item .dot {
+    position: absolute;
+    left: 0;
+    top: 0.65rem;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+  }
+  .slice-col.this-pr .dot { background: var(--green); }
+  .slice-col.future-col .dot { background: var(--text-subtle); }
+  .slice-item strong { color: var(--text); font-weight: 500; }
+
+  .roadmap-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1.5rem;
+    font-size: 0.85rem;
+  }
+  .roadmap-table th {
+    text-align: left;
+    padding: 0.55rem 0.8rem;
+    background: var(--surface-raised);
+    color: var(--text-muted);
+    font-weight: 600;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid var(--border);
+  }
+  .roadmap-table td {
+    padding: 0.45rem 0.8rem;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-muted);
+    vertical-align: top;
+  }
+  .roadmap-table tr:last-child td { border-bottom: none; }
+  .roadmap-table .jira-link {
+    font-family: 'SF Mono', monospace;
+    font-size: 0.8rem;
+    color: var(--accent);
+    text-decoration: none;
+  }
+  .roadmap-table .jira-link:hover { text-decoration: underline; }
+  .roadmap-table .slice-name { color: var(--text); font-weight: 500; }
+  .roadmap-table .current-row td {
+    background: var(--green-bg);
+    border-bottom-color: var(--green-border);
+  }
+  .roadmap-table .current-row .slice-name { color: var(--green); font-weight: 600; }
+  .roadmap-table .current-badge {
+    display: inline-block;
+    font-size: 0.68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    background: var(--green-bg);
+    color: var(--green);
+    border: 1px solid var(--green-border);
+    padding: 0.1rem 0.4rem;
+    border-radius: 999px;
+    margin-left: 0.4rem;
+    vertical-align: middle;
+  }
+
+  .file-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1.5rem;
+    font-size: 0.85rem;
+  }
+  .file-table th {
+    text-align: left;
+    padding: 0.6rem 1rem;
+    background: var(--surface-raised);
+    color: var(--text-muted);
+    font-weight: 600;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid var(--border);
+  }
+  .file-table td {
+    padding: 0.55rem 1rem;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-muted);
+  }
+  .file-table td:first-child {
+    font-family: 'SF Mono', monospace;
+    font-size: 0.82rem;
+    color: var(--accent);
+  }
+  .file-table tr:last-child td { border-bottom: none; }
+  .file-table .addition { color: var(--green); }
+  .file-table .deletion { color: var(--red); }
+
+  .standard-pattern {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    margin-bottom: 1.5rem;
+    overflow: hidden;
+  }
+  .standard-pattern summary {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.7rem 1rem;
+    cursor: pointer;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    background: var(--surface-raised);
+    border-bottom: 1px solid transparent;
+    list-style: none;
+    transition: background 0.15s;
+  }
+  .standard-pattern summary::-webkit-details-marker { display: none; }
+  .standard-pattern summary::before {
+    content: '\25B6';
+    font-size: 0.65rem;
+    color: var(--text-subtle);
+    transition: transform 0.15s;
+    flex-shrink: 0;
+  }
+  .standard-pattern[open] summary::before { transform: rotate(90deg); }
+  .standard-pattern[open] summary { border-bottom-color: var(--border); }
+  .standard-pattern summary:hover { background: rgba(88,166,255,0.06); }
+  .standard-pattern .sp-icon {
+    width: 16px; height: 16px;
+    fill: var(--text-subtle);
+    flex-shrink: 0;
+  }
+  .standard-pattern .sp-title {
+    color: var(--text);
+    font-weight: 600;
+    flex: 1;
+  }
+  .standard-pattern .sp-files {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 0.78rem;
+    color: var(--text-subtle);
+  }
+  .standard-pattern .sp-ref {
+    font-size: 0.78rem;
+    color: var(--text-subtle);
+    margin-left: auto;
+    white-space: nowrap;
+  }
+  .badge-standard {
+    background: rgba(139,148,158,0.15);
+    color: var(--text-muted);
+    border: 1px solid rgba(139,148,158,0.3);
+    font-size: 0.68rem;
+    font-weight: 600;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    letter-spacing: 0.03em;
+    white-space: nowrap;
+  }
+  .standard-pattern .sp-body {
+    padding: 0.8rem 1rem;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    line-height: 1.6;
+  }
+  .standard-pattern .sp-body code {
+    background: var(--surface-raised);
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+    font-size: 0.88em;
+    color: var(--accent);
+    border: 1px solid var(--border);
+  }
+
+  .file-table .novelty { text-align: center; }
+  .novelty-badge {
+    display: inline-block;
+    font-size: 0.68rem;
+    font-weight: 600;
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    letter-spacing: 0.02em;
+  }
+  .novelty-badge.novel { background: var(--accent-soft); color: var(--accent); border: 1px solid rgba(88,166,255,0.3); }
+  .novelty-badge.standard { background: rgba(139,148,158,0.12); color: var(--text-subtle); border: 1px solid rgba(139,148,158,0.25); }
+  .novelty-badge.pattern { background: var(--yellow-bg); color: var(--yellow); border: 1px solid rgba(210,153,34,0.3); }
+
+  footer {
+    text-align: center;
+    padding: 2rem;
+    color: var(--text-subtle);
+    font-size: 0.8rem;
+    border-top: 1px solid var(--border);
+    margin-top: 3rem;
+  }
+
+  @media (max-width: 768px) {
+    .hero { padding: 2rem 1rem; }
+    .hero h1 { font-size: 1.6rem; }
+    main { padding: 1.5rem 1rem 4rem; }
+    nav ol { gap: 0; }
+  }
+</style>
+</head>
+<body>
+
+<!-- ===== HERO ===== -->
+<div class="hero">
+  <span class="hero-badge">PR #133 &middot; AIML-765</span>
+  <h1>Non-Interactive Ralph-Next-Bead Prompts</h1>
+  <p class="subtitle">
+    Fix automation hangs by telling Claude Code skills to make decisions autonomously when invoked from the bead-transition pipeline.
+  </p>
+  <div class="hero-meta">
+    <span class="hero-meta-item"><strong>Branch:</strong> AIML-765-s11-isolation-load-tests</span>
+    <span class="hero-meta-item"><strong>Base:</strong> AIML-764-s10-validate-oauth-staging (PR #132)</span>
+    <span class="hero-meta-item"><strong>Files:</strong> 1 changed</span>
+    <span class="hero-meta-item"><strong>Lines:</strong> +3 / &minus;3</span>
+  </div>
+</div>
+
+<!-- ===== NAV ===== -->
+<nav>
+  <ol>
+    <li><a href="#context"><span class="nav-number">1</span>Context</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#problem"><span class="nav-number">2</span>The Problem</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#approach"><span class="nav-number">3</span>Approach</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#walkthrough"><span class="nav-number">4</span>Code Walkthrough</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#slice11"><span class="nav-number">5</span>Slice 11 in Context</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#summary"><span class="nav-number">6</span>Summary &amp; What's Next</a></li>
+  </ol>
+</nav>
+
+<!-- ===== MAIN ===== -->
+<main>
+
+<!-- ===== CHAPTER 1: CONTEXT ===== -->
+<section class="chapter" id="context">
+  <div class="chapter-header">
+    <span class="chapter-number blue">1</span>
+    <h2>Context</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>AIML-110 is building a Contrast-hosted remote MCP server, and the work is organized into numbered slices &mdash; each slice stacks on the one before it.</strong>
+    The implementation spans two repositories: <code>mcp-contrast</code> (the public stdio MCP server and control plane) and <code>aiml-services</code> (the hosted remote server). An AI agent named <strong>Ralph</strong> implements beads (granular work items) autonomously, while a companion script called <code>ralph-next-bead</code> handles the transitions <em>between</em> slices: creating pull requests, generating reviewer walkthroughs, and setting up the next stacked branch.
+  </p>
+
+  <p class="narrative">
+    <strong>This PR is the <code>mcp-contrast</code> side of Slice 11 (AIML-765), which validates multi-tenant isolation and load testing against the staging environment.</strong>
+    The actual isolation tests, load harness, and capacity telemetry were built in <code>aiml-services</code> across three implementation beads. Once those beads closed, <code>ralph-next-bead</code> was invoked to create PRs and walkthroughs for both repos and to set up the Slice 12 branch. That invocation revealed a bug: the skills it calls have interactive decision points that stall when no human is present.
+  </p>
+
+  <div class="diagram">
+    <div class="diagram-container">
+      <svg viewBox="0 0 900 320" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+        <!-- Title -->
+        <text x="450" y="30" text-anchor="middle" fill="#e6edf3" font-size="14" font-weight="600">Ralph Automation: Two Scripts, Two Roles</text>
+
+        <!-- Ralph box -->
+        <rect x="40" y="60" width="240" height="110" rx="10" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
+        <text x="160" y="85" text-anchor="middle" fill="#58a6ff" font-size="13" font-weight="600">scripts/ralph</text>
+        <text x="160" y="108" text-anchor="middle" fill="#8b949e" font-size="11">Picks a bead from br ready</text>
+        <text x="160" y="125" text-anchor="middle" fill="#8b949e" font-size="11">Runs Codex to implement it</text>
+        <text x="160" y="142" text-anchor="middle" fill="#8b949e" font-size="11">Closes the bead, loops</text>
+        <text x="160" y="159" text-anchor="middle" fill="#6e7681" font-size="10" font-style="italic">Within a slice</text>
+
+        <!-- Arrow -->
+        <line x1="290" y1="115" x2="350" y2="115" stroke="#3fb950" stroke-width="2" stroke-dasharray="6,3"/>
+        <text x="320" y="105" text-anchor="middle" fill="#3fb950" font-size="10">then</text>
+
+        <!-- ralph-next-bead box -->
+        <rect x="360" y="60" width="260" height="110" rx="10" fill="#161b22" stroke="#3fb950" stroke-width="1.5"/>
+        <text x="490" y="85" text-anchor="middle" fill="#3fb950" font-size="13" font-weight="600">scripts/ralph-next-bead</text>
+        <text x="490" y="108" text-anchor="middle" fill="#8b949e" font-size="11">Creates PR + walkthrough</text>
+        <text x="490" y="125" text-anchor="middle" fill="#8b949e" font-size="11">Sets up next stacked branch</text>
+        <text x="490" y="142" text-anchor="middle" fill="#8b949e" font-size="11">Invokes claude -p with skills</text>
+        <text x="490" y="159" text-anchor="middle" fill="#6e7681" font-size="10" font-style="italic">Between slices (this PR)</text>
+
+        <!-- Skills boxes -->
+        <rect x="660" y="55" width="200" height="38" rx="6" fill="#1c2128" stroke="#30363d" stroke-width="1"/>
+        <text x="760" y="78" text-anchor="middle" fill="#d2a8ff" font-size="11">/pr-tools:create-pr</text>
+
+        <rect x="660" y="100" width="200" height="38" rx="6" fill="#1c2128" stroke="#30363d" stroke-width="1"/>
+        <text x="760" y="123" text-anchor="middle" fill="#d2a8ff" font-size="11">/pr-tools:create-html-pr-walkthrough</text>
+
+        <rect x="660" y="145" width="200" height="38" rx="6" fill="#1c2128" stroke="#30363d" stroke-width="1"/>
+        <text x="760" y="168" text-anchor="middle" fill="#d2a8ff" font-size="11">/pr-tools:create-stacked-branch</text>
+
+        <!-- Arrows from ralph-next-bead to skills -->
+        <line x1="620" y1="85" x2="658" y2="75" stroke="#58a6ff" stroke-width="1.2"/>
+        <line x1="620" y1="115" x2="658" y2="118" stroke="#58a6ff" stroke-width="1.2"/>
+        <line x1="620" y1="145" x2="658" y2="162" stroke="#58a6ff" stroke-width="1.2"/>
+        <text x="642" y="100" text-anchor="middle" fill="#58a6ff" font-size="9" transform="rotate(-10,642,100)">claude -p</text>
+
+        <!-- Problem callout -->
+        <rect x="100" y="220" width="700" height="75" rx="8" fill="rgba(248,81,73,0.08)" stroke="rgba(248,81,73,0.25)" stroke-width="1"/>
+        <text x="130" y="245" fill="#f85149" font-size="12" font-weight="600">THE PROBLEM</text>
+        <text x="130" y="265" fill="#8b949e" font-size="11">These skills contain interactive decision points (base branch selection, user clarifications).</text>
+        <text x="130" y="282" fill="#8b949e" font-size="11">In non-interactive <tspan fill="#a5d6ff">claude -p</tspan> mode, the automation hangs forever waiting for input that will never arrive.</text>
+      </svg>
+    </div>
+  </div>
+</section>
+
+<!-- ===== CHAPTER 2: THE PROBLEM ===== -->
+<section class="chapter" id="problem">
+  <div class="chapter-header">
+    <span class="chapter-number yellow">2</span>
+    <h2>The Problem</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>Picture <code>ralph-next-bead</code> finishing a slice at 2 AM.</strong> It calls <code>claude -p "/pr-tools:create-pr ..."</code> to create the pull request. The <code>create-pr</code> skill detects a stacked branch and asks: <em>"Which branch should I target?"</em> Nobody answers. The process hangs indefinitely. The walkthrough skill does the same &mdash; its instructions say to ask the user for additional context before writing. The stacked-branch skill asks which branch to base off. Three interactive prompts, three potential deadlocks, and no human in the loop.
+  </p>
+
+  <p class="narrative">
+    <strong>The root cause is a mismatch between the skill design and the invocation context.</strong> These skills were written for interactive use, where a developer is actively chatting. But <code>ralph-next-bead</code> invokes them via <code>claude -p</code> (print mode), which runs Claude Code non-interactively. The skills don't know they're in automation unless the prompt explicitly tells them.
+  </p>
+
+  <div class="callout why">
+    <span class="callout-label">Why this matters</span>
+    <strong>Without this fix, the bead-transition pipeline cannot run unattended.</strong> Each transition between slices requires creating PRs and walkthroughs in both repos, then setting up the next branch. If any of the six <code>claude -p</code> invocations (3 skills &times; 2 repos) stalls, the entire pipeline stops. This blocks Ralph from starting the next slice's work, which in turn delays the overall AIML-110 timeline.
+  </div>
+</section>
+
+<!-- ===== CHAPTER 3: APPROACH ===== -->
+<section class="chapter" id="approach">
+  <div class="chapter-header">
+    <span class="chapter-number green">3</span>
+    <h2>Approach</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>The fix is surgical: append a non-interactive instruction to each prompt string.</strong> Rather than modifying the skills themselves (which serve interactive users too), the prompts tell each skill to detect context from the bead and codebase and make decisions autonomously. Each of the three <code>claude -p</code> calls gets a tailored instruction:
+  </p>
+
+  <p class="narrative">
+    <strong><code>create-pr</code></strong> &mdash; told to auto-detect the base branch from <code>stacked-pr-facts</code> rather than asking the user to pick one. This is reliable because <code>ralph-next-bead</code> always runs on branches that already have stacked-PR config recorded in local git config.
+  </p>
+
+  <p class="narrative">
+    <strong><code>create-html-pr-walkthrough</code></strong> &mdash; told to use bead, PRD, and codebase context to produce the walkthrough in a single pass, skipping the "Is there anything else?" prompt. The walkthrough skill's instructions explicitly say to ask the user for additional context; the prompt override bypasses this.
+  </p>
+
+  <p class="narrative">
+    <strong><code>create-stacked-branch</code></strong> &mdash; told to make all decisions autonomously. The prompt already specifies the bead ID and stacking direction, so there's nothing left to decide interactively.
+  </p>
+
+  <div class="callout note">
+    <span class="callout-label">Design choice</span>
+    <strong>Prompt-side override, not skill-side change.</strong> Modifying the skills to auto-detect non-interactive mode would be cleaner long-term, but it would require changes to the shared <code>pr-tools</code> plugin that serves all projects. The prompt-side approach is local, low-risk, and specific to Ralph's invocation pattern.
+  </div>
+</section>
+
+<!-- ===== CHAPTER 4: CODE WALKTHROUGH ===== -->
+<section class="chapter" id="walkthrough">
+  <div class="chapter-header">
+    <span class="chapter-number purple">4</span>
+    <h2>Code Walkthrough</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>All three changes follow the same pattern: append a clear non-interactive instruction to the existing prompt string.</strong> The original prompt text is unchanged &mdash; only the instruction suffix is new. Let's walk through each one.
+  </p>
+
+  <!-- Change 1: create-pr -->
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">scripts/ralph-next-bead</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">185</span><span class="code">      (</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">186</span><span class="code">        cd <span class="str">"$repo_dir"</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">187</span><span class="code">        run_claude \</span></span>
+<span class="diff-line del"><span class="marker">-</span><span class="ln">188</span><span class="code">          <span class="str">"/pr-tools:create-pr Read the prd, the bead $COMPLETED_BEAD_ID, and any child beads along with any relevant decision docs to understand the context of these changes on this branch. beads are in $BEADS_PATH"</span> \</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">188</span><span class="code">          <span class="str">"/pr-tools:create-pr Read the prd, the bead $COMPLETED_BEAD_ID, and any child beads along with any relevant decision docs to understand the context of these changes on this branch. beads are in $BEADS_PATH. <span style="color:#aff5b4;font-weight:600">IMPORTANT: Do not ask the user for input or clarification &mdash; this is running non-interactively. Auto-detect the base branch from stacked-pr-facts and make all decisions autonomously.</span>"</span> \</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">189</span><span class="code">          <span class="str">"$LOG_DIR/${repo_name}-create-pr.log"</span></span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>The <code>create-pr</code> skill normally asks the user which branch to target for stacked PRs.</strong> By telling it to auto-detect from <code>stacked-pr-facts</code>, we bypass the interactive prompt while still using the same reliable detection mechanism the skill would use after receiving a user answer. The stacked-PR parent is already recorded in local git config by the time <code>ralph-next-bead</code> runs.
+    </div>
+  </div>
+
+  <!-- Change 2: create-html-pr-walkthrough -->
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">scripts/ralph-next-bead</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">196</span><span class="code">      (</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">197</span><span class="code">        cd <span class="str">"$repo_dir"</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">198</span><span class="code">        run_claude \</span></span>
+<span class="diff-line del"><span class="marker">-</span><span class="ln">199</span><span class="code">          <span class="str">"/pr-tools:create-html-pr-walkthrough Read $COMPLETED_BEAD_ID and its child beads ... beads are in $BEADS_PATH"</span> \</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">199</span><span class="code">          <span class="str">"/pr-tools:create-html-pr-walkthrough Read $COMPLETED_BEAD_ID and its child beads ... beads are in $BEADS_PATH. <span style="color:#aff5b4;font-weight:600">IMPORTANT: Do not ask the user for input or clarification &mdash; this is running non-interactively. Use the bead, PRD, and codebase context to make all decisions autonomously and produce the walkthrough in a single pass.</span>"</span> \</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">200</span><span class="code">          <span class="str">"$LOG_DIR/${repo_name}-walkthrough.log"</span></span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>The walkthrough skill's step 1 explicitly says "ask the user" for additional context before writing.</strong> This instruction tells it to skip that prompt and use what it can find from beads, the PRD, and the codebase. The quality tradeoff is minor &mdash; the bead system already captures design rationale, acceptance criteria, and cross-references that would otherwise come from user input.
+    </div>
+  </div>
+
+  <!-- Change 3: create-stacked-branch -->
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">scripts/ralph-next-bead</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">212</span><span class="code">    (</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">213</span><span class="code">      cd <span class="str">"$repo_dir"</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">214</span><span class="code">      run_claude \</span></span>
+<span class="diff-line del"><span class="marker">-</span><span class="ln">215</span><span class="code">        <span class="str">"/pr-tools:create-stacked-branch for bead $NEXT_BEAD_ID. ... beads are in $BEADS_PATH"</span> \</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">215</span><span class="code">        <span class="str">"/pr-tools:create-stacked-branch for bead $NEXT_BEAD_ID. ... beads are in $BEADS_PATH. <span style="color:#aff5b4;font-weight:600">IMPORTANT: Do not ask the user for input or clarification &mdash; this is running non-interactively. Make all decisions autonomously.</span>"</span> \</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">216</span><span class="code">        <span class="str">"$LOG_DIR/${repo_name}-create-branch.log"</span></span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>The stacked-branch prompt already contains everything needed:</strong> the bead ID, the stacking direction ("on top of the current branch"), and the naming convention. The non-interactive instruction ensures the skill doesn't ask for confirmation on any of these already-specified choices.
+    </div>
+  </div>
+</section>
+
+<!-- ===== CHAPTER 5: SLICE 11 IN CONTEXT ===== -->
+<section class="chapter" id="slice11">
+  <div class="chapter-header">
+    <span class="chapter-number orange">5</span>
+    <h2>Slice 11 in Context</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>Slice 11 is the "prove it works under load" gate for the hosted MCP server.</strong> Before expanding to full tool parity (Slice 12), the team needed confidence that the multi-tenant architecture actually isolates data between organizations under concurrent requests and meets performance SLOs. The work was split across two repos:
+  </p>
+
+  <div class="slice-columns">
+    <div class="slice-col this-pr">
+      <div class="slice-title">mcp-contrast (this repo &amp; PR)</div>
+      <div class="slice-item"><span class="dot"></span><strong>ralph-next-bead non-interactive fix</strong> &mdash; unblock automation pipeline for slice transitions</div>
+      <div class="slice-item"><span class="dot"></span><strong>PR walkthrough</strong> &mdash; this document, generated for code reviewers</div>
+    </div>
+    <div class="slice-col future-col">
+      <div class="slice-title">aiml-services (companion repo)</div>
+      <div class="slice-item"><span class="dot"></span><strong>mcp-uczf</strong> &mdash; concurrent two-user/two-org isolation integration tests</div>
+      <div class="slice-item"><span class="dot"></span><strong>mcp-8ar6</strong> &mdash; representative stateless load and timeout SLO tests</div>
+      <div class="slice-item"><span class="dot"></span><strong>mcp-4wsw</strong> &mdash; observe-first capacity telemetry integration</div>
+      <div class="slice-item"><span class="dot"></span><strong>mcp-ihab.1</strong> &mdash; human-run evidence pass (accepted same-user/two-org)</div>
+    </div>
+  </div>
+
+  <p class="narrative">
+    <strong>The heavy lifting happened in <code>aiml-services</code>.</strong> There, three implementation beads built concurrent isolation tests proving zero cross-org data leakage, a load harness validating p99 &lt; 30s with no execution exceeding 55s, and Micrometer-based capacity telemetry for response size, fan-out, downstream duration, and auth outcomes. The human operator then ran the final evidence pass and accepted same-user/two-org results as sufficient for forward progress.
+  </p>
+
+  <p class="narrative">
+    <strong>This PR's contribution is operational:</strong> ensuring the automation pipeline that creates PRs and transitions between slices works without human babysitting. It's a small change with outsized impact on development velocity &mdash; every future slice transition runs through these same three <code>claude -p</code> calls.
+  </p>
+
+  <table class="roadmap-table">
+    <thead><tr><th>Ticket</th><th>Slice</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><a class="jira-link" href="https://contrast.atlassian.net/browse/AIML-764">AIML-764</a></td>
+        <td><span class="slice-name">Slice 10</span></td>
+        <td>Validate OAuth and API gateway integration in staging</td>
+      </tr>
+      <tr class="current-row">
+        <td><a class="jira-link" href="https://contrast.atlassian.net/browse/AIML-765">AIML-765</a></td>
+        <td><span class="slice-name">Slice 11</span><span class="current-badge">This PR</span></td>
+        <td>Run isolation and load tests against staging environment</td>
+      </tr>
+      <tr>
+        <td><a class="jira-link" href="https://contrast.atlassian.net/browse/AIML-766">AIML-766</a></td>
+        <td><span class="slice-name">Slice 12</span></td>
+        <td>Achieve full tool parity and release hardening</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="callout future">
+    <span class="callout-label">What comes next</span>
+    <strong>Slice 12 (AIML-766) is the final Phase 2 gate:</strong> full remote tool parity, complete test matrix, release runbooks, and privacy/security review evidence. It depends on both Slice 10 and Slice 11 completing. With this fix, <code>ralph-next-bead</code> can create the Slice 12 stacked branch and start the work autonomously.
+  </div>
+</section>
+
+<!-- ===== CHAPTER 6: SUMMARY ===== -->
+<section class="chapter" id="summary">
+  <div class="chapter-header">
+    <span class="chapter-number green">6</span>
+    <h2>Summary &amp; What's Next</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>Three prompt strings, three appended instructions, zero behavioral regression.</strong> The skills still work identically for interactive users &mdash; the non-interactive directive is part of the automation prompt, not the skill definition. The fix was discovered during the Slice 10&rarr;11 transition and applied for all future transitions.
+  </p>
+
+  <table class="file-table">
+    <thead><tr><th>File</th><th>Purpose</th><th>Lines</th><th>Novelty</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>scripts/ralph-next-bead</td>
+        <td>Add non-interactive instructions to all three <code>claude -p</code> prompt strings</td>
+        <td><span class="addition">+3</span> / <span class="deletion">&minus;3</span></td>
+        <td class="novelty"><span class="novelty-badge novel">Novel</span></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="callout note">
+    <span class="callout-label">Review guidance</span>
+    <strong>This is a 6-line diff.</strong> The key thing to verify is that the appended instructions are clear enough for each skill to resolve its interactive decision points without ambiguity. The <code>create-pr</code> instruction specifically names <code>stacked-pr-facts</code> as the detection mechanism; the walkthrough instruction names the data sources (bead, PRD, codebase); the stacked-branch instruction is generic because the existing prompt already specifies all parameters.
+  </div>
+</section>
+
+</main>
+
+<footer>
+  PR #133 &middot; AIML-765 &middot; Contrast-Security-OSS/mcp-contrast
+</footer>
+
+</body>
+</html>

--- a/scripts/ralph-next-bead
+++ b/scripts/ralph-next-bead
@@ -196,7 +196,7 @@ process_repo() {
       (
         cd "$repo_dir"
         run_claude \
-          "/pr-tools:create-html-pr-walkthrough Read $COMPLETED_BEAD_ID and its child beads and prior/next beads along with the Jira ticket, then read the PRD, and any relevant docs in the decisions folder for context. Ensure you frame this in the context of the work that came before and comes after. Is this part of a slice? Which part? How does it relate. Use diagrams to show large file renames to simplify understanding them. Make the walkthrough easy to understand by using explanations of concepts and using concrete examples. beads are in $BEADS_PATH" \
+          "/pr-tools:create-html-pr-walkthrough Read $COMPLETED_BEAD_ID and its child beads and prior/next beads along with the Jira ticket, then read the PRD, and any relevant docs in the decisions folder for context. Ensure you frame this in the context of the work that came before and comes after. Is this part of a slice? Which part? How does it relate. Use diagrams to show large file renames to simplify understanding them. Make the walkthrough easy to understand by using explanations of concepts and using concrete examples. beads are in $BEADS_PATH. IMPORTANT: Do not ask the user for input or clarification — this is running non-interactively. Use the bead, PRD, and codebase context to make all decisions autonomously and produce the walkthrough in a single pass." \
           "$LOG_DIR/${repo_name}-walkthrough.log"
       )
       log "$repo_name: Walkthrough complete"

--- a/scripts/ralph-next-bead
+++ b/scripts/ralph-next-bead
@@ -185,7 +185,7 @@ process_repo() {
       (
         cd "$repo_dir"
         run_claude \
-          "/pr-tools:create-pr Read the prd, the bead $COMPLETED_BEAD_ID, and any child beads along with any relevant decision docs to understand the context of these changes on this branch. beads are in $BEADS_PATH" \
+          "/pr-tools:create-pr Read the prd, the bead $COMPLETED_BEAD_ID, and any child beads along with any relevant decision docs to understand the context of these changes on this branch. beads are in $BEADS_PATH. IMPORTANT: Do not ask the user for input or clarification — this is running non-interactively. Auto-detect the base branch from stacked-pr-facts and make all decisions autonomously." \
           "$LOG_DIR/${repo_name}-create-pr.log"
       )
       log "$repo_name: PR creation complete"
@@ -212,7 +212,7 @@ process_repo() {
     (
       cd "$repo_dir"
       run_claude \
-        "/pr-tools:create-stacked-branch for bead $NEXT_BEAD_ID. It should be created for that epic bead including its children. Ensure it is named prefixed with the jira ticket id like other branches. It should be stacked on top of the current branch. beads are in $BEADS_PATH" \
+        "/pr-tools:create-stacked-branch for bead $NEXT_BEAD_ID. It should be created for that epic bead including its children. Ensure it is named prefixed with the jira ticket id like other branches. It should be stacked on top of the current branch. beads are in $BEADS_PATH. IMPORTANT: Do not ask the user for input or clarification — this is running non-interactively. Make all decisions autonomously." \
         "$LOG_DIR/${repo_name}-create-branch.log"
     )
     log "$repo_name: Stacked branch creation complete"


### PR DESCRIPTION
<!-- pr-tools:stacked:v1 -->
<!-- pr-tools:parent-pr=132 -->
<!-- pr-tools:parent-branch=AIML-764-s10-validate-oauth-staging -->
<!-- pr-tools:parent-base=AIML-763-s9-expand-dataplatform-tools -->
<!-- pr-tools:boundary-commit=5a84263d1c153f19581b938b4f48637be8f758dc -->
<!-- pr-tools:managed:start -->
> ⚠️ **DO NOT MERGE** - This PR is stacked on #132. Merge that first.
>
> **Stack Context**
> - Parent PR: #132
> - Parent branch: `AIML-764-s10-validate-oauth-staging`
> - Promotion target: `AIML-763-s9-expand-dataplatform-tools`
<!-- pr-tools:managed:end -->

> **Reviewer walkthrough:** Run this to open the interactive walkthrough in your browser:
> ```
> gh api 'repos/Contrast-Security-OSS/mcp-contrast/contents/docs/pr-walkthrough/pr-133-non-interactive-ralph-next-bead.html?ref=AIML-765-s11-isolation-load-tests' -H "Accept: application/vnd.github.raw" > /tmp/pr-133-walkthrough.html && (open /tmp/pr-133-walkthrough.html || xdg-open /tmp/pr-133-walkthrough.html)
> ```
> Walks through the non-interactive automation fix in the context of Slice 11's isolation and load testing work.

**Jira:** [AIML-765](https://contrast.atlassian.net/browse/AIML-765)

## Summary
Add explicit non-interactive instructions to all `claude -p` prompts in `ralph-next-bead` so the automation script can run end-to-end without stalling on interactive prompts.

- All three `claude -p` invocations (create-pr, walkthrough, create-stacked-branch) now include `IMPORTANT: Do not ask the user for input or clarification — this is running non-interactively. Make all decisions autonomously.`

## Why This Change Exists
- `ralph-next-bead` orchestrates bead transitions by invoking Claude Code in non-interactive (`-p`) mode
- Skills like `create-pr` and `create-html-pr-walkthrough` contain interactive decision points (base branch selection, user clarifications) that cause the automation to hang waiting for input that will never come
- Adding explicit non-interactive instructions to the prompts lets each skill auto-detect and resolve decisions from context instead of prompting

## What Changed
### `scripts/ralph-next-bead`
- `scripts/ralph-next-bead` — appended non-interactive autonomous-decision instructions to the `create-pr`, `create-html-pr-walkthrough`, and `create-stacked-branch` prompt strings


[AIML-765]: https://contrast.atlassian.net/browse/AIML-765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
