### PR TITLE
[STACKED] AIML-766: Compile MCP core with parameter metadata, restore walkthrough, harden Ralph filtering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ subprojects {
     tasks.withType(JavaCompile).configureEach {
         options.encoding = 'UTF-8'
         options.release = 21
+        options.compilerArgs.add('-parameters')
     }
 
     tasks.withType(Test).configureEach {

--- a/docs/pr-walkthrough/pr-134-compile-parameters-restore-walkthrough-harden-ralph.html
+++ b/docs/pr-walkthrough/pr-134-compile-parameters-restore-walkthrough-harden-ralph.html
@@ -1,0 +1,1149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PR #134 Walkthrough: Compile MCP core with parameter metadata, restore walkthrough, harden Ralph filtering</title>
+<style>
+  :root {
+    --bg: #0d1117;
+    --surface: #161b22;
+    --surface-raised: #1c2128;
+    --border: #30363d;
+    --text: #e6edf3;
+    --text-muted: #8b949e;
+    --text-subtle: #6e7681;
+    --accent: #58a6ff;
+    --accent-soft: rgba(88,166,255,0.15);
+    --green: #3fb950;
+    --green-bg: rgba(63,185,80,0.15);
+    --green-border: rgba(63,185,80,0.4);
+    --red: #f85149;
+    --red-bg: rgba(248,81,73,0.10);
+    --yellow: #d29922;
+    --yellow-bg: rgba(210,153,34,0.15);
+    --purple: #bc8cff;
+    --purple-bg: rgba(188,140,255,0.12);
+    --orange: #f0883e;
+    --line-num: #484f58;
+    --diff-add-bg: rgba(63,185,80,0.10);
+    --diff-add-text: #aff5b4;
+    --diff-add-marker: #3fb950;
+    --diff-del-bg: rgba(248,81,73,0.10);
+    --diff-del-text: #ffa198;
+    --diff-del-marker: #f85149;
+    --diff-context-bg: transparent;
+    --code-bg: #0d1117;
+    --nav-bg: rgba(13,17,23,0.95);
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    overflow-x: hidden;
+  }
+
+  .hero {
+    background: linear-gradient(135deg, #0d1117 0%, #161b22 40%, #1a1e2e 70%, #161b22 100%);
+    border-bottom: 1px solid var(--border);
+    padding: 3rem 2rem 2.5rem;
+    text-align: center;
+  }
+  .hero-badge {
+    display: inline-block;
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-size: 0.8rem;
+    font-weight: 600;
+    padding: 0.3rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid rgba(88,166,255,0.3);
+    margin-bottom: 1rem;
+    letter-spacing: 0.03em;
+  }
+  .hero h1 {
+    font-size: 2.2rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin-bottom: 0.6rem;
+    background: linear-gradient(135deg, var(--text) 0%, var(--accent) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+  .hero .subtitle {
+    color: var(--text-muted);
+    font-size: 1.1rem;
+    max-width: 600px;
+    margin: 0 auto;
+  }
+  .hero-meta {
+    display: flex;
+    justify-content: center;
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+    flex-wrap: wrap;
+  }
+  .hero-meta-item {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+  }
+  .hero-meta-item strong { color: var(--text); }
+
+  nav {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: var(--nav-bg);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border);
+    padding: 0.6rem 2rem;
+    overflow-x: auto;
+  }
+  nav ol {
+    display: flex;
+    gap: 0.3rem;
+    list-style: none;
+    max-width: 1100px;
+    margin: 0 auto;
+    font-size: 0.82rem;
+    align-items: center;
+  }
+  nav li a {
+    color: var(--text-muted);
+    text-decoration: none;
+    padding: 0.35rem 0.7rem;
+    border-radius: 6px;
+    transition: all 0.15s;
+    white-space: nowrap;
+  }
+  nav li a:hover { color: var(--accent); background: var(--accent-soft); }
+  nav .nav-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.4em;
+    height: 1.4em;
+    border-radius: 50%;
+    background: var(--surface-raised);
+    border: 1px solid var(--border);
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    margin-right: 0.4em;
+  }
+  nav .nav-sep { color: var(--text-subtle); font-size: 0.75rem; }
+
+  main {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 2rem 2rem 6rem;
+  }
+
+  .chapter {
+    margin-bottom: 3.5rem;
+    scroll-margin-top: 4rem;
+  }
+  .chapter-header {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.8rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .chapter-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.2rem;
+    height: 2.2rem;
+    border-radius: 50%;
+    font-size: 1rem;
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+  .chapter-number.blue { background: var(--accent-soft); color: var(--accent); border: 1px solid rgba(88,166,255,0.3); }
+  .chapter-number.green { background: var(--green-bg); color: var(--green); border: 1px solid var(--green-border); }
+  .chapter-number.purple { background: var(--purple-bg); color: var(--purple); border: 1px solid rgba(188,140,255,0.3); }
+  .chapter-number.yellow { background: var(--yellow-bg); color: var(--yellow); border: 1px solid rgba(210,153,34,0.3); }
+  .chapter-number.orange { background: rgba(240,136,62,0.12); color: var(--orange); border: 1px solid rgba(240,136,62,0.3); }
+  .chapter h2 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+
+  .narrative {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    line-height: 1.75;
+    margin-bottom: 1.5rem;
+  }
+  .narrative strong { color: var(--text); font-weight: 600; }
+  .narrative code {
+    background: var(--surface-raised);
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+    font-size: 0.88em;
+    color: var(--accent);
+    border: 1px solid var(--border);
+  }
+
+  .callout {
+    border-radius: 8px;
+    padding: 1rem 1.2rem;
+    margin-bottom: 1.5rem;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    border: 1px solid;
+  }
+  .callout.why {
+    background: var(--accent-soft);
+    border-color: rgba(88,166,255,0.25);
+    color: var(--text);
+  }
+  .callout.why .callout-label { color: var(--accent); }
+  .callout.security {
+    background: var(--red-bg);
+    border-color: rgba(248,81,73,0.25);
+  }
+  .callout.security .callout-label { color: var(--red); }
+  .callout.note {
+    background: var(--yellow-bg);
+    border-color: rgba(210,153,34,0.25);
+  }
+  .callout.note .callout-label { color: var(--yellow); }
+  .callout.future {
+    background: var(--purple-bg);
+    border-color: rgba(188,140,255,0.25);
+  }
+  .callout.future .callout-label { color: var(--purple); }
+  .callout-label {
+    font-weight: 700;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 0.3rem;
+    display: block;
+  }
+
+  .diff-block {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+    margin-bottom: 1.5rem;
+  }
+  .diff-header {
+    display: flex;
+    align-items: center;
+    padding: 0.6rem 1rem;
+    background: var(--surface-raised);
+    border-bottom: 1px solid var(--border);
+    font-size: 0.82rem;
+    color: var(--text-muted);
+    gap: 0.5rem;
+  }
+  .diff-header .file-icon {
+    width: 16px; height: 16px;
+    fill: var(--text-subtle);
+    flex-shrink: 0;
+  }
+  .diff-header .filename {
+    color: var(--text);
+    font-weight: 600;
+    font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', monospace;
+    font-size: 0.82rem;
+  }
+  .diff-header .badge {
+    margin-left: auto;
+    font-size: 0.72rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    font-weight: 600;
+  }
+  .badge-new { background: var(--green-bg); color: var(--green); border: 1px solid var(--green-border); }
+  .badge-modified { background: var(--yellow-bg); color: var(--yellow); border: 1px solid rgba(210,153,34,0.3); }
+  .badge-deleted { background: var(--red-bg); color: var(--red); border: 1px solid rgba(248,81,73,0.3); }
+  .badge-restored { background: var(--purple-bg); color: var(--purple); border: 1px solid rgba(188,140,255,0.3); }
+
+  .diff-body {
+    overflow-x: auto;
+  }
+  .diff-body pre {
+    margin: 0;
+    padding: 0.4rem 0;
+    font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', monospace;
+    font-size: 0.82rem;
+    line-height: 1.3;
+    display: flex;
+    flex-direction: column;
+  }
+  .diff-line {
+    display: flex;
+    padding: 0 1rem;
+    min-height: 1.3em;
+  }
+  .diff-line.add {
+    background: var(--diff-add-bg);
+  }
+  .diff-line.del {
+    background: var(--diff-del-bg);
+  }
+  .diff-line.context {
+    background: var(--diff-context-bg);
+  }
+  .diff-line .marker {
+    width: 1.2em;
+    flex-shrink: 0;
+    color: var(--text-subtle);
+    user-select: none;
+    text-align: center;
+  }
+  .diff-line.add .marker { color: var(--diff-add-marker); }
+  .diff-line.del .marker { color: var(--diff-del-marker); }
+  .diff-line .ln {
+    width: 3.5em;
+    flex-shrink: 0;
+    color: var(--line-num);
+    text-align: right;
+    padding-right: 1em;
+    user-select: none;
+  }
+  .diff-line .code {
+    flex: 1;
+    white-space: pre;
+  }
+  .diff-line .code .kw { color: #ff7b72; }
+  .diff-line .code .str { color: #a5d6ff; }
+  .diff-line .code .ann { color: #d2a8ff; }
+  .diff-line .code .type { color: #79c0ff; }
+  .diff-line .code .comment { color: var(--text-subtle); font-style: italic; }
+  .diff-line .code .prop { color: #7ee787; }
+  .diff-line .code .val { color: #a5d6ff; }
+  .diff-line .code .num { color: #79c0ff; }
+  .diff-line .code .param { color: #ffa657; }
+
+  .annotation {
+    background: var(--surface-raised);
+    border-left: 3px solid var(--accent);
+    padding: 0.7rem 1rem;
+    margin: 0 1rem 0.3rem 1rem;
+    border-radius: 0 6px 6px 0;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    line-height: 1.55;
+  }
+  .annotation strong { color: var(--text); }
+  .annotation code {
+    background: rgba(88,166,255,0.1);
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+    font-size: 0.88em;
+    color: var(--accent);
+  }
+  .annotation.security-note { border-left-color: var(--red); }
+  .annotation.future-note { border-left-color: var(--purple); }
+
+  .diagram {
+    margin-bottom: 1.5rem;
+  }
+  .diagram svg {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+  .diagram-container {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.5rem;
+    overflow-x: auto;
+  }
+
+  .slice-columns {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.2rem;
+    margin-bottom: 1.5rem;
+  }
+  @media (max-width: 768px) { .slice-columns { grid-template-columns: 1fr; } }
+  .slice-col {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.2rem 1.4rem;
+  }
+  .slice-col.this-pr { border-color: var(--green-border); }
+  .slice-col.future-col { border-color: var(--border); opacity: 0.7; }
+  .slice-col .slice-title {
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 0.8rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .slice-col.this-pr .slice-title { color: var(--green); }
+  .slice-col.future-col .slice-title { color: var(--text-subtle); }
+  .slice-item {
+    position: relative;
+    padding: 0.3rem 0 0.3rem 1rem;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+  }
+  .slice-item .dot {
+    position: absolute;
+    left: 0;
+    top: 0.65rem;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+  }
+  .slice-col.this-pr .dot { background: var(--green); }
+  .slice-col.future-col .dot { background: var(--text-subtle); }
+  .slice-item strong { color: var(--text); font-weight: 500; }
+
+  .roadmap-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1.5rem;
+    font-size: 0.85rem;
+  }
+  .roadmap-table th {
+    text-align: left;
+    padding: 0.55rem 0.8rem;
+    background: var(--surface-raised);
+    color: var(--text-muted);
+    font-weight: 600;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid var(--border);
+  }
+  .roadmap-table td {
+    padding: 0.45rem 0.8rem;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-muted);
+    vertical-align: top;
+  }
+  .roadmap-table tr:last-child td { border-bottom: none; }
+  .roadmap-table .jira-link {
+    font-family: 'SF Mono', monospace;
+    font-size: 0.8rem;
+    color: var(--accent);
+    text-decoration: none;
+  }
+  .roadmap-table .jira-link:hover { text-decoration: underline; }
+  .roadmap-table .slice-name { color: var(--text); font-weight: 500; }
+  .roadmap-table .current-row td {
+    background: var(--green-bg);
+    border-bottom-color: var(--green-border);
+  }
+  .roadmap-table .current-row .slice-name { color: var(--green); font-weight: 600; }
+  .roadmap-table .current-badge {
+    display: inline-block;
+    font-size: 0.68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    background: var(--green-bg);
+    color: var(--green);
+    border: 1px solid var(--green-border);
+    padding: 0.1rem 0.4rem;
+    border-radius: 999px;
+    margin-left: 0.4rem;
+    vertical-align: middle;
+  }
+
+  .file-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1.5rem;
+    font-size: 0.85rem;
+  }
+  .file-table th {
+    text-align: left;
+    padding: 0.6rem 1rem;
+    background: var(--surface-raised);
+    color: var(--text-muted);
+    font-weight: 600;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid var(--border);
+  }
+  .file-table td {
+    padding: 0.55rem 1rem;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-muted);
+  }
+  .file-table td:first-child {
+    font-family: 'SF Mono', monospace;
+    font-size: 0.82rem;
+    color: var(--accent);
+  }
+  .file-table tr:last-child td { border-bottom: none; }
+  .file-table .addition { color: var(--green); }
+  .file-table .deletion { color: var(--red); }
+
+  .standard-pattern {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    margin-bottom: 1.5rem;
+    overflow: hidden;
+  }
+  .standard-pattern summary {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.7rem 1rem;
+    cursor: pointer;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    background: var(--surface-raised);
+    border-bottom: 1px solid transparent;
+    list-style: none;
+    transition: background 0.15s;
+  }
+  .standard-pattern summary::-webkit-details-marker { display: none; }
+  .standard-pattern summary::before {
+    content: '\25B6';
+    font-size: 0.65rem;
+    color: var(--text-subtle);
+    transition: transform 0.15s;
+    flex-shrink: 0;
+  }
+  .standard-pattern[open] summary::before { transform: rotate(90deg); }
+  .standard-pattern[open] summary { border-bottom-color: var(--border); }
+  .standard-pattern summary:hover { background: rgba(88,166,255,0.06); }
+  .standard-pattern .sp-icon {
+    width: 16px; height: 16px;
+    fill: var(--text-subtle);
+    flex-shrink: 0;
+  }
+  .standard-pattern .sp-title {
+    color: var(--text);
+    font-weight: 600;
+    flex: 1;
+  }
+  .standard-pattern .sp-files {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 0.78rem;
+    color: var(--text-subtle);
+  }
+  .standard-pattern .sp-ref {
+    font-size: 0.78rem;
+    color: var(--text-subtle);
+    margin-left: auto;
+    white-space: nowrap;
+  }
+  .badge-standard {
+    background: rgba(139,148,158,0.15);
+    color: var(--text-muted);
+    border: 1px solid rgba(139,148,158,0.3);
+    font-size: 0.68rem;
+    font-weight: 600;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    letter-spacing: 0.03em;
+    white-space: nowrap;
+  }
+  .standard-pattern .sp-body {
+    padding: 0.8rem 1rem;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    line-height: 1.6;
+  }
+  .standard-pattern .sp-body code {
+    background: var(--surface-raised);
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+    font-size: 0.88em;
+    color: var(--accent);
+    border: 1px solid var(--border);
+  }
+
+  .file-table .novelty { text-align: center; }
+  .novelty-badge {
+    display: inline-block;
+    font-size: 0.68rem;
+    font-weight: 600;
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    letter-spacing: 0.02em;
+  }
+  .novelty-badge.novel { background: var(--accent-soft); color: var(--accent); border: 1px solid rgba(88,166,255,0.3); }
+  .novelty-badge.standard { background: rgba(139,148,158,0.12); color: var(--text-subtle); border: 1px solid rgba(139,148,158,0.25); }
+  .novelty-badge.pattern { background: var(--yellow-bg); color: var(--yellow); border: 1px solid rgba(210,153,34,0.3); }
+
+  footer {
+    text-align: center;
+    padding: 2rem;
+    color: var(--text-subtle);
+    font-size: 0.8rem;
+    border-top: 1px solid var(--border);
+    margin-top: 3rem;
+  }
+
+  @media (max-width: 768px) {
+    .hero { padding: 2rem 1rem; }
+    .hero h1 { font-size: 1.6rem; }
+    main { padding: 1.5rem 1rem 4rem; }
+    nav ol { gap: 0; }
+  }
+</style>
+</head>
+<body>
+
+<!-- ===== HERO ===== -->
+<div class="hero">
+  <span class="hero-badge">PR #134 &middot; AIML-766</span>
+  <h1>S12 Housekeeping: Parameter Metadata, Ralph Hardening, Walkthrough Restore</h1>
+  <p class="subtitle">
+    Three surgical fixes that unblock Slice 12's child beads: the Java compiler now preserves parameter names for MCP tool schemas, Ralph learns to skip two new human-only bead categories, and a lost PR walkthrough is restored.
+  </p>
+  <div class="hero-meta">
+    <span class="hero-meta-item"><strong>Branch:</strong> AIML-766-s12-full-tool-parity-release-hardening</span>
+    <span class="hero-meta-item"><strong>Base:</strong> AIML-765-s11-isolation-load-tests (stacked)</span>
+    <span class="hero-meta-item"><strong>Files:</strong> 3 changed</span>
+    <span class="hero-meta-item"><strong>Lines:</strong> +1,529 / &minus;5</span>
+  </div>
+</div>
+
+<!-- ===== NAV ===== -->
+<nav>
+  <ol>
+    <li><a href="#context"><span class="nav-number">1</span>Context</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#approach"><span class="nav-number">2</span>Approach</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#scope"><span class="nav-number">3</span>Scope</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#parameter-metadata"><span class="nav-number">4</span>Parameter Metadata</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#ralph-hardening"><span class="nav-number">5</span>Ralph Hardening</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#walkthrough-restore"><span class="nav-number">6</span>Walkthrough Restore</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#summary"><span class="nav-number">7</span>Summary</a></li>
+  </ol>
+</nav>
+
+<!-- ===== MAIN ===== -->
+<main>
+
+<!-- ===== CHAPTER 1: Context ===== -->
+<section class="chapter" id="context">
+  <div class="chapter-header">
+    <span class="chapter-number blue">1</span>
+    <h2>Context: Where This PR Fits</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>This PR is the opening move of Slice 12 (AIML-766), the final Phase 2 milestone before the hosted MCP server can ship.</strong>
+    The AIML-110 initiative is building a Contrast-hosted remote MCP server so enterprise customers (like DBS Bank) can use AI-powered vulnerability remediation without distributing API keys. The work is organized into numbered "slices," each building on the last.
+  </p>
+
+  <p class="narrative">
+    <strong>Slices 8&ndash;11 are complete and this branch stacks on top of them.</strong>
+    Slice 8 (AIML-762) migrated all 12 shared tools into <code>contrast-mcp-core</code>.
+    Slice 9 (AIML-763) expanded the dataplatform tools with cursor pagination.
+    Slice 10 (AIML-764) validated OAuth and API gateway integration in staging.
+    Slice 11 (AIML-765) ran isolation and load tests.
+    Now Slice 12 must prove full tool parity, run the complete gate suite, prepare release artifacts, and close out Phase 2.
+  </p>
+
+  <div class="diagram">
+    <div class="diagram-container">
+      <svg viewBox="0 0 900 200" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+        <!-- Timeline -->
+        <line x1="60" y1="100" x2="840" y2="100" stroke="#30363d" stroke-width="2"/>
+
+        <!-- S8 -->
+        <circle cx="140" cy="100" r="18" fill="rgba(63,185,80,0.15)" stroke="#3fb950" stroke-width="2"/>
+        <text x="140" y="105" text-anchor="middle" fill="#3fb950" font-size="13" font-weight="700">S8</text>
+        <text x="140" y="75" text-anchor="middle" fill="#8b949e" font-size="10">Shared Tools</text>
+        <text x="140" y="130" text-anchor="middle" fill="#6e7681" font-size="9">CLOSED</text>
+
+        <!-- S9 -->
+        <circle cx="280" cy="100" r="18" fill="rgba(63,185,80,0.15)" stroke="#3fb950" stroke-width="2"/>
+        <text x="280" y="105" text-anchor="middle" fill="#3fb950" font-size="13" font-weight="700">S9</text>
+        <text x="280" y="75" text-anchor="middle" fill="#8b949e" font-size="10">Dataplatform</text>
+        <text x="280" y="130" text-anchor="middle" fill="#6e7681" font-size="9">CLOSED</text>
+
+        <!-- S10 -->
+        <circle cx="420" cy="100" r="18" fill="rgba(63,185,80,0.15)" stroke="#3fb950" stroke-width="2"/>
+        <text x="420" y="105" text-anchor="middle" fill="#3fb950" font-size="13" font-weight="700">S10</text>
+        <text x="420" y="75" text-anchor="middle" fill="#8b949e" font-size="10">OAuth Staging</text>
+        <text x="420" y="130" text-anchor="middle" fill="#6e7681" font-size="9">CLOSED</text>
+
+        <!-- S11 -->
+        <circle cx="560" cy="100" r="18" fill="rgba(63,185,80,0.15)" stroke="#3fb950" stroke-width="2"/>
+        <text x="560" y="105" text-anchor="middle" fill="#3fb950" font-size="13" font-weight="700">S11</text>
+        <text x="560" y="75" text-anchor="middle" fill="#8b949e" font-size="10">Isolation &amp; Load</text>
+        <text x="560" y="130" text-anchor="middle" fill="#6e7681" font-size="9">CLOSED</text>
+
+        <!-- S12 (current) -->
+        <circle cx="700" cy="100" r="22" fill="rgba(88,166,255,0.15)" stroke="#58a6ff" stroke-width="3"/>
+        <text x="700" y="105" text-anchor="middle" fill="#58a6ff" font-size="14" font-weight="700">S12</text>
+        <text x="700" y="70" text-anchor="middle" fill="#58a6ff" font-size="10" font-weight="600">Parity &amp; Release</text>
+        <text x="700" y="130" text-anchor="middle" fill="#58a6ff" font-size="9" font-weight="600">THIS PR</text>
+
+        <!-- S13 (future) -->
+        <circle cx="840" cy="100" r="16" fill="rgba(139,148,158,0.08)" stroke="#30363d" stroke-width="1.5" stroke-dasharray="4,3"/>
+        <text x="840" y="105" text-anchor="middle" fill="#6e7681" font-size="12">P3</text>
+        <text x="840" y="75" text-anchor="middle" fill="#6e7681" font-size="9">Deploy EKS</text>
+
+        <!-- Arrows -->
+        <path d="M158,100 L262,100" stroke="#3fb950" stroke-width="1.5" marker-end="url(#arr)"/>
+        <path d="M298,100 L402,100" stroke="#3fb950" stroke-width="1.5" marker-end="url(#arr)"/>
+        <path d="M438,100 L542,100" stroke="#3fb950" stroke-width="1.5" marker-end="url(#arr)"/>
+        <path d="M578,100 L676,100" stroke="#58a6ff" stroke-width="2" marker-end="url(#arr-blue)"/>
+        <path d="M722,100 L822,100" stroke="#30363d" stroke-width="1" stroke-dasharray="4,3"/>
+
+        <defs>
+          <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#3fb950"/>
+          </marker>
+          <marker id="arr-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#58a6ff"/>
+          </marker>
+        </defs>
+      </svg>
+    </div>
+  </div>
+
+  <p class="narrative">
+    <strong>S12 itself is a large epic with six child beads, each tackling a different release gate.</strong>
+    This opening PR handles none of the gates directly &mdash; it fixes three small prerequisites that would otherwise block or confuse the child beads. Think of it as clearing the runway before the real planes take off.
+  </p>
+
+  <div class="callout note">
+    <span class="callout-label">Stacked Branch</span>
+    This PR is stacked on PR #133 (AIML-765, S11 isolation and load tests). It cannot be merged until #133 merges first. Once #133 lands, this branch will be rebased onto <code>main</code> and the PR will be promoted to ready-for-review.
+  </div>
+</section>
+
+<!-- ===== CHAPTER 2: Approach ===== -->
+<section class="chapter" id="approach">
+  <div class="chapter-header">
+    <span class="chapter-number green">2</span>
+    <h2>Approach: Three Independent Fixes</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>Each of the three commits solves an independent problem discovered while preparing S12's child beads for execution.</strong>
+    They're bundled in one PR because they're all small, all on the same stacked branch, and all need to land before the S12 child beads can safely proceed. None of the three changes affect runtime behavior of the MCP server itself.
+  </p>
+
+  <p class="narrative">
+    <strong>Here's what each fix addresses:</strong>
+  </p>
+
+  <p class="narrative">
+    1. <strong><code>-parameters</code> compiler flag</strong> &mdash; Without this flag, Java strips method parameter names during compilation, replacing them with <code>arg0</code>, <code>arg1</code>, etc. Spring AI MCP uses these names to generate tool parameter schemas exposed to AI agents. With the flag missing, the schemas would show meaningless names.
+  </p>
+
+  <p class="narrative">
+    2. <strong>Ralph human-only bead filtering</strong> &mdash; Ralph is the Bash supervisor script that drives automated bead implementation using Codex. S12 introduces two new bead label categories (<code>human-security-review</code> and <code>external-approval</code>) that Ralph must skip. Without this fix, Ralph would attempt to run security review beads that require a human.
+  </p>
+
+  <p class="narrative">
+    3. <strong>PR #131 walkthrough restore</strong> &mdash; The HTML walkthrough for PR #131 (cursor pagination core abstraction) was accidentally deleted during a prior branch's rebase. This commit restores the 1,514-line file from the commit history.
+  </p>
+</section>
+
+<!-- ===== CHAPTER 3: Scope ===== -->
+<section class="chapter" id="scope">
+  <div class="chapter-header">
+    <span class="chapter-number purple">3</span>
+    <h2>Scope: What's In vs. What's Next</h2>
+  </div>
+
+  <div class="slice-columns">
+    <div class="slice-col this-pr">
+      <div class="slice-title">This PR (Housekeeping)</div>
+      <div class="slice-item"><span class="dot"></span><strong><code>-parameters</code> flag</strong> &mdash; Correct MCP tool schema generation</div>
+      <div class="slice-item"><span class="dot"></span><strong>Ralph label filter</strong> &mdash; Skip <code>human-security-review</code> and <code>external-approval</code> beads</div>
+      <div class="slice-item"><span class="dot"></span><strong>Walkthrough restore</strong> &mdash; PR #131 HTML doc back in tree</div>
+    </div>
+    <div class="slice-col future-col">
+      <div class="slice-title">S12 Child Beads (Coming Next)</div>
+      <div class="slice-item"><span class="dot"></span>Full remote auth, pipeline, and schema gates (mcp-stcg)</div>
+      <div class="slice-item"><span class="dot"></span>Shared parity, pagination, cache, and exclusion gates (mcp-qpkv)</div>
+      <div class="slice-item"><span class="dot"></span>CI fallback, runbooks, release readiness (mcp-a6sj)</div>
+      <div class="slice-item"><span class="dot"></span>DCR monitoring and post-GA follow-up (mcp-82qj)</div>
+      <div class="slice-item"><span class="dot"></span>Privacy, data-flow, security review evidence (mcp-lkk6)</div>
+      <div class="slice-item"><span class="dot"></span>Final error, isolation, and SLO gates (mcp-8nub.1)</div>
+    </div>
+  </div>
+</section>
+
+<!-- ===== CHAPTER 4: Parameter Metadata ===== -->
+<section class="chapter" id="parameter-metadata">
+  <div class="chapter-header">
+    <span class="chapter-number yellow">4</span>
+    <h2>Parameter Metadata: One Line, Big Impact</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>Java's compiler discards method parameter names by default &mdash; a design choice from 1996 that creates a real problem for modern tool frameworks.</strong>
+    When you write <code>public String searchVulnerabilities(String appId, String severity)</code>, the compiled bytecode only sees <code>arg0</code> and <code>arg1</code> unless you tell <code>javac</code> to preserve the names. Spring AI MCP uses Java reflection to auto-generate JSON schemas for tool parameters. Without the real names, the schema an AI agent sees looks like this:
+  </p>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">Without -parameters (what AI agents see)</span>
+      <span class="badge badge-deleted">BAD</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line context"><span class="marker"> </span><span class="ln"></span><span class="code">{</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln"></span><span class="code">  <span class="str">"name"</span>: <span class="str">"search_vulnerabilities"</span>,</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln"></span><span class="code">  <span class="str">"parameters"</span>: {</span></span>
+<span class="diff-line del"><span class="marker">-</span><span class="ln"></span><span class="code">    <span class="str">"arg0"</span>: { <span class="str">"type"</span>: <span class="str">"string"</span> },</span></span>
+<span class="diff-line del"><span class="marker">-</span><span class="ln"></span><span class="code">    <span class="str">"arg1"</span>: { <span class="str">"type"</span>: <span class="str">"string"</span> }</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln"></span><span class="code">  }</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln"></span><span class="code">}</span></span>
+    </pre></div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">With -parameters (what AI agents see)</span>
+      <span class="badge badge-new">GOOD</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line context"><span class="marker"> </span><span class="ln"></span><span class="code">{</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln"></span><span class="code">  <span class="str">"name"</span>: <span class="str">"search_vulnerabilities"</span>,</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln"></span><span class="code">  <span class="str">"parameters"</span>: {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln"></span><span class="code">    <span class="str">"appId"</span>: { <span class="str">"type"</span>: <span class="str">"string"</span> },</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln"></span><span class="code">    <span class="str">"severity"</span>: { <span class="str">"type"</span>: <span class="str">"string"</span> }</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln"></span><span class="code">  }</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln"></span><span class="code">}</span></span>
+    </pre></div>
+  </div>
+
+  <p class="narrative">
+    <strong>The fix is a single line in the root <code>build.gradle</code>.</strong> It applies to all subprojects (both <code>contrast-mcp-core</code> and <code>contrast-mcp-stdio-app</code>), ensuring every compiled class carries full parameter metadata.
+  </p>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">build.gradle</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">63</span><span class="code">    tasks.withType(<span class="type">JavaCompile</span>).configureEach {</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">64</span><span class="code">        options.encoding = <span class="str">'UTF-8'</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">65</span><span class="code">        options.release = <span class="num">21</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">66</span><span class="code">        options.compilerArgs.add(<span class="str">'-parameters'</span>)</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">67</span><span class="code">    }</span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>The <code>-parameters</code> flag tells <code>javac</code> to store formal parameter names in the bytecode's <code>MethodParameters</code> attribute.</strong> This is the same flag Spring Boot projects commonly enable. It has zero runtime cost &mdash; slightly larger class files but no performance impact. The flag is placed in the <code>subprojects</code> block so it applies to both <code>contrast-mcp-core</code> (the published library) and <code>contrast-mcp-stdio-app</code> (the local server).
+    </div>
+  </div>
+
+  <div class="callout why">
+    <span class="callout-label">Why this matters for S12</span>
+    The S12 child bead <code>mcp-stcg</code> runs the generated schema gate, which snapshots the <code>tools/list</code> response and diffs it against a committed baseline. Without <code>-parameters</code>, the snapshot would contain <code>arg0</code>/<code>arg1</code> parameter names, and either the gate would fail or the baseline would be wrong. This one-line fix ensures the schema gate sees real parameter names from the start.
+  </div>
+</section>
+
+<!-- ===== CHAPTER 5: Ralph Hardening ===== -->
+<section class="chapter" id="ralph-hardening">
+  <div class="chapter-header">
+    <span class="chapter-number orange">5</span>
+    <h2>Ralph Hardening: Teaching the Automation to Stay in Its Lane</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>Ralph is the Bash supervisor that runs Codex workers against beads &mdash; think of it as the robot foreman on the AI implementation assembly line.</strong>
+    When Ralph scans for work, it queries <code>br ready</code> to find unblocked beads, then filters out ones that require human judgment. Before this PR, Ralph knew about two human-only labels: <code>ready-for-human</code> and <code>needs-human-review</code>. But S12 introduces two new categories:
+  </p>
+
+  <p class="narrative">
+    &bull; <strong><code>human-security-review</code></strong> &mdash; Beads that require a human security reviewer (like the privacy/data-flow evidence bead <code>mcp-lkk6</code>)<br/>
+    &bull; <strong><code>external-approval</code></strong> &mdash; Beads waiting on an external team's sign-off (like the DCR monitoring bead <code>mcp-82qj</code> which depends on the OAuth team)
+  </p>
+
+  <p class="narrative">
+    <strong>Without this fix, Ralph would pick up a security review bead and try to implement it &mdash; which at best wastes compute and at worst produces incorrect evidence.</strong>
+  </p>
+
+  <div class="callout why">
+    <span class="callout-label">Design decision</span>
+    Rather than duplicating the label list in four places (as the old code did), this commit extracts the filter into a single <code>human_only_label_filter</code> jq variable. The variable is interpolated into each call site using Bash string substitution. This means future label additions only need to change one place.
+  </div>
+
+  <p class="narrative">
+    <strong>Here's the extracted filter variable &mdash; the single source of truth for what Ralph skips:</strong>
+  </p>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">scripts/ralph</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">112</span><span class="code">  (<span class="kw">cd</span> <span class="str">"$CONTROL_REPO"</span> &amp;&amp; BEADS_DIR=<span class="str">"$BEADS_DIR"</span> br <span class="str">"$@"</span>)</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">113</span><span class="code">}</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">114</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">115</span><span class="code"><span class="prop">human_only_label_filter</span>=<span class="str">'</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">116</span><span class="code"><span class="str">  any(</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">117</span><span class="code"><span class="str">    . == "ready-for-human"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">118</span><span class="code"><span class="str">    or . == "needs-human-review"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">119</span><span class="code"><span class="str">    or . == "human-security-review"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">120</span><span class="code"><span class="str">    or . == "external-approval"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">121</span><span class="code"><span class="str">  )</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">122</span><span class="code"><span class="str">'</span></span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>This jq fragment is defined once as a Bash variable and interpolated into four call sites via <code>'"$human_only_label_filter"'</code>.</strong> The <code>any()</code> jq function returns <code>true</code> if any element in the input array matches one of the four conditions. The single-quote Bash string ensures no shell expansion happens inside the jq code.
+    </div>
+  </div>
+
+  <p class="narrative">
+    <strong>The variable replaces inline duplicated logic in four functions.</strong> Here are the call sites where the old hardcoded two-label check was replaced:
+  </p>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">scripts/ralph &mdash; filter_agent_ready_json()</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">139</span><span class="code">  jq <span class="str">'</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">140</span><span class="code"><span class="str">    map(</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">141</span><span class="code"><span class="str">      select(</span></span></span>
+<span class="diff-line del"><span class="marker">-</span><span class="ln"></span><span class="code">        ((.labels // []) | any(. == <span class="str">"ready-for-human"</span> or . == <span class="str">"needs-human-review"</span>))</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">142</span><span class="code">        ((.labels // []) | <span class="str">'"$human_only_label_filter"'</span>)</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">143</span><span class="code"><span class="str">        | not</span></span></span>
+    </pre></div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">scripts/ralph &mdash; has_human_only_label()</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">149</span><span class="code">has_human_only_label() {</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">150</span><span class="code">  jq -e <span class="str">'</span></span></span>
+<span class="diff-line del"><span class="marker">-</span><span class="ln"></span><span class="code">    (.[0].labels // []) | any(. == <span class="str">"ready-for-human"</span> or . == <span class="str">"needs-human-review"</span>)</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">151</span><span class="code">    (.[0].labels // []) | <span class="str">'"$human_only_label_filter"'</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">152</span><span class="code">  <span class="str">' &gt;/dev/null &lt;&lt;&lt;"$1"</span></span></span>
+    </pre></div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">scripts/ralph &mdash; find_incomplete_bead()</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">170</span><span class="code">    .issues</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">171</span><span class="code">    | map(</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">172</span><span class="code">        select(</span></span>
+<span class="diff-line del"><span class="marker">-</span><span class="ln"></span><span class="code">          ((.labels // []) | any(. == <span class="str">"ready-for-human"</span> or . == <span class="str">"needs-human-review"</span>))</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">173</span><span class="code">          ((.labels // []) | <span class="str">'"$human_only_label_filter"'</span>)</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">174</span><span class="code">          | not</span></span>
+    </pre></div>
+  </div>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">scripts/ralph &mdash; validate_bead_and_repo_label()</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">207</span><span class="code">  [[ <span class="str">"$status"</span> == <span class="str">"open"</span> || <span class="str">"$status"</span> == <span class="str">"in_progress"</span> ]] || die <span class="str">"$bead_id has unexpected status: $status"</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">208</span><span class="code">  <span class="kw">if</span> has_human_only_label <span class="str">"$bead_json"</span>; <span class="kw">then</span></span></span>
+<span class="diff-line del"><span class="marker">-</span><span class="ln"></span><span class="code">    die <span class="str">"$bead_id is labeled ready-for-human or needs-human-review; Ralph must not run human-only work"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">209</span><span class="code">    die <span class="str">"$bead_id is labeled for human-only work; Ralph must not run it"</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">210</span><span class="code">  <span class="kw">fi</span></span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>The error message was simplified to be label-agnostic.</strong> Instead of enumerating the specific label names (which would need updating every time a new label is added), the message now says "labeled for human-only work" &mdash; accurate regardless of which label triggered the rejection.
+    </div>
+  </div>
+
+  <p class="narrative">
+    <strong>The usage help text was also updated to list all four labels:</strong>
+  </p>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">scripts/ralph &mdash; usage()</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line del"><span class="marker">-</span><span class="ln"></span><span class="code">  - skips beads labeled ready-for-human or needs-human-review</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">39</span><span class="code">  - skips beads labeled ready-for-human, needs-human-review, human-security-review, or external-approval</span></span>
+    </pre></div>
+  </div>
+
+  <div class="diagram">
+    <div class="diagram-container">
+      <svg viewBox="0 0 900 300" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+        <text x="450" y="30" text-anchor="middle" fill="#e6edf3" font-size="14" font-weight="600">Ralph's Bead Selection Flow</text>
+
+        <!-- br ready -->
+        <rect x="50" y="60" width="160" height="50" rx="8" fill="#161b22" stroke="#30363d" stroke-width="1.5"/>
+        <text x="130" y="90" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="500">br ready --parent</text>
+
+        <!-- Arrow -->
+        <path d="M210,85 L270,85" stroke="#8b949e" stroke-width="1.5" marker-end="url(#arr-gray)"/>
+
+        <!-- Filter box -->
+        <rect x="270" y="50" width="280" height="70" rx="8" fill="rgba(240,136,62,0.08)" stroke="#f0883e" stroke-width="2"/>
+        <text x="410" y="75" text-anchor="middle" fill="#f0883e" font-size="11" font-weight="700">human_only_label_filter</text>
+        <text x="410" y="95" text-anchor="middle" fill="#8b949e" font-size="10">ready-for-human | needs-human-review</text>
+        <text x="410" y="110" text-anchor="middle" fill="#58a6ff" font-size="10" font-weight="600">+ human-security-review | external-approval</text>
+
+        <!-- Arrow to OK -->
+        <path d="M550,75 L620,75" stroke="#3fb950" stroke-width="1.5" marker-end="url(#arr-green)"/>
+        <text x="585" y="68" text-anchor="middle" fill="#3fb950" font-size="9">PASS</text>
+
+        <!-- OK box -->
+        <rect x="620" y="55" width="180" height="40" rx="8" fill="rgba(63,185,80,0.1)" stroke="#3fb950" stroke-width="1.5"/>
+        <text x="710" y="80" text-anchor="middle" fill="#3fb950" font-size="12" font-weight="500">Claim &amp; dispatch Codex</text>
+
+        <!-- Arrow to Skip -->
+        <path d="M550,100 L620,160" stroke="#f85149" stroke-width="1.5" marker-end="url(#arr-red)"/>
+        <text x="600" y="130" text-anchor="middle" fill="#f85149" font-size="9">SKIP</text>
+
+        <!-- Skip box -->
+        <rect x="620" y="145" width="180" height="40" rx="8" fill="rgba(248,81,73,0.08)" stroke="#f85149" stroke-width="1.5"/>
+        <text x="710" y="170" text-anchor="middle" fill="#f85149" font-size="12" font-weight="500">die: human-only work</text>
+
+        <!-- Example beads -->
+        <text x="130" y="170" fill="#8b949e" font-size="11" font-weight="600">Example S12 beads:</text>
+
+        <rect x="50" y="185" width="200" height="30" rx="6" fill="rgba(63,185,80,0.08)" stroke="#3fb950" stroke-width="1"/>
+        <text x="150" y="205" text-anchor="middle" fill="#3fb950" font-size="10">mcp-stcg (auth gates) &rarr; Ralph runs</text>
+
+        <rect x="50" y="225" width="200" height="30" rx="6" fill="rgba(248,81,73,0.08)" stroke="#f85149" stroke-width="1"/>
+        <text x="150" y="245" text-anchor="middle" fill="#f85149" font-size="10">mcp-lkk6 (security review) &rarr; Skip</text>
+
+        <rect x="50" y="265" width="200" height="30" rx="6" fill="rgba(248,81,73,0.08)" stroke="#f85149" stroke-width="1"/>
+        <text x="150" y="285" text-anchor="middle" fill="#f85149" font-size="10">mcp-82qj (DCR approval) &rarr; Skip</text>
+
+        <defs>
+          <marker id="arr-gray" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#8b949e"/>
+          </marker>
+          <marker id="arr-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#3fb950"/>
+          </marker>
+          <marker id="arr-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#f85149"/>
+          </marker>
+        </defs>
+      </svg>
+    </div>
+  </div>
+</section>
+
+<!-- ===== CHAPTER 6: Walkthrough Restore ===== -->
+<section class="chapter" id="walkthrough-restore">
+  <div class="chapter-header">
+    <span class="chapter-number purple">6</span>
+    <h2>Walkthrough Restore: Bringing Back the Lost Document</h2>
+  </div>
+
+  <details class="standard-pattern">
+    <summary>
+      <svg class="sp-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill="currentColor" opacity=".3"/></svg>
+      <span class="sp-title">Restored PR Walkthrough Document</span>
+      <span class="badge-standard">Standard Pattern</span>
+      <span class="sp-files">pr-131-cursor-pagination-core-abstraction.html (1,514 lines)</span>
+      <span class="sp-ref">Follows: pr-115, pr-116, pr-123, pr-124, pr-125, pr-129, pr-130</span>
+    </summary>
+    <div class="sp-body">
+      <strong>The PR #131 walkthrough was accidentally deleted during a prior branch's rebase and is restored here verbatim from the commit history.</strong>
+      This is the same self-contained HTML walkthrough format used for all PRs in this series. It documents the cursor pagination core abstraction &mdash; the <code>CursorPaginatedTool</code> base class, <code>CursorPaginationParams</code>, and <code>CursorToolResponse</code> added in PR #131 for Slice 9's dataplatform tools. No content was modified; this is a pure restoration. The <code>docs/pr-walkthrough/</code> directory now has all 10 walkthrough documents intact (PRs #115 through #133).
+    </div>
+  </details>
+</section>
+
+<!-- ===== CHAPTER 7: Summary ===== -->
+<section class="chapter" id="summary">
+  <div class="chapter-header">
+    <span class="chapter-number green">7</span>
+    <h2>Summary &amp; File Reference</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>Three surgical changes that clear the path for S12's real work.</strong> The <code>-parameters</code> flag ensures MCP tool schemas carry meaningful parameter names. The Ralph filter expansion prevents the automation from touching human-gated beads. The walkthrough restore keeps the documentation chain unbroken. None of these changes affect runtime MCP server behavior.
+  </p>
+
+  <table class="file-table">
+    <thead><tr><th>File</th><th>Purpose</th><th>Lines</th><th>Novelty</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>build.gradle</td>
+        <td>Add <code>-parameters</code> javac flag for bytecode parameter name retention</td>
+        <td class="addition">+1</td>
+        <td class="novelty"><span class="novelty-badge novel">Novel</span></td>
+      </tr>
+      <tr>
+        <td>scripts/ralph</td>
+        <td>Extract &amp; expand human-only label filter to four labels, simplify error message</td>
+        <td><span class="addition">+19</span> / <span class="deletion">&minus;5</span></td>
+        <td class="novelty"><span class="novelty-badge pattern">Pattern</span></td>
+      </tr>
+      <tr>
+        <td>docs/pr-walkthrough/pr-131-*.html</td>
+        <td>Restore accidentally deleted PR #131 walkthrough document</td>
+        <td class="addition">+1,514</td>
+        <td class="novelty"><span class="novelty-badge standard">Standard</span></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="callout future">
+    <span class="callout-label">What comes next</span>
+    With these prerequisites in place, S12's six child beads can proceed:
+    <code>mcp-stcg</code> (auth/schema gates, already closed in aiml-services),
+    <code>mcp-qpkv</code> (shared parity and pagination gates),
+    <code>mcp-a6sj</code> (CI fallback and runbooks),
+    <code>mcp-82qj</code> (DCR monitoring, requires external-approval),
+    <code>mcp-lkk6</code> (privacy/security evidence, requires human-security-review), and
+    <code>mcp-8nub.1</code> (final error/isolation/SLO gates).
+    Expect follow-up PRs for each as the S12 child beads are implemented.
+  </div>
+
+  <p class="narrative">
+    <strong>Suggested review order:</strong> Start with Chapter 4 (<code>build.gradle</code>, one line). Then Chapter 5 (<code>scripts/ralph</code>, the meaningful logic change). Skip Chapter 6 unless you want to verify the restored walkthrough matches the original.
+  </p>
+</section>
+
+</main>
+
+<footer>
+  PR #134 &middot; AIML-766 &middot; Contrast-Security-OSS/mcp-contrast
+</footer>
+
+</body>
+</html>

--- a/scripts/ralph
+++ b/scripts/ralph
@@ -37,7 +37,7 @@ Usage:
 Runs a small AIML-110 implementation loop:
   - resumes any incomplete bead from a previous run before selecting new work
   - uses br ready as executable truth for new bead selection
-  - skips beads labeled ready-for-human or needs-human-review
+  - skips beads labeled ready-for-human, needs-human-review, human-security-review, or external-approval
   - claims one ready bead
   - invokes one Codex worker in the selected repo
   - saves prompt/output under history/ralph-runs/
@@ -112,6 +112,15 @@ run_br() {
   (cd "$CONTROL_REPO" && BEADS_DIR="$BEADS_DIR" br "$@")
 }
 
+human_only_label_filter='
+  any(
+    . == "ready-for-human"
+    or . == "needs-human-review"
+    or . == "human-security-review"
+    or . == "external-approval"
+  )
+'
+
 # br ready is the executable source of truth — a bead is only runnable if
 # br says all its dependencies are satisfied. --parent scopes to children
 # (and descendants) of the given bead. Optional repo label filter restricts
@@ -131,7 +140,7 @@ filter_agent_ready_json() {
   jq '
     map(
       select(
-        ((.labels // []) | any(. == "ready-for-human" or . == "needs-human-review"))
+        ((.labels // []) | '"$human_only_label_filter"')
         | not
       )
     )
@@ -140,7 +149,7 @@ filter_agent_ready_json() {
 
 has_human_only_label() {
   jq -e '
-    (.[0].labels // []) | any(. == "ready-for-human" or . == "needs-human-review")
+    (.[0].labels // []) | '"$human_only_label_filter"'
   ' >/dev/null <<<"$1"
 }
 
@@ -162,7 +171,7 @@ find_incomplete_bead() {
     .issues
     | map(
         select(
-          ((.labels // []) | any(. == "ready-for-human" or . == "needs-human-review"))
+          ((.labels // []) | '"$human_only_label_filter"')
           | not
         )
       )
@@ -198,7 +207,7 @@ validate_bead_and_repo_label() {
 
   [[ "$status" == "open" || "$status" == "in_progress" ]] || die "$bead_id has unexpected status: $status"
   if has_human_only_label "$bead_json"; then
-    die "$bead_id is labeled ready-for-human or needs-human-review; Ralph must not run human-only work"
+    die "$bead_id is labeled for human-only work; Ralph must not run it"
   fi
 
   case "$issue_type" in


### PR DESCRIPTION
<!-- pr-tools:stacked:v1 -->
<!-- pr-tools:parent-pr=133 -->
<!-- pr-tools:parent-branch=AIML-765-s11-isolation-load-tests -->
<!-- pr-tools:parent-base=AIML-764-s10-validate-oauth-staging -->
<!-- pr-tools:boundary-commit=e74448759885dfe49c962b006e20b58b53d2e2b0 -->
<!-- pr-tools:managed:start -->
> ⚠️ **DO NOT MERGE** - This PR is stacked on #133. Merge that first.
>
> **Stack Context**
> - Parent PR: #133
> - Parent branch: `AIML-765-s11-isolation-load-tests`
> - Promotion target: `AIML-764-s10-validate-oauth-staging`
<!-- pr-tools:managed:end -->

> **Reviewer walkthrough:** Run this to open the interactive walkthrough in your browser:
> ```
> gh api 'repos/Contrast-Security-OSS/mcp-contrast/contents/docs/pr-walkthrough/pr-134-compile-parameters-restore-walkthrough-harden-ralph.html?ref=AIML-766-s12-full-tool-parity-release-hardening' -H "Accept: application/vnd.github.raw" > /tmp/pr-134-walkthrough.html && (open /tmp/pr-134-walkthrough.html || xdg-open /tmp/pr-134-walkthrough.html)
> ```
> Walks through the three S12 housekeeping changes: `-parameters` compiler flag, Ralph label hardening, and walkthrough restoration.
**Jira:** [AIML-766](https://contrast.atlassian.net/browse/AIML-766)

## Summary
Early S12 housekeeping: compile MCP core with `-parameters` for parameter metadata, restore the PR #131 walkthrough document deleted in a prior branch, and harden Ralph's human-only bead filtering to cover two new label categories.

- Java compiler now preserves method parameter names in bytecode (needed for MCP tool parameter metadata)
- Ralph skips beads labeled `human-security-review` or `external-approval` in addition to the existing `ready-for-human` / `needs-human-review` labels
- PR #131 walkthrough document restored to `docs/pr-walkthrough/`

## Why This Change Exists
- The `-parameters` compiler flag is required for Spring AI MCP to expose meaningful parameter names in tool schemas — without it, parameter names compile to `arg0`, `arg1`, etc.
- Ralph was only filtering two human-only labels, but S12 introduces `human-security-review` and `external-approval` beads that must also be excluded from automated runs
- The PR #131 walkthrough was accidentally deleted during a prior branch's rebase/cleanup

## What Changed
### Build configuration
- `build.gradle` — Added `-parameters` to `JavaCompile` compiler args so method parameter names survive compilation

### Ralph automation script
- `scripts/ralph` — Extracted the human-only label check into a reusable `human_only_label_filter` jq variable, added `human-security-review` and `external-approval` to the filter, and simplified the die message

### Documentation
- `docs/pr-walkthrough/pr-131-cursor-pagination-core-abstraction.html` — Restored the PR #131 walkthrough document

## Testing
- `build.gradle` change verified by successful `make check-test` (the `-parameters` flag is a standard javac option)
- Ralph label filtering verified by inspecting jq filter logic — the extracted variable is used consistently across all four call sites
- No new tests required: build config is covered by existing compilation, Ralph is a shell script with no test harness in this repo


[AIML-766]: https://contrast.atlassian.net/browse/AIML-766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
