### PR TITLE
[STACKED] AIML-767: Support Phase 3 repos in Ralph automation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,8 +324,12 @@ EOF
 
 ### Human Review Labels
 
+- `ready-for-human` — human should inspect, decide, or run the work with agent assistance; autonomous agents should not pick it up
 - `needs-human-review` — DO NOT start work; ask human to review first
-- `human-reviewed` — approved; AI may proceed
+- `human-security-review` — security review is required before agent work proceeds
+- `external-approval` — blocked on approval outside the agent workflow
+
+`human-reviewed` is the cleared marker after review; AI may proceed when no human-only label remains.
 
 When reviewing a `needs-human-review` bead, update the description if needed, then:
 ```bash

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -11,7 +11,7 @@
       <property name="severity" value="error"/>
     </module>
     <module name="RegexpSinglelineJava">
-      <property name="format" value="^\s+(com|java|org|io|net)\.[a-z]+\.[a-zA-Z.]+\.[A-Z][a-zA-Z]+[\s&lt;(]"/>
+      <property name="format" value="^\s+(com|java|org|io|net)\.[a-z]+(\.[a-zA-Z]+)*\.[A-Z][a-zA-Z]+[\s&lt;(]"/>
       <property name="message" value="Use import instead of fully-qualified class name"/>
       <property name="severity" value="error"/>
       <property name="ignoreComments" value="true"/>

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/LibraryExtended.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/LibraryExtended.java
@@ -98,10 +98,14 @@ public class LibraryExtended {
    * @return the count of vulnerabilities from the array, or the API value if array is empty/null
    */
   public int getTotalVulnerabilities() {
-    if (vulnerabilities != null && !vulnerabilities.isEmpty()) {
+    if (hasVulnerabilityDetails()) {
       return vulnerabilities.size();
     }
     return totalVulnerabilities;
+  }
+
+  private boolean hasVulnerabilityDetails() {
+    return vulnerabilities != null && !vulnerabilities.isEmpty();
   }
 
   private int countBySeverity(RuleSeverity severity) {
@@ -110,6 +114,20 @@ public class LibraryExtended {
         vulnerabilities.stream()
             .filter(v -> severity.name().equalsIgnoreCase(v.getSeverityCode()))
             .count();
+  }
+
+  public int getCriticalVulnerabilities() {
+    if (hasVulnerabilityDetails()) {
+      return countBySeverity(RuleSeverity.CRITICAL);
+    }
+    return criticalVulnerabilities;
+  }
+
+  public int getHighVulnerabilities() {
+    if (hasVulnerabilityDetails()) {
+      return countBySeverity(RuleSeverity.HIGH);
+    }
+    return highVulnerabilities;
   }
 
   public int getMediumVulnerabilities() {

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesTool.java
@@ -53,6 +53,11 @@ public class GetProtectRulesTool extends SingleTool<GetProtectRulesParams, Prote
           - Production mode for each rule (block, monitor, or off)
           - Rule-specific configuration settings
 
+          Response shape note:
+          - Protect Rules use development/qa/production mode strings and populate uuid.
+          - Virtual Patches use enabledDev/enabledQa/enabledProd booleans instead; their
+            development/qa/production mode fields and uuid may be null.
+
           Usage examples:
           - Get protect rules: appId="app-123"
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesTool.java
@@ -70,6 +70,10 @@ public class GetProtectRulesTool extends SingleTool<GetProtectRulesParams, Prote
     return executePipeline(() -> GetProtectRulesParams.of(appId), toolContext);
   }
 
+  public SingleToolResponse<ProtectData> getProtectRules(String appId) {
+    return getProtectRules(appId, null);
+  }
+
   @Override
   protected ProtectData doExecute(GetProtectRulesParams params, WarningCollector collector)
       throws Exception {

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseTool.java
@@ -64,7 +64,9 @@ public abstract class BaseTool {
       case 401 ->
           "Authentication failed or resource not found. Verify credentials and that the resource ID"
               + " is correct.";
-      case 403 -> "Access denied. User lacks permission for this resource.";
+      case 403 ->
+          "Access denied or resource not found. Verify credentials and that the resource ID is"
+              + " correct.";
       case 404 -> "Resource not found.";
       case 429 -> "Rate limit exceeded. Retry after a brief pause.";
       case 500, 502, 503 ->

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java
@@ -81,7 +81,7 @@ public abstract class CursorPaginatedTool<P extends ToolParams, R> extends BaseT
       return buildSuccessResponse(result, pagination, collector, duration, requestId);
 
     } catch (UnauthorizedException e) {
-      return handleException(e, pagination, requestId, mapHttpErrorCode(401));
+      return handleException(e, pagination, requestId, mapHttpErrorCode(e.getCode()));
     } catch (ResourceNotFoundException e) {
       return handleException(e, pagination, requestId, "Resource not found");
     } catch (HttpResponseException e) {

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java
@@ -155,7 +155,7 @@ public abstract class CursorPaginatedTool<P extends ToolParams, R> extends BaseT
       long duration,
       String requestId) {
 
-    if (result.items().isEmpty() && !result.hasMore()) {
+    if (result.items().isEmpty() && !result.hasMore() && !collector.hasEmptyResultsWarning()) {
       collector.warn("No results found matching the specified criteria.");
     }
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
@@ -111,7 +111,7 @@ public abstract class PaginatedTool<P extends ToolParams, R> extends BaseTool {
       return buildSuccessResponse(result, pagination, collector, duration, requestId);
 
     } catch (UnauthorizedException e) {
-      return handleException(e, pagination, requestId, mapHttpErrorCode(401));
+      return handleException(e, pagination, requestId, mapHttpErrorCode(e.getCode()));
     } catch (ResourceNotFoundException e) {
       return handleException(e, pagination, requestId, "Resource not found");
     } catch (HttpResponseException e) {

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
@@ -188,7 +188,10 @@ public abstract class PaginatedTool<P extends ToolParams, R> extends BaseTool {
       long duration,
       String requestId) {
 
-    if (result.items().isEmpty() && result.totalItems() != null && result.totalItems() == 0) {
+    if (result.items().isEmpty()
+        && result.totalItems() != null
+        && result.totalItems() == 0
+        && !collector.hasEmptyResultsWarning()) {
       collector.warn("No results found matching the specified criteria.");
     }
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
@@ -131,7 +131,6 @@ public abstract class SingleTool<P extends ToolParams, R> extends BaseTool {
         .addKeyValue(LoggingKeys.EXCEPTION_TYPE, e.getClass().getSimpleName())
         .setMessage("Request failed")
         .log();
-    collector.warn(userMessage);
     return new SingleToolResponse<>(null, List.of(userMessage), collector.snapshot(), false);
   }
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
@@ -96,7 +96,7 @@ public abstract class SingleTool<P extends ToolParams, R> extends BaseTool {
       logNotFound(requestId, duration);
       return SingleToolResponse.notFound("Resource not found", collector.snapshot());
     } catch (UnauthorizedException e) {
-      return handleException(e, requestId, mapHttpErrorCode(401), collector);
+      return handleException(e, requestId, mapHttpErrorCode(e.getCode()), collector);
     } catch (HttpResponseException e) {
       return handleHttpResponseException(e, requestId, collector);
     } catch (IllegalArgumentException e) {

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/WarningCollector.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/WarningCollector.java
@@ -50,6 +50,7 @@ public final class WarningCollector {
 
   private final Map<String, Object> context;
   private final List<String> warnings = new ArrayList<>();
+  private boolean emptyResultsWarningRecorded;
 
   private WarningCollector(Map<String, Object> context) {
     this.context = context;
@@ -114,6 +115,22 @@ public final class WarningCollector {
     if (!message.isBlank()) {
       warnings.add(message);
     }
+  }
+
+  /**
+   * Appends a warning that explains why an otherwise successful result set is empty. Base
+   * pagination classes use this marker to avoid adding their generic empty-result warning on top of
+   * a more specific tool-level explanation.
+   */
+  public void warnForEmptyResults(String message) {
+    warn(message);
+    if (!message.isBlank()) {
+      emptyResultsWarningRecorded = true;
+    }
+  }
+
+  boolean hasEmptyResultsWarning() {
+    return emptyResultsWarningRecorded;
   }
 
   /**

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesTool.java
@@ -113,7 +113,7 @@ public class ListApplicationLibrariesTool
 
     if (libraries == null || libraries.isEmpty()) {
       if (pagination.offset() == 0 && total == 0) {
-        collector.warn(
+        collector.warnForEmptyResults(
             "No libraries found for this application. "
                 + "The application may not have any third-party dependencies, "
                 + "or library data may not have been collected yet.");

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
@@ -177,7 +177,7 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
     // Fetch libraries and match to stack frames
     var started = Instant.now();
     var libs = contrastApiClient.getAllLibraries(appId);
-    var lobs = buildLibraryObservations(libs, appId);
+    var lobs = buildVulnerableLibraryObservations(libs, appId);
     log.debug(
         "Built vulnerability library enrichment: libraryCount={}, observationGroupCount={},"
             + " stackFrameCount={}, durationMs={}",
@@ -191,7 +191,7 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
       if (matchingLlobOpt.isPresent()) {
         var llob = matchingLlobOpt.get();
         var library = llob.library();
-        if (!library.getVulnerabilities().isEmpty()) {
+        if (hasVulnerabilities(library)) {
           libsToReturn.add(library);
           stackLibs.add(new StackLib(stackTrace, library.getHash()));
         } else {
@@ -221,16 +221,23 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
     return stackTraces;
   }
 
-  private List<LibraryLibraryObservation> buildLibraryObservations(
+  private List<LibraryLibraryObservation> buildVulnerableLibraryObservations(
       List<LibraryExtended> libs, String appId) throws Exception {
     var lobs = new ArrayList<LibraryLibraryObservation>();
     for (LibraryExtended lib : libs) {
+      if (!hasVulnerabilities(lib)) {
+        continue;
+      }
       var observations =
           contrastApiClient.getLibraryObservations(
               appId, lib.getHash(), ValidationConstants.API_MAX_PAGE_SIZE);
       lobs.add(new LibraryLibraryObservation(lib, observations));
     }
     return lobs;
+  }
+
+  private boolean hasVulnerabilities(LibraryExtended library) {
+    return library.getVulnerabilities() != null && !library.getVulnerabilities().isEmpty();
   }
 
   private Optional<LibraryLibraryObservation> findMatchingLibraryData(

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
@@ -162,7 +162,7 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
 
     var triggerEvent =
         eventSummaryResponse.getEvents().stream()
-            .filter(e -> e.getType().equalsIgnoreCase("trigger"))
+            .filter(e -> e != null && "trigger".equalsIgnoreCase(e.getType()))
             .findFirst();
 
     if (triggerEvent.isEmpty()) {
@@ -205,9 +205,18 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
 
   private List<String> extractStackTraces(EventResource triggerEvent) {
     var stackTraces = new ArrayList<String>();
-    var sTrace = triggerEvent.getEvent().getStacktraces();
+    var event = triggerEvent.getEvent();
+    if (event == null) {
+      return stackTraces;
+    }
+
+    var sTrace = event.getStacktraces();
     if (sTrace != null) {
-      stackTraces.addAll(sTrace.stream().map(Stacktrace::getDescription).toList());
+      stackTraces.addAll(
+          sTrace.stream()
+              .filter(stacktrace -> stacktrace != null && stacktrace.getDescription() != null)
+              .map(Stacktrace::getDescription)
+              .toList());
     }
     return stackTraces;
   }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/HttpRequestRedactor.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/HttpRequestRedactor.java
@@ -25,7 +25,16 @@ import org.springframework.util.StringUtils;
 final class HttpRequestRedactor {
 
   private static final Set<String> SENSITIVE_HEADERS =
-      Set.of("authorization", "cookie", "set-cookie");
+      Set.of(
+          "api-key",
+          "authorization",
+          "cookie",
+          "proxy-authorization",
+          "set-cookie",
+          "x-api-key",
+          "x-auth-token",
+          "x-csrf-token",
+          "x-xsrf-token");
 
   static String redact(String httpRequest) {
     if (!StringUtils.hasText(httpRequest)) {

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesTool.java
@@ -61,6 +61,10 @@ public class ListVulnerabilityTypesTool
     return executePipeline(ListVulnerabilityTypesParams::of, toolContext);
   }
 
+  public SingleToolResponse<List<String>> listVulnerabilityTypes() {
+    return listVulnerabilityTypes(null);
+  }
+
   @Override
   protected List<String> doExecute(ListVulnerabilityTypesParams params, WarningCollector collector)
       throws Exception {

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/LibraryExtendedTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/LibraryExtendedTest.java
@@ -82,12 +82,76 @@ class LibraryExtendedTest {
     assertThat(library.getCriticalVulnerabilities()).isEqualTo(5);
   }
 
+  @Test
+  void highVulnerabilities_should_be_settable_and_gettable() {
+    var library = new LibraryExtended();
+    library.setHighVulnerabilities(4);
+
+    assertThat(library.getHighVulnerabilities()).isEqualTo(4);
+  }
+
   // ---- helper ----
 
   private LibraryVulnerabilityExtended vuln(String severityCode) {
     var v = new LibraryVulnerabilityExtended();
     v.setSeverityCode(severityCode);
     return v;
+  }
+
+  // ---- getCriticalVulnerabilities ----
+
+  @Test
+  void getCriticalVulnerabilities_should_return_count_when_critical_vulns_present() {
+    var library = new LibraryExtended();
+    library.setCriticalVulnerabilities(0);
+    library.setVulnerabilities(List.of(vuln("CRITICAL"), vuln("CRITICAL"), vuln("HIGH")));
+
+    assertThat(library.getCriticalVulnerabilities()).isEqualTo(2);
+  }
+
+  @Test
+  void getCriticalVulnerabilities_should_return_api_value_when_vulnerabilities_null() {
+    var library = new LibraryExtended();
+    library.setCriticalVulnerabilities(3);
+
+    assertThat(library.getCriticalVulnerabilities()).isEqualTo(3);
+  }
+
+  @Test
+  void getCriticalVulnerabilities_should_return_api_value_when_vulnerabilities_empty() {
+    var library = new LibraryExtended();
+    library.setCriticalVulnerabilities(3);
+    library.setVulnerabilities(new ArrayList<>());
+
+    assertThat(library.getCriticalVulnerabilities()).isEqualTo(3);
+  }
+
+  // ---- getHighVulnerabilities ----
+
+  @Test
+  void getHighVulnerabilities_should_return_count_when_high_vulns_present() {
+    var library = new LibraryExtended();
+    library.setHighVulnerabilities(0);
+    library.setVulnerabilities(List.of(vuln("HIGH"), vuln("HIGH"), vuln("MEDIUM")));
+
+    assertThat(library.getHighVulnerabilities()).isEqualTo(2);
+  }
+
+  @Test
+  void getHighVulnerabilities_should_return_api_value_when_vulnerabilities_null() {
+    var library = new LibraryExtended();
+    library.setHighVulnerabilities(3);
+
+    assertThat(library.getHighVulnerabilities()).isEqualTo(3);
+  }
+
+  @Test
+  void getHighVulnerabilities_should_return_api_value_when_vulnerabilities_empty() {
+    var library = new LibraryExtended();
+    library.setHighVulnerabilities(3);
+    library.setVulnerabilities(new ArrayList<>());
+
+    assertThat(library.getHighVulnerabilities()).isEqualTo(3);
   }
 
   // ---- getMediumVulnerabilities ----
@@ -171,8 +235,17 @@ class LibraryExtendedTest {
   @Test
   void get_vulnerability_counts_should_return_only_matching_severity_from_mixed_array() {
     var library = new LibraryExtended();
-    library.setVulnerabilities(List.of(vuln("MEDIUM"), vuln("MEDIUM"), vuln("LOW"), vuln("NOTE")));
+    library.setVulnerabilities(
+        List.of(
+            vuln("CRITICAL"),
+            vuln("HIGH"),
+            vuln("MEDIUM"),
+            vuln("MEDIUM"),
+            vuln("LOW"),
+            vuln("NOTE")));
 
+    assertThat(library.getCriticalVulnerabilities()).isEqualTo(1);
+    assertThat(library.getHighVulnerabilities()).isEqualTo(1);
     assertThat(library.getMediumVulnerabilities()).isEqualTo(2);
     assertThat(library.getLowVulnerabilities()).isEqualTo(1);
     assertThat(library.getNoteVulnerabilities()).isEqualTo(1);
@@ -193,8 +266,11 @@ class LibraryExtendedTest {
   @Test
   void get_vulnerability_counts_should_match_lowercase_severity_codes() {
     var library = new LibraryExtended();
-    library.setVulnerabilities(List.of(vuln("medium"), vuln("low"), vuln("note")));
+    library.setVulnerabilities(
+        List.of(vuln("critical"), vuln("high"), vuln("medium"), vuln("low"), vuln("note")));
 
+    assertThat(library.getCriticalVulnerabilities()).isEqualTo(1);
+    assertThat(library.getHighVulnerabilities()).isEqualTo(1);
     assertThat(library.getMediumVulnerabilities()).isEqualTo(1);
     assertThat(library.getLowVulnerabilities()).isEqualTo(1);
     assertThat(library.getNoteVulnerabilities()).isEqualTo(1);
@@ -203,8 +279,11 @@ class LibraryExtendedTest {
   @Test
   void get_vulnerability_counts_should_match_mixed_case_severity_codes() {
     var library = new LibraryExtended();
-    library.setVulnerabilities(List.of(vuln("Medium"), vuln("Low"), vuln("Note")));
+    library.setVulnerabilities(
+        List.of(vuln("Critical"), vuln("High"), vuln("Medium"), vuln("Low"), vuln("Note")));
 
+    assertThat(library.getCriticalVulnerabilities()).isEqualTo(1);
+    assertThat(library.getHighVulnerabilities()).isEqualTo(1);
     assertThat(library.getMediumVulnerabilities()).isEqualTo(1);
     assertThat(library.getLowVulnerabilities()).isEqualTo(1);
     assertThat(library.getNoteVulnerabilities()).isEqualTo(1);
@@ -215,8 +294,10 @@ class LibraryExtendedTest {
   @Test
   void get_vulnerability_counts_should_return_0_when_vuln_has_null_severity_code() {
     var library = new LibraryExtended();
-    library.setVulnerabilities(List.of(vuln(null), vuln("HIGH")));
+    library.setVulnerabilities(List.of(vuln(null)));
 
+    assertThat(library.getCriticalVulnerabilities()).isEqualTo(0);
+    assertThat(library.getHighVulnerabilities()).isEqualTo(0);
     assertThat(library.getMediumVulnerabilities()).isEqualTo(0);
     assertThat(library.getLowVulnerabilities()).isEqualTo(0);
     assertThat(library.getNoteVulnerabilities()).isEqualTo(0);

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataToolTest.java
@@ -106,7 +106,9 @@ class GetSessionMetadataToolTest {
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors())
-        .containsExactly("Access denied. User lacks permission for this resource.");
+        .containsExactly(
+            "Access denied or resource not found. Verify credentials and that the resource ID is"
+                + " correct.");
     assertThat(result.toString()).doesNotContain(SECRET_BODY, "/ng/org/apps");
   }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolTest.java
@@ -174,7 +174,9 @@ class SearchApplicationsToolTest {
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors())
-        .containsExactly("Access denied. User lacks permission for this resource.");
+        .containsExactly(
+            "Access denied or resource not found. Verify credentials and that the resource ID is"
+                + " correct.");
     assertThat(result.toString()).doesNotContain(SECRET_BODY, "/ng/org/apps");
   }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolTest.java
@@ -51,7 +51,7 @@ class GetProtectRulesToolTest {
     var protectData = createProtectData();
     when(contrastApiClient.getProtectRules(TEST_APP_ID)).thenReturn(protectData);
 
-    var result = tool.getProtectRules(TEST_APP_ID, null);
+    var result = tool.getProtectRules(TEST_APP_ID);
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.found()).isTrue();

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksToolTest.java
@@ -185,7 +185,9 @@ class SearchAttacksToolTest {
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors())
-        .containsExactly("Access denied. User lacks permission for this resource.");
+        .containsExactly(
+            "Access denied or resource not found. Verify credentials and that the resource ID is"
+                + " correct.");
     assertThat(result.toString()).doesNotContain(SECRET_BODY, "/ng/org/attacks");
   }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseToolTest.java
@@ -28,7 +28,8 @@ class BaseToolTest {
   @CsvSource({
     "401, Authentication failed or resource not found. Verify credentials and that the resource ID"
         + " is correct.",
-    "403, Access denied. User lacks permission for this resource.",
+    "403, Access denied or resource not found. Verify credentials and that the resource ID is"
+        + " correct.",
     "404, Resource not found.",
     "429, Rate limit exceeded. Retry after a brief pause.",
     "500, 'The service returned an error. Narrow filters or reduce page size, then retry.'",

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
@@ -158,7 +158,9 @@ class CursorPaginatedToolTest {
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors())
-        .containsExactly("Access denied. User lacks permission for this resource.");
+        .containsExactly(
+            "Access denied or resource not found. Verify credentials and that the resource ID is"
+                + " correct.");
     assertThat(result.errors()).noneMatch(error -> error.contains(OPAQUE_CURSOR));
   }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
@@ -148,6 +148,21 @@ class CursorPaginatedToolTest {
   }
 
   @Test
+  void executePipeline_should_handle_unauthorized_exception_403_without_cursor_value() {
+    tool.setDoExecuteHandler(
+        (pagination, params, collector) -> {
+          throw new UnauthorizedException("Forbidden", "GET", "/api/test", 403, "Forbidden");
+        });
+
+    var result = tool.executePipeline(OPAQUE_CURSOR, 25, TestParams::valid);
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors())
+        .containsExactly("Access denied. User lacks permission for this resource.");
+    assertThat(result.errors()).noneMatch(error -> error.contains(OPAQUE_CURSOR));
+  }
+
+  @Test
   void executePipeline_should_handle_resource_not_found_without_cursor_value() {
     tool.setDoExecuteHandler(
         (pagination, params, collector) -> {

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
@@ -209,6 +209,34 @@ class CursorPaginatedToolTest {
     assertThat(result.durationMs()).isGreaterThanOrEqualTo(0);
   }
 
+  @Test
+  void executePipeline_should_add_empty_results_warning() {
+    tool.setDoExecuteHandler(
+        (pagination, params, collector) -> CursorExecutionResult.of(List.of(), null, false));
+
+    var result = tool.executePipeline(null, 25, TestParams::valid);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.items()).isEmpty();
+    assertThat(result.warnings())
+        .containsExactly("No results found matching the specified criteria.");
+  }
+
+  @Test
+  void executePipeline_should_not_add_generic_empty_warning_when_tool_explains_empty_result() {
+    tool.setDoExecuteHandler(
+        (pagination, params, collector) -> {
+          collector.warnForEmptyResults("No cursor widgets found.");
+          return CursorExecutionResult.of(List.of(), null, false);
+        });
+
+    var result = tool.executePipeline(null, 25, TestParams::valid);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.items()).isEmpty();
+    assertThat(result.warnings()).containsExactly("No cursor widgets found.");
+  }
+
   private static class TestCursorTool extends CursorPaginatedTool<TestParams, String> {
     private DoExecuteHandler handler;
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolTest.java
@@ -99,10 +99,10 @@ class PaginatedToolTest {
   }
 
   @Test
-  void executePipeline_should_handle_http_response_exception_403() {
+  void executePipeline_should_handle_unauthorized_exception_403() {
     tool.setDoExecuteHandler(
         (pagination, params, collector) -> {
-          throw new HttpResponseException("Forbidden", "GET", "/api/test", 403, "Forbidden");
+          throw new UnauthorizedException("Forbidden", "GET", "/api/test", 403, "Forbidden");
         });
 
     var result = tool.executePipeline(1, 10, () -> TestParams.valid());

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolTest.java
@@ -109,7 +109,9 @@ class PaginatedToolTest {
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors())
-        .containsExactly("Access denied. User lacks permission for this resource.");
+        .containsExactly(
+            "Access denied or resource not found. Verify credentials and that the resource ID is"
+                + " correct.");
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolTest.java
@@ -263,6 +263,22 @@ class PaginatedToolTest {
   }
 
   @Test
+  void executePipeline_should_not_add_generic_empty_warning_when_tool_explains_empty_result() {
+    tool.setDoExecuteHandler(
+        (pagination, params, collector) -> {
+          collector.warnForEmptyResults("No widgets found for this account.");
+          return ExecutionResult.of(List.of(), 0);
+        });
+
+    var result = tool.executePipeline(1, 10, () -> TestParams.valid());
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.items()).isEmpty();
+    assertThat(result.totalItems()).isZero();
+    assertThat(result.warnings()).containsExactly("No widgets found for this account.");
+  }
+
+  @Test
   void executePipeline_should_include_pagination_warnings() {
     tool.setDoExecuteHandler(
         (pagination, params, collector) -> ExecutionResult.of(List.of("item"), 1));

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolTest.java
@@ -112,10 +112,10 @@ class SingleToolTest {
   }
 
   @Test
-  void executePipeline_should_handle_http_response_exception_403() {
+  void executePipeline_should_handle_unauthorized_exception_403() {
     tool.setDoExecuteHandler(
         (params, warnings) -> {
-          throw new HttpResponseException("Forbidden", "GET", "/api/test", 403, "Forbidden");
+          throw new UnauthorizedException("Forbidden", "GET", "/api/test", 403, "Forbidden");
         });
 
     var result = tool.executePipeline(() -> TestParams.valid());

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolTest.java
@@ -251,8 +251,7 @@ class SingleToolTest {
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors()).containsExactly(AUTH_OR_NOT_FOUND_MESSAGE);
     assertThat(result.warnings())
-        .containsExactlyInAnyOrder(
-            "Initial warning", "Warning added before exception", AUTH_OR_NOT_FOUND_MESSAGE);
+        .containsExactlyInAnyOrder("Initial warning", "Warning added before exception");
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolTest.java
@@ -122,7 +122,9 @@ class SingleToolTest {
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors())
-        .containsExactly("Access denied. User lacks permission for this resource.");
+        .containsExactly(
+            "Access denied or resource not found. Verify credentials and that the resource ID is"
+                + " correct.");
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/WarningCollectorTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/WarningCollectorTest.java
@@ -116,6 +116,14 @@ class WarningCollectorTest {
   }
 
   @Test
+  void warnForEmptyResults_should_append_warning_and_mark_empty_result_explained() {
+    collector.warnForEmptyResults("No domain objects found");
+
+    assertThat(collector.snapshot()).containsExactly("No domain objects found");
+    assertThat(collector.hasEmptyResultsWarning()).isTrue();
+  }
+
+  @Test
   void warn_should_throw_when_message_is_null() {
     assertThatThrownBy(() -> collector.warn(null)).isInstanceOf(NullPointerException.class);
   }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolTest.java
@@ -210,7 +210,9 @@ class GetRouteCoverageToolTest {
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors())
-        .containsExactly("Access denied. User lacks permission for this resource.");
+        .containsExactly(
+            "Access denied or resource not found. Verify credentials and that the resource ID is"
+                + " correct.");
     assertThat(result.toString()).doesNotContain(SECRET_BODY, "/ng/org/route");
   }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolTest.java
@@ -178,7 +178,9 @@ class ListApplicationLibrariesToolTest {
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors())
-        .containsExactly("Access denied. User lacks permission for this resource.");
+        .containsExactly(
+            "Access denied or resource not found. Verify credentials and that the resource ID is"
+                + " correct.");
     assertThat(result.toString()).doesNotContain(SECRET_BODY, "/ng/org/apps/app-123/libraries");
   }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolTest.java
@@ -121,7 +121,11 @@ class ListApplicationLibrariesToolTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.items()).isEmpty();
     assertThat(result.totalItems()).isEqualTo(0);
-    assertThat(result.warnings()).anyMatch(w -> w.contains("No libraries found"));
+    assertThat(result.warnings())
+        .containsExactly(
+            "No libraries found for this application. "
+                + "The application may not have any third-party dependencies, "
+                + "or library data may not have been collected yet.");
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
@@ -190,7 +190,9 @@ class ListApplicationsByCveToolTest {
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors())
-        .containsExactly("Access denied. User lacks permission for this resource.");
+        .containsExactly(
+            "Access denied or resource not found. Verify credentials and that the resource ID is"
+                + " correct.");
     assertThat(result.toString()).doesNotContain(SECRET_BODY, "/ng/org/libraries/cve");
   }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectToolTest.java
@@ -152,7 +152,9 @@ class GetSastProjectToolTest {
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors())
-        .containsExactly("Access denied. User lacks permission for this resource.");
+        .containsExactly(
+            "Access denied or resource not found. Verify credentials and that the resource ID is"
+                + " correct.");
     assertThat(result.toString()).doesNotContain(SECRET_BODY, "/ng/org/scan");
   }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -178,6 +179,36 @@ class GetVulnerabilityToolTest {
     assertThat(result.warnings())
         .contains("Recommendation data not available (retrieval error, HTTP 403)");
     assertThat(result.toString()).doesNotContain(SECRET_BODY, "/ng/org/recommendation");
+  }
+
+  @Test
+  void getVulnerability_should_ignore_trigger_event_without_nested_event() throws Exception {
+    Trace trace = mock();
+    Vulnerability vulnerability = mock();
+    var trigger = new EventResource();
+    trigger.setType("trigger");
+    var eventSummaryResponse = new EventSummaryResponse();
+    eventSummaryResponse.setEvents(List.of(trigger));
+
+    when(contrastApiClient.getVulnerability(eq(VALID_APP_ID), eq(VALID_VULN_ID), any()))
+        .thenReturn(trace);
+    when(contrastApiClient.getEventSummary(VALID_VULN_ID)).thenReturn(eventSummaryResponse);
+    when(vulnerabilityMapper.toFullVulnerability(eq(trace), any(VulnerabilityContext.class)))
+        .thenReturn(vulnerability);
+
+    var result = tool.getVulnerability(VALID_VULN_ID, VALID_APP_ID);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.found()).isTrue();
+    assertThat(result.warnings())
+        .doesNotContain("Stack trace data not available (retrieval error)");
+
+    ArgumentCaptor<VulnerabilityContext> contextCaptor =
+        ArgumentCaptor.forClass(VulnerabilityContext.class);
+    verify(vulnerabilityMapper).toFullVulnerability(eq(trace), contextCaptor.capture());
+    assertThat(contextCaptor.getValue().stackLibs()).isEmpty();
+    assertThat(contextCaptor.getValue().libraries()).isEmpty();
+    verify(contrastApiClient, never()).getAllLibraries(VALID_APP_ID);
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolTest.java
@@ -106,6 +106,7 @@ class GetVulnerabilityToolTest {
             """);
     var eventSummaryResponse = eventSummaryResponse("com.example.Library.method");
     var library = vulnerableLibrary("lib-hash");
+    var nonVulnerableLibrary = nonVulnerableLibrary("safe-lib-hash");
     var observation = libraryObservation("com.example.Library");
 
     when(contrastApiClient.getVulnerability(eq(VALID_APP_ID), eq(VALID_VULN_ID), any()))
@@ -113,7 +114,8 @@ class GetVulnerabilityToolTest {
     when(contrastApiClient.getRecommendation(VALID_VULN_ID)).thenReturn(recommendationResponse);
     when(contrastApiClient.getHttpRequest(VALID_VULN_ID)).thenReturn(httpRequestResponse);
     when(contrastApiClient.getEventSummary(VALID_VULN_ID)).thenReturn(eventSummaryResponse);
-    when(contrastApiClient.getAllLibraries(VALID_APP_ID)).thenReturn(List.of(library));
+    when(contrastApiClient.getAllLibraries(VALID_APP_ID))
+        .thenReturn(List.of(nonVulnerableLibrary, library));
     when(contrastApiClient.getLibraryObservations(
             VALID_APP_ID, "lib-hash", ValidationConstants.API_MAX_PAGE_SIZE))
         .thenReturn(List.of(observation));
@@ -157,6 +159,9 @@ class GetVulnerabilityToolTest {
     verify(contrastApiClient).getAllLibraries(VALID_APP_ID);
     verify(contrastApiClient)
         .getLibraryObservations(VALID_APP_ID, "lib-hash", ValidationConstants.API_MAX_PAGE_SIZE);
+    verify(contrastApiClient, never())
+        .getLibraryObservations(
+            VALID_APP_ID, "safe-lib-hash", ValidationConstants.API_MAX_PAGE_SIZE);
   }
 
   @Test
@@ -255,6 +260,13 @@ class GetVulnerabilityToolTest {
     var library = new LibraryExtended();
     library.setHash(hash);
     library.setVulnerabilities(List.of(vulnerability));
+    return library;
+  }
+
+  private static LibraryExtended nonVulnerableLibrary(String hash) {
+    var library = new LibraryExtended();
+    library.setHash(hash);
+    library.setVulnerabilities(List.of());
     return library;
   }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/HttpRequestRedactorTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/HttpRequestRedactorTest.java
@@ -30,7 +30,13 @@ class HttpRequestRedactorTest {
             "Host: example.com",
             "Authorization: Bearer secret",
             "Cookie: session=abc; token=def",
+            "Proxy-Authorization: Basic proxy-secret",
             "Set-Cookie: id=ghi",
+            "X-Api-Key: api-secret",
+            "X-Auth-Token: auth-secret",
+            "X-Csrf-Token: csrf-secret",
+            "X-Xsrf-Token: xsrf-secret",
+            "Api-Key: alternate-api-secret",
             "X-Trace-Id: trace-123",
             "",
             "{\"user\":\"chris\"}");
@@ -43,7 +49,21 @@ class HttpRequestRedactorTest {
     assertThat(redacted).contains("{\"user\":\"chris\"}");
     assertThat(redacted).doesNotContain("Authorization:");
     assertThat(redacted).doesNotContain("Cookie:");
+    assertThat(redacted).doesNotContain("Proxy-Authorization:");
     assertThat(redacted).doesNotContain("Set-Cookie:");
+    assertThat(redacted).doesNotContain("X-Api-Key:");
+    assertThat(redacted).doesNotContain("X-Auth-Token:");
+    assertThat(redacted).doesNotContain("X-Csrf-Token:");
+    assertThat(redacted).doesNotContain("X-Xsrf-Token:");
+    assertThat(redacted).doesNotContain("Api-Key:");
+    assertThat(redacted)
+        .doesNotContain(
+            "api-secret",
+            "auth-secret",
+            "csrf-secret",
+            "xsrf-secret",
+            "alternate-api-secret",
+            "proxy-secret");
   }
 
   @Test
@@ -72,7 +92,7 @@ class HttpRequestRedactorTest {
         String.join(
             "\n",
             "GET /token HTTP/1.1",
-            "Authorization: Bearer secret",
+            "X-Api-Key: api-secret",
             "  continued",
             "X-Test: ok",
             "",
@@ -80,7 +100,8 @@ class HttpRequestRedactorTest {
 
     String redacted = HttpRequestRedactor.redact(request);
 
-    assertThat(redacted).doesNotContain("Authorization:");
+    assertThat(redacted).doesNotContain("X-Api-Key:");
+    assertThat(redacted).doesNotContain("api-secret");
     assertThat(redacted).doesNotContain("continued");
     assertThat(redacted).contains("X-Test: ok");
     assertThat(redacted).contains("body");

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesToolTest.java
@@ -56,7 +56,7 @@ class ListVulnerabilityTypesToolTest {
     when(rules.getRules()).thenReturn(List.of(rule1, rule2, rule3));
     when(contrastApiClient.getRules()).thenReturn(rules);
 
-    var result = tool.listVulnerabilityTypes(null);
+    var result = tool.listVulnerabilityTypes();
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.found()).isTrue();

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolTest.java
@@ -180,7 +180,9 @@ class SearchVulnerabilitiesToolTest {
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors())
-        .containsExactly("Access denied. User lacks permission for this resource.");
+        .containsExactly(
+            "Access denied or resource not found. Verify credentials and that the resource ID is"
+                + " correct.");
     assertThat(result.toString()).doesNotContain(SECRET_BODY, "/ng/orgtraces/filter");
   }
 }

--- a/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/client/SdkApiClient.java
+++ b/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/client/SdkApiClient.java
@@ -31,6 +31,8 @@ import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.Applicati
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.routecoverage.RouteCoverageResponse;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.sca.LibraryObservation;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.sessionmetadata.SessionMetadataResponse;
+import com.contrastsecurity.exceptions.HttpResponseException;
+import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.TraceFilterForm.TraceExpandValue;
 import com.contrastsecurity.models.EventSummaryResponse;
 import com.contrastsecurity.models.HttpRequestResponse;
@@ -98,9 +100,13 @@ public class SdkApiClient implements ContrastApiClient {
       int offset,
       EnumSet<TraceExpandValue> expand)
       throws Exception {
-    return sdkExtensionFactory
-        .getSDKExtension()
-        .getTraces(localOrganization(), appId, filters, limit, offset, expand);
+    try {
+      return sdkExtensionFactory
+          .getSDKExtension()
+          .getTraces(localOrganization(), appId, filters, limit, offset, expand);
+    } catch (UnauthorizedException e) {
+      throw normalizeForbidden(e);
+    }
   }
 
   @Override
@@ -185,5 +191,18 @@ public class SdkApiClient implements ContrastApiClient {
 
   private String localOrganization() {
     return contrastSDKFactory.getOrgId();
+  }
+
+  private static HttpResponseException normalizeForbidden(UnauthorizedException e) {
+    if (e.getCode() != 403) {
+      return e;
+    }
+    return new HttpResponseException(
+        "Downstream request failed",
+        "POST",
+        "[redacted]",
+        e.getCode(),
+        e.getStatus(),
+        "[redacted]");
   }
 }

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataLocalParityTest.java
@@ -21,7 +21,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.contrast.labs.ai.mcp.contrast.client.SdkApiClient;
@@ -32,7 +31,7 @@ import com.contrastsecurity.sdk.ContrastSDK;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class GetSessionMetadataToolTest {
+class GetSessionMetadataLocalParityTest {
 
   private GetSessionMetadataTool tool;
   private ContrastSDKFactory sdkFactory;
@@ -49,24 +48,6 @@ class GetSessionMetadataToolTest {
     when(sdkFactory.getOrgId()).thenReturn("test-org-id");
 
     tool = new GetSessionMetadataTool(new SdkApiClient(sdkFactory, sdkExtensionFactory));
-  }
-
-  @Test
-  void getSessionMetadata_should_return_validation_error_for_missing_app_id() {
-    var result = tool.getSessionMetadata(null);
-
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("appId") && e.contains("required"));
-    verifyNoInteractions(sdk);
-  }
-
-  @Test
-  void getSessionMetadata_should_return_validation_error_for_empty_app_id() {
-    var result = tool.getSessionMetadata("");
-
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("appId") && e.contains("required"));
-    verifyNoInteractions(sdk);
   }
 
   @Test

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataToolIT.java
@@ -58,13 +58,16 @@ public class GetSessionMetadataToolIT
   // SingleTool's 5xx mapping — validation errors must never look like this.
   private static final String CONTRAST_API_ERROR = "Contrast API error";
 
-  // SingleTool's 401/403 mapping — see BaseTool#mapHttpErrorCode and
+  // SingleTool's 401 and 403 mappings — see BaseTool#mapHttpErrorCode and
   // SingleTool#executePipeline (UnauthorizedException branch). Surfaces for both invalid
   // credentials and unknown application IDs (TeamServer returns 403 rather than 404 for an
   // appId the caller cannot see).
   private static final String AUTH_OR_NOT_FOUND_ERROR =
       "Authentication failed or resource not found. Verify credentials and that the resource ID"
           + " is correct.";
+  private static final String ACCESS_OR_NOT_FOUND_ERROR =
+      "Access denied or resource not found. Verify credentials and that the resource ID is"
+          + " correct.";
 
   // Tool warning emitted when the SDK returns null (no recorded sessions).
   private static final String NO_METADATA_WARNING_FRAGMENT = "No session metadata found";
@@ -286,8 +289,9 @@ public class GetSessionMetadataToolIT
     assertThat(result.found()).as("unknown appId must not report found").isFalse();
     assertThat(result.data()).as("error response must not carry data").isNull();
     assertThat(result.errors())
-        .as("unknown appId must produce the documented auth-or-not-found error")
-        .containsExactly(AUTH_OR_NOT_FOUND_ERROR);
+        .as("unknown appId must produce a documented auth/access-or-not-found error")
+        .singleElement()
+        .isIn(AUTH_OR_NOT_FOUND_ERROR, ACCESS_OR_NOT_FOUND_ERROR);
     assertThat(result.errors())
         .as("unknown appId must not be surfaced as a generic 5xx Contrast API error")
         .noneMatch(e -> e.contains(CONTRAST_API_ERROR));

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsLocalParityTest.java
@@ -19,12 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.contrast.labs.ai.mcp.contrast.client.SdkApiClient;
@@ -41,12 +39,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
-class SearchApplicationsToolTest {
+class SearchApplicationsLocalParityTest {
 
   private SearchApplicationsTool tool;
 
@@ -65,31 +60,13 @@ class SearchApplicationsToolTest {
   }
 
   @Test
-  void searchApplications_should_return_validation_error_for_invalid_json_metadata() {
-    var result = tool.searchApplications(1, 10, null, null, "{invalid json}");
-
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("Invalid JSON"));
-    verifyNoInteractions(sdkExtension);
-  }
-
-  @Test
-  void searchApplications_should_return_validation_error_for_empty_metadata_value() {
-    var result = tool.searchApplications(1, 10, null, null, "{\"freeform\":\"\"}");
-
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("freeform") && e.contains("empty"));
-    verifyNoInteractions(sdkExtension);
-  }
-
-  @Test
   void searchApplications_should_return_all_applications_when_no_filters() throws Exception {
     var app1 = createApp("App1", "Active");
     var app2 = createApp("App2", "Inactive");
     var response = createResponse(List.of(app1, app2), 2);
 
     when(sdkExtension.getApplicationsFiltered(
-            anyString(), isNull(), isNull(), isNull(), anyInt(), anyInt()))
+            eq(TEST_ORG_ID), isNull(), isNull(), isNull(), anyInt(), anyInt()))
         .thenReturn(response);
 
     var result = tool.searchApplications(1, 10, null, null, null);
@@ -105,7 +82,7 @@ class SearchApplicationsToolTest {
     var response = createResponse(List.of(app1), 1);
 
     when(sdkExtension.getApplicationsFiltered(
-            anyString(), eq("prod"), isNull(), isNull(), anyInt(), anyInt()))
+            eq(TEST_ORG_ID), eq("prod"), isNull(), isNull(), anyInt(), anyInt()))
         .thenReturn(response);
 
     var result = tool.searchApplications(1, 10, "prod", null, null);
@@ -114,7 +91,8 @@ class SearchApplicationsToolTest {
     assertThat(result.items()).hasSize(1);
 
     verify(sdkExtension)
-        .getApplicationsFiltered(anyString(), eq("prod"), isNull(), isNull(), anyInt(), anyInt());
+        .getApplicationsFiltered(
+            eq(TEST_ORG_ID), eq("prod"), isNull(), isNull(), anyInt(), anyInt());
   }
 
   @Test
@@ -123,7 +101,7 @@ class SearchApplicationsToolTest {
     var response = createResponse(List.of(app1), 1);
 
     when(sdkExtension.getApplicationsFiltered(
-            anyString(), isNull(), any(String[].class), isNull(), anyInt(), anyInt()))
+            eq(TEST_ORG_ID), isNull(), any(String[].class), isNull(), anyInt(), anyInt()))
         .thenReturn(response);
 
     var result = tool.searchApplications(1, 10, null, "Production", null);
@@ -141,9 +119,10 @@ class SearchApplicationsToolTest {
     metadataField.setFieldId(123L);
     metadataField.setDisplayLabel("environment");
 
-    when(sdkExtension.getApplicationMetadataFields(anyString())).thenReturn(List.of(metadataField));
+    when(sdkExtension.getApplicationMetadataFields(eq(TEST_ORG_ID)))
+        .thenReturn(List.of(metadataField));
     when(sdkExtension.getApplicationsFiltered(
-            anyString(), isNull(), isNull(), anyList(), anyInt(), anyInt()))
+            eq(TEST_ORG_ID), isNull(), isNull(), anyList(), anyInt(), anyInt()))
         .thenReturn(response);
 
     var result = tool.searchApplications(1, 10, null, null, "{\"environment\":\"production\"}");
@@ -152,9 +131,10 @@ class SearchApplicationsToolTest {
     assertThat(result.items()).hasSize(1);
     assertThat(result.items().get(0).name()).isEqualTo("App1");
 
-    verify(sdkExtension).getApplicationMetadataFields(anyString());
+    verify(sdkExtension).getApplicationMetadataFields(eq(TEST_ORG_ID));
     verify(sdkExtension)
-        .getApplicationsFiltered(anyString(), isNull(), isNull(), anyList(), anyInt(), anyInt());
+        .getApplicationsFiltered(
+            eq(TEST_ORG_ID), isNull(), isNull(), anyList(), anyInt(), anyInt());
   }
 
   @Test
@@ -163,7 +143,8 @@ class SearchApplicationsToolTest {
     metadataField.setFieldId(123L);
     metadataField.setDisplayLabel("environment");
 
-    when(sdkExtension.getApplicationMetadataFields(anyString())).thenReturn(List.of(metadataField));
+    when(sdkExtension.getApplicationMetadataFields(eq(TEST_ORG_ID)))
+        .thenReturn(List.of(metadataField));
 
     var result = tool.searchApplications(1, 10, null, null, "{\"unknownField\":\"value\"}");
 
@@ -178,9 +159,9 @@ class SearchApplicationsToolTest {
               assertThat(error).doesNotContain("An internal error occurred");
             });
 
-    verify(sdkExtension).getApplicationMetadataFields(anyString());
+    verify(sdkExtension).getApplicationMetadataFields(eq(TEST_ORG_ID));
     verify(sdkExtension, never())
-        .getApplicationsFiltered(anyString(), any(), any(), anyList(), anyInt(), anyInt());
+        .getApplicationsFiltered(eq(TEST_ORG_ID), any(), any(), anyList(), anyInt(), anyInt());
   }
 
   @Test
@@ -188,7 +169,7 @@ class SearchApplicationsToolTest {
     var response = createResponse(List.of(), 0);
 
     when(sdkExtension.getApplicationsFiltered(
-            anyString(), eq("nonexistent"), isNull(), isNull(), anyInt(), anyInt()))
+            eq(TEST_ORG_ID), eq("nonexistent"), isNull(), isNull(), anyInt(), anyInt()))
         .thenReturn(response);
 
     var result = tool.searchApplications(1, 10, "nonexistent", null, null);
@@ -206,7 +187,7 @@ class SearchApplicationsToolTest {
     var response = createResponse(List.of(app1, app2), 5);
 
     when(sdkExtension.getApplicationsFiltered(
-            anyString(), isNull(), isNull(), isNull(), eq(2), eq(2)))
+            eq(TEST_ORG_ID), isNull(), isNull(), isNull(), eq(2), eq(2)))
         .thenReturn(response);
 
     // Request page 2 with page size 2 (offset should be 2)
@@ -218,7 +199,7 @@ class SearchApplicationsToolTest {
     assertThat(result.hasMorePages()).isTrue();
 
     verify(sdkExtension)
-        .getApplicationsFiltered(anyString(), isNull(), isNull(), isNull(), eq(2), eq(2));
+        .getApplicationsFiltered(eq(TEST_ORG_ID), isNull(), isNull(), isNull(), eq(2), eq(2));
   }
 
   @Test
@@ -227,7 +208,7 @@ class SearchApplicationsToolTest {
     var response = createResponse(List.of(app), 1);
 
     when(sdkExtension.getApplicationsFiltered(
-            anyString(), isNull(), isNull(), isNull(), anyInt(), anyInt()))
+            eq(TEST_ORG_ID), isNull(), isNull(), isNull(), anyInt(), anyInt()))
         .thenReturn(response);
 
     var result = tool.searchApplications(1, 10, null, null, null);
@@ -242,7 +223,7 @@ class SearchApplicationsToolTest {
   @Test
   void searchApplications_should_handle_null_response() throws Exception {
     when(sdkExtension.getApplicationsFiltered(
-            anyString(), isNull(), isNull(), isNull(), anyInt(), anyInt()))
+            eq(TEST_ORG_ID), isNull(), isNull(), isNull(), anyInt(), anyInt()))
         .thenReturn(null);
 
     var result = tool.searchApplications(1, 10, null, null, null);

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesLocalParityTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.contrast.labs.ai.mcp.contrast.AnonymousLibraryExtendedBuilder;
@@ -40,12 +39,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
-class ListApplicationLibrariesToolTest {
+class ListApplicationLibrariesLocalParityTest {
 
   private static final String TEST_ORG_ID = "test-org-123";
   private static final String TEST_APP_ID = "test-app-456";
@@ -74,24 +70,6 @@ class ListApplicationLibrariesToolTest {
     if (mockedSDKHelper != null) {
       mockedSDKHelper.close();
     }
-  }
-
-  @Test
-  void listApplicationLibraries_should_return_validation_error_for_missing_app_id() {
-    var result = tool.listApplicationLibraries(null, null, null);
-
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("appId") && e.contains("required"));
-    verifyNoInteractions(sdkExtension);
-  }
-
-  @Test
-  void listApplicationLibraries_should_return_validation_error_for_empty_app_id() {
-    var result = tool.listApplicationLibraries(null, null, "");
-
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("appId") && e.contains("required"));
-    verifyNoInteractions(sdkExtension);
   }
 
   @Test

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveLocalParityTest.java
@@ -18,7 +18,7 @@ package com.contrast.labs.ai.mcp.contrast.tool.library;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.contrast.labs.ai.mcp.contrast.AnonymousLibraryExtendedBuilder;
@@ -42,12 +42,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
-class ListApplicationsByCveToolTest {
+class ListApplicationsByCveLocalParityTest {
 
   private static final String TEST_ORG_ID = "test-org-123";
   private static final String TEST_CVE_ID = "CVE-2021-44228";
@@ -80,24 +77,6 @@ class ListApplicationsByCveToolTest {
   }
 
   @Test
-  void listApplicationsByCve_should_return_validation_error_for_missing_cve_id() {
-    var result = tool.listApplicationsByCve(null);
-
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("cveId") && e.contains("required"));
-    verifyNoInteractions(sdkExtension);
-  }
-
-  @Test
-  void listApplicationsByCve_should_return_validation_error_for_invalid_cve_format() {
-    var result = tool.listApplicationsByCve("not-a-cve");
-
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("cveId") && e.contains("CVE format"));
-    verifyNoInteractions(sdkExtension);
-  }
-
-  @Test
   void listApplicationsByCve_should_return_cve_data_on_success() throws IOException {
     var mockCveData = createMockCveDataWithApps();
     var mockLibraries = createMockLibrariesWithMatchingHash();
@@ -115,6 +94,9 @@ class ListApplicationsByCveToolTest {
     assertThat(result.data()).isNotNull();
     assertThat(result.data().getApps()).isNotEmpty();
     assertThat(result.errors()).isEmpty();
+    verify(sdkExtension).getAppsForCVE(eq(TEST_ORG_ID), eq(TEST_CVE_ID));
+    mockedSDKHelper.verify(
+        () -> SDKHelper.getLibsForID(eq(TEST_APP_ID), eq(TEST_ORG_ID), eq(sdkExtension)));
   }
 
   @Test

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityLocalParityTest.java
@@ -20,7 +20,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.contrast.labs.ai.mcp.contrast.client.SdkApiClient;
@@ -33,7 +32,7 @@ import java.util.EnumSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class GetVulnerabilityToolTest {
+class GetVulnerabilityLocalParityTest {
 
   private static final String VALID_VULN_ID = "vuln-123";
   private static final String VALID_APP_ID = "app-123";
@@ -56,28 +55,6 @@ class GetVulnerabilityToolTest {
     when(sdkFactory.getOrgId()).thenReturn(ORG_ID);
 
     tool = new GetVulnerabilityTool(new SdkApiClient(sdkFactory, sdkExtensionFactory), mapper);
-  }
-
-  @Test
-  void getVulnerability_should_return_validation_error_when_vulnId_missing() {
-    var result = tool.getVulnerability(null, VALID_APP_ID);
-
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("vulnId is required"));
-
-    verifyNoInteractions(sdk);
-    verifyNoInteractions(mapper);
-  }
-
-  @Test
-  void getVulnerability_should_return_validation_error_when_appId_missing() {
-    var result = tool.getVulnerability(VALID_VULN_ID, null);
-
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("appId is required"));
-
-    verifyNoInteractions(sdk);
-    verifyNoInteractions(mapper);
   }
 
   @Test

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java
@@ -60,12 +60,14 @@ public class GetVulnerabilityToolIT
   // UUID-formatted ID that will not match any real resource. The Contrast API treats lookups for
   // nonexistent vuln/app IDs as 401/403 rather than 404 (a deliberate security choice — the API
   // does not differentiate "no permission" from "doesn't exist", to avoid leaking resource
-  // existence). SingleTool maps that to its UnauthorizedException handler with this exact
-  // user-facing message.
+  // existence).
   private static final String NONEXISTENT_UUID = "00000000-0000-0000-0000-000000000000";
-  private static final String UNKNOWN_RESOURCE_ERROR =
+  private static final String AUTH_OR_NOT_FOUND_ERROR =
       "Authentication failed or resource not found."
           + " Verify credentials and that the resource ID is correct.";
+  private static final String ACCESS_OR_NOT_FOUND_ERROR =
+      "Access denied or resource not found. Verify credentials and that the resource ID is"
+          + " correct.";
 
   /**
    * Container for discovered test data. Populated once per class by {@link #performDiscovery()}.
@@ -437,8 +439,9 @@ public class GetVulnerabilityToolIT
         .isFalse();
     assertThat(response.data()).as("error response must not carry vulnerability data").isNull();
     assertThat(response.errors())
-        .as("errors must contain exactly the documented unknown-resource message")
-        .containsExactly(UNKNOWN_RESOURCE_ERROR);
+        .as("errors must contain exactly one documented unknown-resource message")
+        .singleElement()
+        .isIn(AUTH_OR_NOT_FOUND_ERROR, ACCESS_OR_NOT_FOUND_ERROR);
     assertThat(response.errors())
         .as("error must not surface as a Contrast API (5xx) error")
         .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
@@ -468,8 +471,9 @@ public class GetVulnerabilityToolIT
         .as("error response must not carry data even when vulnId is real")
         .isNull();
     assertThat(response.errors())
-        .as("errors must contain exactly the documented unknown-resource message")
-        .containsExactly(UNKNOWN_RESOURCE_ERROR);
+        .as("errors must contain exactly one documented unknown-resource message")
+        .singleElement()
+        .isIn(AUTH_OR_NOT_FOUND_ERROR, ACCESS_OR_NOT_FOUND_ERROR);
   }
 
   // ---------- Warnings (graceful degradation) ----------

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesLocalParityTest.java
@@ -28,6 +28,7 @@ import com.contrast.labs.ai.mcp.contrast.config.ContrastSDKFactory;
 import com.contrast.labs.ai.mcp.contrast.config.SDKExtensionFactory;
 import com.contrast.labs.ai.mcp.contrast.result.VulnLight;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.SDKExtension;
+import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.http.HttpMethod;
 import com.contrastsecurity.http.MediaType;
 import com.contrastsecurity.models.Trace;
@@ -154,6 +155,29 @@ class SearchAppVulnerabilitiesLocalParityTest {
             APP_ID, 1, 10, null, null, null, null, null, null, null, null, null);
 
     assertThat(result.isSuccess()).isTrue();
+    assertThat(result.warnings()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+  }
+
+  @Test
+  void searchAppVulnerabilities_should_normalize_sdk_forbidden_to_downstream_error()
+      throws Exception {
+    var realSdkExtension = new SDKExtension(sdk);
+    when(sdkExtensionFactory.getSDKExtension()).thenReturn(realSdkExtension);
+    when(sdk.makeRequestWithBody(
+            eq(HttpMethod.POST), contains("/traces/"), anyString(), eq(MediaType.JSON)))
+        .thenThrow(
+            new UnauthorizedException(
+                "Forbidden", "POST", "/Contrast/api/ng/org/traces/app/filter", 403, "Forbidden"));
+
+    var result =
+        tool.searchAppVulnerabilities(
+            APP_ID, 1, 10, null, null, null, null, null, null, null, null, null);
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors())
+        .containsExactly(
+            "Access denied or resource not found. Verify credentials and that the resource ID is"
+                + " correct.");
     assertThat(result.warnings()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
   }
 

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesLocalParityTest.java
@@ -21,7 +21,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.contrast.labs.ai.mcp.contrast.client.SdkApiClient;
@@ -41,12 +40,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
-class SearchAppVulnerabilitiesToolTest {
+class SearchAppVulnerabilitiesLocalParityTest {
 
   private static final String ORG_ID = "test-org-id";
   private static final String APP_ID = "app-123";
@@ -58,16 +54,9 @@ class SearchAppVulnerabilitiesToolTest {
   @Mock private SDKExtensionFactory sdkExtensionFactory;
   @Mock private ContrastSDK sdk;
 
-  private SDKExtension realSdkExtension;
-
   @BeforeEach
   void setUp() {
-    when(sdkFactory.getSDK()).thenReturn(sdk);
     when(sdkFactory.getOrgId()).thenReturn(ORG_ID);
-    // Create a real SDKExtension wrapping the mock SDK to preserve HTTP-level mocking
-    realSdkExtension = new SDKExtension(sdk);
-    when(sdkExtensionFactory.getSDKExtension()).thenReturn(realSdkExtension);
-
     tool =
         new SearchAppVulnerabilitiesTool(new SdkApiClient(sdkFactory, sdkExtensionFactory), mapper);
   }
@@ -77,6 +66,8 @@ class SearchAppVulnerabilitiesToolTest {
    * the traces endpoint.
    */
   private void mockSdkWithTracesResponse(String jsonResponse) throws Exception {
+    var realSdkExtension = new SDKExtension(sdk);
+    when(sdkExtensionFactory.getSDKExtension()).thenReturn(realSdkExtension);
     when(sdk.makeRequestWithBody(
             eq(HttpMethod.POST), contains("/traces/"), anyString(), eq(MediaType.JSON)))
         .thenReturn(new ByteArrayInputStream(jsonResponse.getBytes(StandardCharsets.UTF_8)));
@@ -88,6 +79,7 @@ class SearchAppVulnerabilitiesToolTest {
    * @param fields Array of field definitions as [label, id] pairs
    */
   private void mockSessionMetadataWithFields(String[]... fields) throws Exception {
+    when(sdkFactory.getSDK()).thenReturn(sdk);
     var filterJson = new StringBuilder();
     filterJson.append("{\"filters\": [");
     for (int i = 0; i < fields.length; i++) {
@@ -104,69 +96,6 @@ class SearchAppVulnerabilitiesToolTest {
                 .fromJson(
                     filterJson.toString(),
                     com.contrastsecurity.models.MetadataFilterResponse.class));
-  }
-
-  // -- Validation tests --
-
-  @Test
-  void searchAppVulnerabilities_should_return_error_when_appId_missing() {
-    var result =
-        tool.searchAppVulnerabilities(
-            null, 1, 10, null, null, null, null, null, null, null, null, null);
-
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("appId is required"));
-
-    verifyNoInteractions(sdk);
-  }
-
-  @Test
-  void searchAppVulnerabilities_should_return_error_for_invalid_severity() {
-    var result =
-        tool.searchAppVulnerabilities(
-            APP_ID, 1, 10, "INVALID", null, null, null, null, null, null, null, null);
-
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("Invalid severities"));
-
-    verifyNoInteractions(sdk);
-  }
-
-  @Test
-  void searchAppVulnerabilities_should_return_error_for_invalid_json_in_sessionMetadataFilters() {
-    var result =
-        tool.searchAppVulnerabilities(
-            APP_ID, 1, 10, null, null, null, null, null, null, null, "not valid json", null);
-
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("Invalid JSON"));
-
-    verifyNoInteractions(sdk);
-  }
-
-  @Test
-  void searchAppVulnerabilities_should_return_validation_error_for_empty_session_metadata_value() {
-    var result =
-        tool.searchAppVulnerabilities(
-            APP_ID, 1, 10, null, null, null, null, null, null, null, "{\"branch\":\"\"}", null);
-
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("branch") && e.contains("empty"));
-
-    verifyNoInteractions(sdk);
-  }
-
-  @Test
-  void
-      searchAppVulnerabilities_should_return_error_when_useLatestSession_with_sessionMetadataFilters() {
-    var result =
-        tool.searchAppVulnerabilities(
-            APP_ID, 1, 10, null, null, null, null, null, null, null, "{\"branch\":\"main\"}", true);
-
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("mutually exclusive"));
-
-    verifyNoInteractions(sdk);
   }
 
   // -- Success tests (refactored to mock at SDK boundary) --
@@ -367,7 +296,7 @@ class SearchAppVulnerabilitiesToolTest {
 
     var urlCaptor = ArgumentCaptor.forClass(String.class);
     verify(sdk).makeRequestWithBody(any(), urlCaptor.capture(), anyString(), any());
-    assertThat(urlCaptor.getValue()).contains("/traces/app-xyz-123/filter");
+    assertThat(urlCaptor.getValue()).contains(ORG_ID).contains("/traces/app-xyz-123/filter");
   }
 
   @Test

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesLocalParityTest.java
@@ -21,7 +21,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.contrast.labs.ai.mcp.contrast.client.SdkApiClient;
@@ -41,12 +40,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
-class SearchVulnerabilitiesToolTest {
+class SearchVulnerabilitiesLocalParityTest {
 
   private SearchVulnerabilitiesTool tool;
 
@@ -59,12 +55,7 @@ class SearchVulnerabilitiesToolTest {
 
   @BeforeEach
   void setUp() {
-    when(sdkFactory.getSDK()).thenReturn(sdk);
     when(sdkFactory.getOrgId()).thenReturn(TEST_ORG_ID);
-    // Create a real SDKExtension wrapping the mock SDK to preserve HTTP-level mocking
-    var realSdkExtension = new SDKExtension(sdk);
-    when(sdkExtensionFactory.getSDKExtension()).thenReturn(realSdkExtension);
-
     tool = new SearchVulnerabilitiesTool(new SdkApiClient(sdkFactory, sdkExtensionFactory), mapper);
   }
 
@@ -73,34 +64,11 @@ class SearchVulnerabilitiesToolTest {
    * the orgtraces endpoint.
    */
   private void mockSdkWithTracesResponse(String jsonResponse) throws Exception {
+    var realSdkExtension = new SDKExtension(sdk);
+    when(sdkExtensionFactory.getSDKExtension()).thenReturn(realSdkExtension);
     when(sdk.makeRequestWithBody(
             eq(HttpMethod.POST), contains("/orgtraces/filter"), anyString(), eq(MediaType.JSON)))
         .thenReturn(new ByteArrayInputStream(jsonResponse.getBytes(StandardCharsets.UTF_8)));
-  }
-
-  // -- Validation tests --
-
-  @Test
-  void searchVulnerabilities_should_return_validation_error_without_sdk_call() {
-    var result =
-        tool.searchVulnerabilities(1, 10, "INVALID_SEVERITY", null, null, null, null, null, null);
-
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).anyMatch(e -> e.contains("Invalid severities"));
-
-    // SDK should NOT be called when validation fails
-    verifyNoInteractions(sdk);
-  }
-
-  @Test
-  void searchVulnerabilities_should_collect_multiple_validation_errors() {
-    var result =
-        tool.searchVulnerabilities(
-            1, 10, "INVALID", "BadStatus", null, "FAKE_ENV", null, null, null);
-
-    assertThat(result.isSuccess()).isFalse();
-    assertThat(result.errors()).hasSizeGreaterThan(1);
-    verifyNoInteractions(sdk);
   }
 
   // -- Success tests (refactored to mock at SDK boundary) --
@@ -244,6 +212,9 @@ class SearchVulnerabilitiesToolTest {
 
     var urlCaptor = ArgumentCaptor.forClass(String.class);
     verify(sdk).makeRequestWithBody(any(), urlCaptor.capture(), anyString(), any());
-    assertThat(urlCaptor.getValue()).contains("limit=25").contains("offset=50");
+    assertThat(urlCaptor.getValue())
+        .contains(TEST_ORG_ID)
+        .contains("limit=25")
+        .contains("offset=50");
   }
 }

--- a/docs/pr-walkthrough/pr-135-support-p3-repos-in-ralph.html
+++ b/docs/pr-walkthrough/pr-135-support-p3-repos-in-ralph.html
@@ -1,0 +1,1126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PR #135 Walkthrough: Support Phase 3 repos in Ralph automation</title>
+<style>
+  :root {
+    --bg: #0d1117;
+    --surface: #161b22;
+    --surface-raised: #1c2128;
+    --border: #30363d;
+    --text: #e6edf3;
+    --text-muted: #8b949e;
+    --text-subtle: #6e7681;
+    --accent: #58a6ff;
+    --accent-soft: rgba(88,166,255,0.15);
+    --green: #3fb950;
+    --green-bg: rgba(63,185,80,0.15);
+    --green-border: rgba(63,185,80,0.4);
+    --red: #f85149;
+    --red-bg: rgba(248,81,73,0.10);
+    --yellow: #d29922;
+    --yellow-bg: rgba(210,153,34,0.15);
+    --purple: #bc8cff;
+    --purple-bg: rgba(188,140,255,0.12);
+    --orange: #f0883e;
+    --line-num: #484f58;
+    --diff-add-bg: rgba(63,185,80,0.10);
+    --diff-add-text: #aff5b4;
+    --diff-add-marker: #3fb950;
+    --diff-del-bg: rgba(248,81,73,0.10);
+    --diff-del-text: #ffa198;
+    --diff-del-marker: #f85149;
+    --diff-context-bg: transparent;
+    --code-bg: #0d1117;
+    --nav-bg: rgba(13,17,23,0.95);
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    overflow-x: hidden;
+  }
+
+  /* --- Hero --- */
+  .hero {
+    background: linear-gradient(135deg, #0d1117 0%, #161b22 40%, #1a1e2e 70%, #161b22 100%);
+    border-bottom: 1px solid var(--border);
+    padding: 3rem 2rem 2.5rem;
+    text-align: center;
+  }
+  .hero-badge {
+    display: inline-block;
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-size: 0.8rem;
+    font-weight: 600;
+    padding: 0.3rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid rgba(88,166,255,0.3);
+    margin-bottom: 1rem;
+    letter-spacing: 0.03em;
+  }
+  .hero h1 {
+    font-size: 2.2rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin-bottom: 0.6rem;
+    background: linear-gradient(135deg, var(--text) 0%, var(--accent) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+  .hero .subtitle {
+    color: var(--text-muted);
+    font-size: 1.1rem;
+    max-width: 600px;
+    margin: 0 auto;
+  }
+  .hero-meta {
+    display: flex;
+    justify-content: center;
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+    flex-wrap: wrap;
+  }
+  .hero-meta-item {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+  }
+  .hero-meta-item strong { color: var(--text); }
+
+  /* --- Navigation --- */
+  nav {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: var(--nav-bg);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border);
+    padding: 0.6rem 2rem;
+    overflow-x: auto;
+  }
+  nav ol {
+    display: flex;
+    gap: 0.3rem;
+    list-style: none;
+    max-width: 1100px;
+    margin: 0 auto;
+    font-size: 0.82rem;
+    align-items: center;
+  }
+  nav li a {
+    color: var(--text-muted);
+    text-decoration: none;
+    padding: 0.35rem 0.7rem;
+    border-radius: 6px;
+    transition: all 0.15s;
+    white-space: nowrap;
+  }
+  nav li a:hover { color: var(--accent); background: var(--accent-soft); }
+  nav .nav-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.4em;
+    height: 1.4em;
+    border-radius: 50%;
+    background: var(--surface-raised);
+    border: 1px solid var(--border);
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    margin-right: 0.4em;
+  }
+  nav .nav-sep { color: var(--text-subtle); font-size: 0.75rem; }
+
+  /* --- Main --- */
+  main {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 2rem 2rem 6rem;
+  }
+
+  /* --- Sections --- */
+  .chapter {
+    margin-bottom: 3.5rem;
+    scroll-margin-top: 4rem;
+  }
+  .chapter-header {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.8rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .chapter-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.2rem;
+    height: 2.2rem;
+    border-radius: 50%;
+    font-size: 1rem;
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+  .chapter-number.blue { background: var(--accent-soft); color: var(--accent); border: 1px solid rgba(88,166,255,0.3); }
+  .chapter-number.green { background: var(--green-bg); color: var(--green); border: 1px solid var(--green-border); }
+  .chapter-number.purple { background: var(--purple-bg); color: var(--purple); border: 1px solid rgba(188,140,255,0.3); }
+  .chapter-number.yellow { background: var(--yellow-bg); color: var(--yellow); border: 1px solid rgba(210,153,34,0.3); }
+  .chapter-number.orange { background: rgba(240,136,62,0.12); color: var(--orange); border: 1px solid rgba(240,136,62,0.3); }
+
+  .chapter h2 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+
+  /* --- Prose --- */
+  .narrative {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    line-height: 1.75;
+    margin-bottom: 1.5rem;
+  }
+  .narrative strong { color: var(--text); font-weight: 600; }
+  .narrative code {
+    background: var(--surface-raised);
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+    font-size: 0.88em;
+    color: var(--accent);
+    border: 1px solid var(--border);
+  }
+
+  /* --- Callout boxes --- */
+  .callout {
+    border-radius: 8px;
+    padding: 1rem 1.2rem;
+    margin-bottom: 1.5rem;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    border: 1px solid;
+  }
+  .callout.why {
+    background: var(--accent-soft);
+    border-color: rgba(88,166,255,0.25);
+    color: var(--text);
+  }
+  .callout.why .callout-label { color: var(--accent); }
+  .callout.security {
+    background: var(--red-bg);
+    border-color: rgba(248,81,73,0.25);
+  }
+  .callout.security .callout-label { color: var(--red); }
+  .callout.note {
+    background: var(--yellow-bg);
+    border-color: rgba(210,153,34,0.25);
+  }
+  .callout.note .callout-label { color: var(--yellow); }
+  .callout.future {
+    background: var(--purple-bg);
+    border-color: rgba(188,140,255,0.25);
+  }
+  .callout.future .callout-label { color: var(--purple); }
+  .callout-label {
+    font-weight: 700;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 0.3rem;
+    display: block;
+  }
+
+  /* --- Code / Diff blocks --- */
+  .diff-block {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+    margin-bottom: 1.5rem;
+  }
+  .diff-header {
+    display: flex;
+    align-items: center;
+    padding: 0.6rem 1rem;
+    background: var(--surface-raised);
+    border-bottom: 1px solid var(--border);
+    font-size: 0.82rem;
+    color: var(--text-muted);
+    gap: 0.5rem;
+  }
+  .diff-header .file-icon {
+    width: 16px; height: 16px;
+    fill: var(--text-subtle);
+    flex-shrink: 0;
+  }
+  .diff-header .filename {
+    color: var(--text);
+    font-weight: 600;
+    font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', monospace;
+    font-size: 0.82rem;
+  }
+  .diff-header .badge {
+    margin-left: auto;
+    font-size: 0.72rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    font-weight: 600;
+  }
+  .badge-new { background: var(--green-bg); color: var(--green); border: 1px solid var(--green-border); }
+  .badge-modified { background: var(--yellow-bg); color: var(--yellow); border: 1px solid rgba(210,153,34,0.3); }
+  .badge-deleted { background: var(--red-bg); color: var(--red); border: 1px solid rgba(248,81,73,0.3); }
+
+  .diff-body {
+    overflow-x: auto;
+  }
+  .diff-body pre {
+    margin: 0;
+    padding: 0.4rem 0;
+    font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', monospace;
+    font-size: 0.82rem;
+    line-height: 1.3;
+    display: flex;
+    flex-direction: column;
+  }
+  .diff-line {
+    display: flex;
+    padding: 0 1rem;
+    min-height: 1.3em;
+  }
+  .diff-line.add {
+    background: var(--diff-add-bg);
+  }
+  .diff-line.del {
+    background: var(--diff-del-bg);
+  }
+  .diff-line.context {
+    background: var(--diff-context-bg);
+  }
+  .diff-line .marker {
+    width: 1.2em;
+    flex-shrink: 0;
+    color: var(--text-subtle);
+    user-select: none;
+    text-align: center;
+  }
+  .diff-line.add .marker { color: var(--diff-add-marker); }
+  .diff-line.del .marker { color: var(--diff-del-marker); }
+  .diff-line .ln {
+    width: 3.5em;
+    flex-shrink: 0;
+    color: var(--line-num);
+    text-align: right;
+    padding-right: 1em;
+    user-select: none;
+  }
+  .diff-line .code {
+    flex: 1;
+    white-space: pre;
+  }
+  /* Syntax highlighting classes */
+  .diff-line .code .kw { color: #ff7b72; }
+  .diff-line .code .str { color: #a5d6ff; }
+  .diff-line .code .ann { color: #d2a8ff; }
+  .diff-line .code .type { color: #79c0ff; }
+  .diff-line .code .comment { color: var(--text-subtle); font-style: italic; }
+  .diff-line .code .prop { color: #7ee787; }
+  .diff-line .code .val { color: #a5d6ff; }
+  .diff-line .code .num { color: #79c0ff; }
+  .diff-line .code .param { color: #ffa657; }
+
+  /* Annotation inline (between diff lines or after a block) */
+  .annotation {
+    background: var(--surface-raised);
+    border-left: 3px solid var(--accent);
+    padding: 0.7rem 1rem;
+    margin: 0 1rem 0.3rem 1rem;
+    border-radius: 0 6px 6px 0;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    line-height: 1.55;
+  }
+  .annotation strong { color: var(--text); }
+  .annotation code {
+    background: rgba(88,166,255,0.1);
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+    font-size: 0.88em;
+    color: var(--accent);
+  }
+  .annotation.security-note { border-left-color: var(--red); }
+  .annotation.future-note { border-left-color: var(--purple); }
+
+  /* --- Architecture diagrams (inline SVG) --- */
+  .diagram {
+    margin-bottom: 1.5rem;
+  }
+  .diagram svg {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+  .diagram-container {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.5rem;
+    overflow-x: auto;
+  }
+
+  /* --- Slice / scope columns --- */
+  .slice-columns {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.2rem;
+    margin-bottom: 1.5rem;
+  }
+  @media (max-width: 768px) { .slice-columns { grid-template-columns: 1fr; } }
+  .slice-col {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.2rem 1.4rem;
+  }
+  .slice-col.this-pr { border-color: var(--green-border); }
+  .slice-col.future-col { border-color: var(--border); opacity: 0.7; }
+  .slice-col .slice-title {
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 0.8rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .slice-col.this-pr .slice-title { color: var(--green); }
+  .slice-col.future-col .slice-title { color: var(--text-subtle); }
+  .slice-item {
+    position: relative;
+    padding: 0.3rem 0 0.3rem 1rem;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+  }
+  .slice-item .dot {
+    position: absolute;
+    left: 0;
+    top: 0.65rem;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+  }
+  .slice-col.this-pr .dot { background: var(--green); }
+  .slice-col.future-col .dot { background: var(--text-subtle); }
+  .slice-item strong { color: var(--text); font-weight: 500; }
+
+  /* --- Roadmap table --- */
+  .roadmap-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1.5rem;
+    font-size: 0.85rem;
+  }
+  .roadmap-table th {
+    text-align: left;
+    padding: 0.55rem 0.8rem;
+    background: var(--surface-raised);
+    color: var(--text-muted);
+    font-weight: 600;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid var(--border);
+  }
+  .roadmap-table td {
+    padding: 0.45rem 0.8rem;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-muted);
+    vertical-align: top;
+  }
+  .roadmap-table tr:last-child td { border-bottom: none; }
+  .roadmap-table .jira-link {
+    font-family: 'SF Mono', monospace;
+    font-size: 0.8rem;
+    color: var(--accent);
+    text-decoration: none;
+  }
+  .roadmap-table .jira-link:hover { text-decoration: underline; }
+  .roadmap-table .slice-name { color: var(--text); font-weight: 500; }
+  .roadmap-table .current-row td {
+    background: var(--green-bg);
+    border-bottom-color: var(--green-border);
+  }
+  .roadmap-table .current-row .slice-name { color: var(--green); font-weight: 600; }
+  .roadmap-table .current-badge {
+    display: inline-block;
+    font-size: 0.68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    background: var(--green-bg);
+    color: var(--green);
+    border: 1px solid var(--green-border);
+    padding: 0.1rem 0.4rem;
+    border-radius: 999px;
+    margin-left: 0.4rem;
+    vertical-align: middle;
+  }
+
+  /* --- File summary table --- */
+  .file-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1.5rem;
+    font-size: 0.85rem;
+  }
+  .file-table th {
+    text-align: left;
+    padding: 0.6rem 1rem;
+    background: var(--surface-raised);
+    color: var(--text-muted);
+    font-weight: 600;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid var(--border);
+  }
+  .file-table td {
+    padding: 0.55rem 1rem;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-muted);
+  }
+  .file-table td:first-child {
+    font-family: 'SF Mono', monospace;
+    font-size: 0.82rem;
+    color: var(--accent);
+  }
+  .file-table tr:last-child td { border-bottom: none; }
+  .file-table .addition { color: var(--green); }
+  .file-table .deletion { color: var(--red); }
+
+  /* --- Standard Pattern (collapsible boilerplate) --- */
+  .standard-pattern {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    margin-bottom: 1.5rem;
+    overflow: hidden;
+  }
+  .standard-pattern summary {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.7rem 1rem;
+    cursor: pointer;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    background: var(--surface-raised);
+    border-bottom: 1px solid transparent;
+    list-style: none;
+    transition: background 0.15s;
+  }
+  .standard-pattern summary::-webkit-details-marker { display: none; }
+  .standard-pattern summary::before {
+    content: '\25B6';
+    font-size: 0.65rem;
+    color: var(--text-subtle);
+    transition: transform 0.15s;
+    flex-shrink: 0;
+  }
+  .standard-pattern[open] summary::before { transform: rotate(90deg); }
+  .standard-pattern[open] summary { border-bottom-color: var(--border); }
+  .standard-pattern summary:hover { background: rgba(88,166,255,0.06); }
+  .standard-pattern .sp-icon {
+    width: 16px; height: 16px;
+    fill: var(--text-subtle);
+    flex-shrink: 0;
+  }
+  .standard-pattern .sp-title {
+    color: var(--text);
+    font-weight: 600;
+    flex: 1;
+  }
+  .standard-pattern .sp-files {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 0.78rem;
+    color: var(--text-subtle);
+  }
+  .standard-pattern .sp-ref {
+    font-size: 0.78rem;
+    color: var(--text-subtle);
+    margin-left: auto;
+    white-space: nowrap;
+  }
+  .badge-standard {
+    background: rgba(139,148,158,0.15);
+    color: var(--text-muted);
+    border: 1px solid rgba(139,148,158,0.3);
+    font-size: 0.68rem;
+    font-weight: 600;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    letter-spacing: 0.03em;
+    white-space: nowrap;
+  }
+  .standard-pattern .sp-body {
+    padding: 0.8rem 1rem;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    line-height: 1.6;
+  }
+  .standard-pattern .sp-body code {
+    background: var(--surface-raised);
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+    font-size: 0.88em;
+    color: var(--accent);
+    border: 1px solid var(--border);
+  }
+
+  /* --- Novelty badges for file summary table --- */
+  .file-table .novelty { text-align: center; }
+  .novelty-badge {
+    display: inline-block;
+    font-size: 0.68rem;
+    font-weight: 600;
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    letter-spacing: 0.02em;
+  }
+  .novelty-badge.novel { background: var(--accent-soft); color: var(--accent); border: 1px solid rgba(88,166,255,0.3); }
+  .novelty-badge.standard { background: rgba(139,148,158,0.12); color: var(--text-subtle); border: 1px solid rgba(139,148,158,0.25); }
+  .novelty-badge.pattern { background: var(--yellow-bg); color: var(--yellow); border: 1px solid rgba(210,153,34,0.3); }
+
+  /* --- Footer --- */
+  footer {
+    text-align: center;
+    padding: 2rem;
+    color: var(--text-subtle);
+    font-size: 0.8rem;
+    border-top: 1px solid var(--border);
+    margin-top: 3rem;
+  }
+
+  /* --- Responsive --- */
+  @media (max-width: 768px) {
+    .hero { padding: 2rem 1rem; }
+    .hero h1 { font-size: 1.6rem; }
+    main { padding: 1.5rem 1rem 4rem; }
+    nav ol { gap: 0; }
+  }
+</style>
+</head>
+<body>
+
+<!-- ===== HERO ===== -->
+<div class="hero">
+  <span class="hero-badge">PR #135 &middot; AIML-767</span>
+  <h1>Support Phase 3 Repos in Ralph</h1>
+  <p class="subtitle">
+    Extend the Ralph AI agent supervisor to operate across all four repositories needed for Phase 3 cross-repo EKS deployment work.
+  </p>
+  <div class="hero-meta">
+    <span class="hero-meta-item"><strong>Branch:</strong> AIML-767-p3-deploy-eks-dbs-pilot</span>
+    <span class="hero-meta-item"><strong>Base:</strong> AIML-766-s12-full-tool-parity-release-hardening</span>
+    <span class="hero-meta-item"><strong>Files:</strong> 2 changed</span>
+    <span class="hero-meta-item"><strong>Lines:</strong> +48 / -13</span>
+  </div>
+</div>
+
+<!-- ===== NAV ===== -->
+<nav>
+  <ol>
+    <li><a href="#context"><span class="nav-number">1</span>Context</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#approach"><span class="nav-number">2</span>Approach</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#scope"><span class="nav-number">3</span>Scope</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#ralph-script"><span class="nav-number">4</span>Ralph Script</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#ralph-next-bead"><span class="nav-number">5</span>ralph-next-bead</a></li>
+    <li class="nav-sep">&rsaquo;</li>
+    <li><a href="#summary"><span class="nav-number">6</span>Summary</a></li>
+  </ol>
+</nav>
+
+<!-- ===== MAIN ===== -->
+<main>
+
+<!-- ============================================ -->
+<!-- Chapter 1: Context                           -->
+<!-- ============================================ -->
+<section class="chapter" id="context">
+  <div class="chapter-header">
+    <span class="chapter-number blue">1</span>
+    <h2>Why This PR Exists</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>Ralph is the AI agent supervisor that picks up implementation beads and dispatches Codex workers, but it only knew about two repositories.</strong> Phase 3 of the hosted MCP server project (AIML-767) introduces deployment and gateway work that spans <em>four</em> repos: <code>mcp-contrast</code>, <code>aiml-services</code>, <code>aiml-deployment</code>, and <code>contrast-api-gateway</code>. Without this change, Ralph cannot autonomously select or execute beads labeled <code>repo:aiml-deployment</code> or <code>repo:contrast-api-gateway</code>, which means the Phase 3 child beads for Helm deployment, CAG routing, and network policy hardening would all require manual human intervention to start.
+  </p>
+
+  <p class="narrative">
+    <strong>To understand why four repos matter, consider what Phase 3 is building.</strong> The goal is to deploy a production-ready hosted MCP server on AWS EKS behind the Contrast API Gateway (CAG). That involves:
+  </p>
+  <p class="narrative" style="padding-left: 1rem;">
+    &bull; <code>aiml-services</code> builds the container image with Jib (bead <code>mcp-18eh</code>, now closed).<br>
+    &bull; <code>aiml-deployment</code> holds the Helm values, network policies, and HPA config (beads <code>mcp-xn8i.1</code>, <code>mcp-r07w</code>, <code>mcp-y5to.1</code>).<br>
+    &bull; <code>contrast-api-gateway</code> adds the CAG route for <code>POST /mcp</code> (bead <code>mcp-xn8i.2</code>).<br>
+    &bull; <code>mcp-contrast</code> is the control repo where beads live and Ralph runs.
+  </p>
+
+  <div class="diagram">
+    <div class="diagram-container">
+      <svg viewBox="0 0 900 340" xmlns="http://www.w3.org/2000/svg" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+        <!-- Title -->
+        <text x="450" y="30" text-anchor="middle" fill="#e6edf3" font-size="15" font-weight="600">Phase 3 Cross-Repo Architecture</text>
+
+        <!-- Ralph (top center) -->
+        <rect x="340" y="55" width="220" height="50" rx="8" fill="#161b22" stroke="#58a6ff" stroke-width="2"/>
+        <text x="450" y="85" text-anchor="middle" fill="#58a6ff" font-size="13" font-weight="600">Ralph (Supervisor)</text>
+
+        <!-- Arrow down from Ralph -->
+        <line x1="450" y1="105" x2="450" y2="135" stroke="#30363d" stroke-width="1.5"/>
+        <text x="458" y="125" fill="#8b949e" font-size="10">dispatches to</text>
+
+        <!-- Four repos -->
+        <!-- mcp-contrast -->
+        <rect x="30" y="145" width="190" height="75" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1.5"/>
+        <text x="125" y="170" text-anchor="middle" fill="#3fb950" font-size="12" font-weight="600">mcp-contrast</text>
+        <text x="125" y="187" text-anchor="middle" fill="#8b949e" font-size="10">Control repo + beads</text>
+        <text x="125" y="202" text-anchor="middle" fill="#8b949e" font-size="10">Shared core library</text>
+
+        <!-- aiml-services -->
+        <rect x="245" y="145" width="190" height="75" rx="8" fill="#161b22" stroke="#3fb950" stroke-width="1.5"/>
+        <text x="340" y="170" text-anchor="middle" fill="#3fb950" font-size="12" font-weight="600">aiml-services</text>
+        <text x="340" y="187" text-anchor="middle" fill="#8b949e" font-size="10">Hosted MCP server</text>
+        <text x="340" y="202" text-anchor="middle" fill="#8b949e" font-size="10">Jib container image</text>
+
+        <!-- aiml-deployment (NEW) -->
+        <rect x="460" y="145" width="190" height="75" rx="8" fill="#161b22" stroke="#f0883e" stroke-width="2" stroke-dasharray="6,3"/>
+        <text x="555" y="170" text-anchor="middle" fill="#f0883e" font-size="12" font-weight="600">aiml-deployment</text>
+        <text x="555" y="187" text-anchor="middle" fill="#8b949e" font-size="10">Helm values + network</text>
+        <text x="555" y="202" text-anchor="middle" fill="#8b949e" font-size="10">policies + HPA config</text>
+        <text x="650" y="155" fill="#f0883e" font-size="9" font-weight="700">NEW</text>
+
+        <!-- contrast-api-gateway (NEW) -->
+        <rect x="675" y="145" width="195" height="75" rx="8" fill="#161b22" stroke="#f0883e" stroke-width="2" stroke-dasharray="6,3"/>
+        <text x="772" y="170" text-anchor="middle" fill="#f0883e" font-size="12" font-weight="600">contrast-api-gateway</text>
+        <text x="772" y="187" text-anchor="middle" fill="#8b949e" font-size="10">CAG route for</text>
+        <text x="772" y="202" text-anchor="middle" fill="#8b949e" font-size="10">POST /mcp</text>
+        <text x="870" y="155" fill="#f0883e" font-size="9" font-weight="700">NEW</text>
+
+        <!-- Connection lines from Ralph to repos -->
+        <line x1="400" y1="105" x2="125" y2="145" stroke="#3fb950" stroke-width="1" opacity="0.6"/>
+        <line x1="430" y1="105" x2="340" y2="145" stroke="#3fb950" stroke-width="1" opacity="0.6"/>
+        <line x1="470" y1="105" x2="555" y2="145" stroke="#f0883e" stroke-width="1.5" opacity="0.8"/>
+        <line x1="500" y1="105" x2="772" y2="145" stroke="#f0883e" stroke-width="1.5" opacity="0.8"/>
+
+        <!-- Legend -->
+        <rect x="30" y="260" width="16" height="3" fill="#3fb950" rx="1"/>
+        <text x="52" y="265" fill="#8b949e" font-size="10">Previously supported</text>
+
+        <rect x="200" y="260" width="16" height="3" fill="#f0883e" rx="1" stroke-dasharray="4,2"/>
+        <text x="222" y="265" fill="#8b949e" font-size="10">Added in this PR</text>
+
+        <!-- Bead examples below repos -->
+        <text x="555" y="240" text-anchor="middle" fill="#6e7681" font-size="9">mcp-xn8i.1, mcp-r07w, mcp-y5to.1</text>
+        <text x="772" y="240" text-anchor="middle" fill="#6e7681" font-size="9">mcp-xn8i.2</text>
+      </svg>
+    </div>
+  </div>
+
+  <div class="callout why">
+    <span class="callout-label">Why this matters</span>
+    <strong>Without this PR, every Phase 3 bead in <code>aiml-deployment</code> or <code>contrast-api-gateway</code> would fail Ralph's validation gate.</strong> Ralph checks that each bead has exactly one <code>repo:*</code> label and that the label maps to a known repository path. A bead labeled <code>repo:aiml-deployment</code> would hit the <code>die "unsupported repo label"</code> error and stop the entire automation loop. This PR adds two repo path mappings and replaces hardcoded validation with a data-driven approach.
+  </div>
+
+  <p class="narrative">
+    <strong>This PR is part of a stacked branch chain.</strong> It sits on top of PR #134 (<a href="https://contrast.atlassian.net/browse/AIML-766" style="color: var(--accent); text-decoration: none;">AIML-766</a>: Slice 12, full tool parity and release hardening), which itself is stacked on AIML-765 (Slice 11, isolation and load tests). The AIML-767 epic (bead <code>mcp-4s5y</code>) is the third major phase of the hosted MCP server rollout. Phase 1 and 2 proved the architecture and achieved tool parity. Phase 3 deploys it for real.
+  </p>
+</section>
+
+<!-- ============================================ -->
+<!-- Chapter 2: Approach                          -->
+<!-- ============================================ -->
+<section class="chapter" id="approach">
+  <div class="chapter-header">
+    <span class="chapter-number green">2</span>
+    <h2>Design Approach</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>The design principle is: make the repo list data-driven instead of hardcoded.</strong> Before this PR, both scripts used inline <code>case</code> statements and explicit <code>process_repo</code> calls for each repo. Adding a third or fourth repo meant editing multiple places and hoping you got them all. The fix introduces two data structures:
+  </p>
+  <p class="narrative" style="padding-left: 1rem;">
+    &bull; A <code>SUPPORTED_REPO_LABELS</code> array in <code>ralph</code> with a helper function <code>is_supported_repo_label()</code> for validation.<br>
+    &bull; A <code>REPOS</code> array in <code>ralph-next-bead</code> that pairs each repo path with its name, iterated with a single loop.
+  </p>
+  <p class="narrative">
+    <strong>This means adding a fifth repo in the future would be a one-line change in each script</strong>, rather than hunting through case branches and function calls. The existing <code>repo_path_for_label()</code> function retains its <code>case</code> statement because it maps labels to paths (a lookup, not a validation), but it gains two new entries.
+  </p>
+
+  <div class="callout note">
+    <span class="callout-label">Note</span>
+    <strong>The prompt template also gets a small improvement.</strong> Previously, the Codex worker prompt only mentioned reading <code>CLAUDE.md</code> from <code>aiml-services</code>. Now it instructs Codex to read <code>CLAUDE.md</code> or <code>AGENTS.md</code> from whichever implementation repo the bead targets. This matters because <code>aiml-deployment</code> and <code>contrast-api-gateway</code> may use <code>AGENTS.md</code> instead of <code>CLAUDE.md</code> for their coding rules.
+  </div>
+</section>
+
+<!-- ============================================ -->
+<!-- Chapter 3: Scope                             -->
+<!-- ============================================ -->
+<section class="chapter" id="scope">
+  <div class="chapter-header">
+    <span class="chapter-number purple">3</span>
+    <h2>Scope</h2>
+  </div>
+
+  <div class="slice-columns">
+    <div class="slice-col this-pr">
+      <div class="slice-title">This PR</div>
+      <div class="slice-item"><span class="dot"></span><strong>Two new repo constants</strong> for aiml-deployment and contrast-api-gateway paths</div>
+      <div class="slice-item"><span class="dot"></span><strong>Data-driven repo validation</strong> via SUPPORTED_REPO_LABELS array + is_supported_repo_label()</div>
+      <div class="slice-item"><span class="dot"></span><strong>Extended repo_path_for_label()</strong> with two new case entries</div>
+      <div class="slice-item"><span class="dot"></span><strong>Loop-based repo processing</strong> in ralph-next-bead replaces hardcoded process_repo calls</div>
+      <div class="slice-item"><span class="dot"></span><strong>Updated prompt template</strong> reads CLAUDE.md/AGENTS.md from any implementation repo</div>
+      <div class="slice-item"><span class="dot"></span><strong>Updated usage text</strong> lists all four supported repo labels</div>
+    </div>
+    <div class="slice-col future-col">
+      <div class="slice-title">Phase 3 Child Beads (Future PRs)</div>
+      <div class="slice-item"><span class="dot"></span>mcp-xn8i.1: Helm values + network policy in aiml-deployment</div>
+      <div class="slice-item"><span class="dot"></span>mcp-xn8i.2: CAG route for POST /mcp in contrast-api-gateway</div>
+      <div class="slice-item"><span class="dot"></span>mcp-xn8i.3: Service-side deployment diagnostics in aiml-services</div>
+      <div class="slice-item"><span class="dot"></span>mcp-r07w: Deployment hardening verification</div>
+      <div class="slice-item"><span class="dot"></span>mcp-y5to.*: Autoscaling, monitoring, Datadog dashboards</div>
+      <div class="slice-item"><span class="dot"></span>mcp-p4sk: Staging integration, rollback drill, DBS pilot</div>
+    </div>
+  </div>
+
+  <p class="narrative">
+    <strong>This is the enabling commit that unlocks Ralph for Phase 3.</strong> It does not change any Java code, deployment config, or test coverage. It is strictly a tooling/automation change in two Bash scripts that control how the AI agent supervisor selects and dispatches work.
+  </p>
+
+  <table class="roadmap-table">
+    <thead><tr><th>Ticket</th><th>Phase</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><a class="jira-link" href="https://contrast.atlassian.net/browse/AIML-766">AIML-766</a></td>
+        <td><span class="slice-name">Phase 2 (Slice 12)</span></td>
+        <td>Full tool parity, release hardening, privacy/security evidence (closed)</td>
+      </tr>
+      <tr class="current-row">
+        <td><a class="jira-link" href="https://contrast.atlassian.net/browse/AIML-767">AIML-767</a></td>
+        <td><span class="slice-name">Phase 3</span><span class="current-badge">This PR</span></td>
+        <td>Deploy to EKS behind CAG, DBS pilot validation</td>
+      </tr>
+      <tr>
+        <td><a class="jira-link" href="https://contrast.atlassian.net/browse/AIML-768">AIML-768</a></td>
+        <td><span class="slice-name">Phase 4</span></td>
+        <td>Operational iteration, Spring AI 2 migration readiness</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ============================================ -->
+<!-- Chapter 4: Ralph Script                      -->
+<!-- ============================================ -->
+<section class="chapter" id="ralph-script">
+  <div class="chapter-header">
+    <span class="chapter-number yellow">4</span>
+    <h2>scripts/ralph</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>The ralph script is the main supervisor loop: it finds an unblocked bead, validates it, and dispatches a Codex worker.</strong> This chapter walks through the four areas of change, all in service of the same goal: teach Ralph about two new repos.
+  </p>
+
+  <!-- Part A: New repo constants and SUPPORTED_REPO_LABELS -->
+  <p class="narrative">
+    <strong>First, the path constants and the new validation array.</strong> Two new constants map to local filesystem paths. The <code>SUPPORTED_REPO_LABELS</code> array centralizes the list of valid <code>repo:*</code> labels, replacing what was previously embedded in a <code>case</code> statement inside <code>main()</code>.
+  </p>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">scripts/ralph</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">23</span><span class="code"><span class="comment"># --- Paths ---</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">24</span><span class="code"><span class="comment"># Control repo: where br runs and .beads/ lives (never committed).</span></span></span>
+<span class="diff-line del"><span class="marker">-</span><span class="ln"> </span><span class="code"><span class="comment"># AIML repo: second implementation target for cross-repo AIML-110 work.</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">25</span><span class="code"><span class="comment"># Implementation repos: cross-repo AIML-110 work selected by repo:* labels.</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">26</span><span class="code"><span class="comment"># Results: gitignored -- may contain prompts, paths, and implementation details.</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">27</span><span class="code"><span class="prop">CONTROL_REPO</span>=<span class="str">"/Users/chrisedwards/projects/contrast/mcp-contrast"</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">28</span><span class="code"><span class="prop">AIML_REPO</span>=<span class="str">"/Users/chrisedwards/projects/contrast/aiml-services"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">29</span><span class="code"><span class="prop">AIML_DEPLOYMENT_REPO</span>=<span class="str">"/Users/chrisedwards/projects/contrast/aiml-deployment"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">30</span><span class="code"><span class="prop">CONTRAST_API_GATEWAY_REPO</span>=<span class="str">"/Users/chrisedwards/projects/contrast/contrast-api-gateway"</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">31</span><span class="code"><span class="prop">RESULT_DIR</span>=<span class="str">"$CONTROL_REPO/history/ralph-runs"</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">32</span><span class="code"><span class="prop">BEADS_DIR</span>=<span class="str">"$CONTROL_REPO/.beads"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">33</span><span class="code"><span class="prop">SUPPORTED_REPO_LABELS</span>=(</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">34</span><span class="code">  <span class="str">"repo:mcp-contrast"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">35</span><span class="code">  <span class="str">"repo:aiml-services"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">36</span><span class="code">  <span class="str">"repo:aiml-deployment"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">37</span><span class="code">  <span class="str">"repo:contrast-api-gateway"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">38</span><span class="code">)</span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>The array is the single source of truth for supported repos.</strong> Both the <code>--repo</code> flag validation and the usage text reference this list, so adding a future repo means adding one string to one array.
+    </div>
+  </div>
+
+  <!-- Part B: New helper function -->
+  <p class="narrative">
+    <strong>Next, a helper function that loops over the array to validate a label.</strong> This replaces the inline <code>case</code> statement that previously lived in <code>main()</code>'s argument parser.
+  </p>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">scripts/ralph</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">76</span><span class="code"><span class="comment"># Map a repo:* bead label to a local filesystem path.</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">77</span><span class="code"><span class="kw">repo_path_for_label</span>() {</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">78</span><span class="code">  <span class="kw">case</span> <span class="str">"$1"</span> <span class="kw">in</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">79</span><span class="code">    repo:mcp-contrast) printf <span class="str">'%s\n'</span> <span class="str">"$CONTROL_REPO"</span> ;;</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">80</span><span class="code">    repo:aiml-services) printf <span class="str">'%s\n'</span> <span class="str">"$AIML_REPO"</span> ;;</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">81</span><span class="code">    repo:aiml-deployment) printf <span class="str">'%s\n'</span> <span class="str">"$AIML_DEPLOYMENT_REPO"</span> ;;</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">82</span><span class="code">    repo:contrast-api-gateway) printf <span class="str">'%s\n'</span> <span class="str">"$CONTRAST_API_GATEWAY_REPO"</span> ;;</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">83</span><span class="code">    *) <span class="kw">return</span> <span class="num">1</span> ;;</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">84</span><span class="code">  <span class="kw">esac</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">85</span><span class="code">}</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">87</span><span class="code"><span class="kw">is_supported_repo_label</span>() {</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">88</span><span class="code">  <span class="kw">local</span> <span class="param">label</span>=<span class="str">"$1"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">89</span><span class="code">  <span class="kw">local</span> <span class="param">supported</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">90</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">91</span><span class="code">  <span class="kw">for</span> supported <span class="kw">in</span> <span class="str">"${SUPPORTED_REPO_LABELS[@]}"</span>; <span class="kw">do</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">92</span><span class="code">    [[ <span class="str">"$label"</span> == <span class="str">"$supported"</span> ]] &amp;&amp; <span class="kw">return</span> <span class="num">0</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">93</span><span class="code">  <span class="kw">done</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">94</span><span class="code"></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">95</span><span class="code">  <span class="kw">return</span> <span class="num">1</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">96</span><span class="code">}</span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>Two functions, two responsibilities.</strong> <code>repo_path_for_label()</code> does the lookup (label to path), while <code>is_supported_repo_label()</code> does the validation (is this label in our known set?). The validation function iterates <code>SUPPORTED_REPO_LABELS</code>, so it automatically picks up any future additions to the array.
+    </div>
+  </div>
+
+  <!-- Part C: Argument parsing refactor -->
+  <p class="narrative">
+    <strong>The <code>--repo</code> flag validation in <code>main()</code> is now a one-liner.</strong> Compare the before and after: a four-line case statement becomes a single function call.
+  </p>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">scripts/ralph</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">345</span><span class="code">      --repo)</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">346</span><span class="code">        [[ $# -ge <span class="num">2</span> ]] || die <span class="str">"--repo requires a value"</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">347</span><span class="code">        repo_filter=<span class="str">"$2"</span></span></span>
+<span class="diff-line del"><span class="marker">-</span><span class="ln"> </span><span class="code">        <span class="kw">case</span> <span class="str">"$repo_filter"</span> <span class="kw">in</span></span></span>
+<span class="diff-line del"><span class="marker">-</span><span class="ln"> </span><span class="code">          repo:mcp-contrast | repo:aiml-services) ;;</span></span>
+<span class="diff-line del"><span class="marker">-</span><span class="ln"> </span><span class="code">          *) die <span class="str">"unsupported repo filter: $repo_filter"</span> ;;</span></span>
+<span class="diff-line del"><span class="marker">-</span><span class="ln"> </span><span class="code">        <span class="kw">esac</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">348</span><span class="code">        is_supported_repo_label <span class="str">"$repo_filter"</span> || die <span class="str">"unsupported repo filter: $repo_filter"</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">349</span><span class="code">        shift <span class="num">2</span></span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>Same error message, same behavior, less duplication.</strong> The <code>die</code> call and the error message are preserved. The only difference is that the validation now delegates to the array-backed helper, which means future repos do not require a change here.
+    </div>
+  </div>
+
+  <!-- Part D: Prompt template update -->
+  <p class="narrative">
+    <strong>Finally, the Codex worker prompt is updated to be repo-agnostic.</strong> Instead of only mentioning <code>aiml-services</code> CLAUDE.md, it now tells the worker to read the implementation repo's instruction file regardless of which repo the bead targets.
+  </p>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">scripts/ralph</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">265</span><span class="code">You are Codex, but this repository's coding rules live in CLAUDE.md.</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">266</span><span class="code"></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">267</span><span class="code">Before inspecting or editing implementation code:</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">268</span><span class="code">- Read the implementation repo's CLAUDE.md or AGENTS.md if present.</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">269</span><span class="code">- If the implementation repo is aiml-services, also read services/aiml-hosted-mcp-server/CLAUDE.md.</span></span>
+<span class="diff-line del"><span class="marker">-</span><span class="ln"> </span><span class="code">- Follow those CLAUDE.md files as binding repository rules.</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">270</span><span class="code">- Follow those repository instruction files as binding rules.</span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>This prevents a Codex worker from ignoring coding rules in unfamiliar repos.</strong> The <code>aiml-deployment</code> and <code>contrast-api-gateway</code> repos may define their standards in <code>AGENTS.md</code> rather than <code>CLAUDE.md</code>. The new first bullet catches both. The existing <code>aiml-services</code>-specific bullet is preserved since that repo has a nested service-level CLAUDE.md.
+    </div>
+  </div>
+
+  <!-- Part E: Minor comment and usage updates -->
+  <p class="narrative">
+    <strong>The remaining changes are cosmetic.</strong> Comment text changes from "both repos" to "multiple repositories," and the usage text now lists all four supported repo labels. These are straightforward readability improvements.
+  </p>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">scripts/ralph</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">40</span><span class="code">usage() {</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">41</span><span class="code">  cat &lt;&lt;'EOF'</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">42</span><span class="code">Usage:</span></span>
+<span class="diff-line del"><span class="marker">-</span><span class="ln"> </span><span class="code">  scripts/ralph &lt;parent-bead-id&gt; &lt;max-iterations&gt; [--repo repo:mcp-contrast|repo:aiml-services]</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">43</span><span class="code">  scripts/ralph &lt;parent-bead-id&gt; &lt;max-iterations&gt; [--repo &lt;repo-label&gt;]</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln"> </span><span class="code">...</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">53</span><span class="code">Ralph requires clean relevant worktrees and refuses protected branches.</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">55</span><span class="code">Supported repo labels:</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">56</span><span class="code">  repo:mcp-contrast</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">57</span><span class="code">  repo:aiml-services</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">58</span><span class="code">  repo:aiml-deployment</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">59</span><span class="code">  repo:contrast-api-gateway</span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>The usage text moved from an inline pipe-separated list to a separate, readable block.</strong> This scales better as the repo list grows and is easier to scan at a glance when running <code>scripts/ralph --help</code>.
+    </div>
+  </div>
+</section>
+
+<!-- ============================================ -->
+<!-- Chapter 5: ralph-next-bead                   -->
+<!-- ============================================ -->
+<section class="chapter" id="ralph-next-bead">
+  <div class="chapter-header">
+    <span class="chapter-number orange">5</span>
+    <h2>scripts/ralph-next-bead</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>The <code>ralph-next-bead</code> script handles the transition between completed beads: creating PRs, generating walkthroughs, and setting up stacked branches.</strong> It processes every repo that has commits on the current branch. Before this PR, it hardcoded two <code>process_repo</code> calls. Now it iterates over a <code>REPOS</code> array, following the same data-driven pattern.
+  </p>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">scripts/ralph-next-bead</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">2</span><span class="code"><span class="comment"># ralph-next-bead -- Transition between beads: PR the completed one, set up the next.</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">3</span><span class="code"><span class="comment">#</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">4</span><span class="code"><span class="comment"># Orchestrates claude -p calls to create PRs, walkthroughs, and stacked branches</span></span></span>
+<span class="diff-line del"><span class="marker">-</span><span class="ln"> </span><span class="code"><span class="comment"># across mcp-contrast and aiml-services repos.</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">5</span><span class="code"><span class="comment"># across the repos used by AIML-110 / hosted MCP beads.</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">7</span><span class="code"><span class="kw">set</span> -euo pipefail</span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">9</span><span class="code"><span class="prop">CONTROL_REPO</span>=<span class="str">"/Users/chrisedwards/projects/contrast/mcp-contrast"</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">10</span><span class="code"><span class="prop">AIML_REPO</span>=<span class="str">"/Users/chrisedwards/projects/contrast/aiml-services"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">11</span><span class="code"><span class="prop">AIML_DEPLOYMENT_REPO</span>=<span class="str">"/Users/chrisedwards/projects/contrast/aiml-deployment"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">12</span><span class="code"><span class="prop">CONTRAST_API_GATEWAY_REPO</span>=<span class="str">"/Users/chrisedwards/projects/contrast/contrast-api-gateway"</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">13</span><span class="code"><span class="prop">BEADS_PATH</span>=<span class="str">"$CONTROL_REPO"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">14</span><span class="code"><span class="prop">REPOS</span>=(</span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">15</span><span class="code">  <span class="str">"$CONTROL_REPO|mcp-contrast"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">16</span><span class="code">  <span class="str">"$AIML_REPO|aiml-services"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">17</span><span class="code">  <span class="str">"$AIML_DEPLOYMENT_REPO|aiml-deployment"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">18</span><span class="code">  <span class="str">"$CONTRAST_API_GATEWAY_REPO|contrast-api-gateway"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">19</span><span class="code">)</span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>Each entry in <code>REPOS</code> is a pipe-delimited pair: filesystem path and display name.</strong> The pipe delimiter is safe here because paths never contain <code>|</code>. The <code>${repo_entry%%|*}</code> and <code>${repo_entry##*|}</code> parameter expansions split each entry without spawning a subshell.
+    </div>
+  </div>
+
+  <p class="narrative">
+    <strong>The loop replacement is the most visible structural change.</strong> Two explicit calls become a three-line loop that processes every entry in the array.
+  </p>
+
+  <div class="diff-block">
+    <div class="diff-header">
+      <svg class="file-icon" viewBox="0 0 16 16"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Z" fill-rule="evenodd"/></svg>
+      <span class="filename">scripts/ralph-next-bead</span>
+      <span class="badge badge-modified">MODIFIED</span>
+    </div>
+    <div class="diff-body"><pre>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">233</span><span class="code">log <span class="str">"Logs: $LOG_DIR"</span></span></span>
+<span class="diff-line context"><span class="marker"> </span><span class="ln">234</span><span class="code"></span></span>
+<span class="diff-line del"><span class="marker">-</span><span class="ln"> </span><span class="code">process_repo <span class="str">"$CONTROL_REPO"</span> <span class="str">"mcp-contrast"</span></span></span>
+<span class="diff-line del"><span class="marker">-</span><span class="ln"> </span><span class="code">process_repo <span class="str">"$AIML_REPO"</span> <span class="str">"aiml-services"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">235</span><span class="code"><span class="kw">for</span> repo_entry <span class="kw">in</span> <span class="str">"${REPOS[@]}"</span>; <span class="kw">do</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">236</span><span class="code">  process_repo <span class="str">"${repo_entry%%|*}"</span> <span class="str">"${repo_entry##*|}"</span></span></span>
+<span class="diff-line add"><span class="marker">+</span><span class="ln">237</span><span class="code"><span class="kw">done</span></span></span>
+    </pre></div>
+    <div class="annotation">
+      <strong>Repos that do not exist on disk are safely skipped.</strong> The <code>process_repo</code> function already has a guard: <code>if [[ ! -d "$repo_dir" ]]; then log "SKIP: ..."; return 0; fi</code>. So if a developer does not have <code>aiml-deployment</code> checked out locally, the script logs a skip and continues. No new error handling is needed.
+    </div>
+  </div>
+</section>
+
+<!-- ============================================ -->
+<!-- Chapter 6: Summary                           -->
+<!-- ============================================ -->
+<section class="chapter" id="summary">
+  <div class="chapter-header">
+    <span class="chapter-number green">6</span>
+    <h2>Summary and Review Guide</h2>
+  </div>
+
+  <p class="narrative">
+    <strong>This is a small, self-contained automation change that prepares Ralph for Phase 3's four-repo scope.</strong> No Java code, no deployment config, no test changes. The only risk is a typo in a repo path, which would surface immediately when Ralph tries to dispatch a bead to a nonexistent directory.
+  </p>
+
+  <div class="callout note">
+    <span class="callout-label">Review focus areas</span>
+    <strong>Check the following:</strong><br>
+    1. Are the two new repo paths correct? (<code>/Users/chrisedwards/projects/contrast/aiml-deployment</code> and <code>/Users/chrisedwards/projects/contrast/contrast-api-gateway</code>)<br>
+    2. Does the <code>SUPPORTED_REPO_LABELS</code> array match the bead labels used in Phase 3? (The epic lists <code>repo:aiml-deployment</code> and <code>repo:contrast-api-gateway</code>, which match.)<br>
+    3. Is the prompt template improvement reasonable? (Reading AGENTS.md in addition to CLAUDE.md.)
+  </div>
+
+  <table class="file-table">
+    <thead><tr><th>File</th><th>Purpose</th><th>Lines</th><th>Novelty</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>scripts/ralph</td>
+        <td>Add 2 repo constants, SUPPORTED_REPO_LABELS array, is_supported_repo_label() helper, extend repo_path_for_label(), update prompt template and usage text</td>
+        <td><span class="addition">+38</span> / <span class="deletion">-10</span></td>
+        <td class="novelty"><span class="novelty-badge pattern">Pattern</span></td>
+      </tr>
+      <tr>
+        <td>scripts/ralph-next-bead</td>
+        <td>Add 2 repo constants, REPOS array, replace hardcoded process_repo calls with loop</td>
+        <td><span class="addition">+12</span> / <span class="deletion">-3</span></td>
+        <td class="novelty"><span class="novelty-badge pattern">Pattern</span></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="callout future">
+    <span class="callout-label">What comes next</span>
+    <strong>With Ralph now aware of all four repos, the Phase 3 child beads can begin executing.</strong> The immediate next steps are the beads under <code>mcp-xn8i</code> (Helm deployment, CAG route, network policy) and <code>mcp-y5to</code> (autoscaling, monitoring). Those beads will produce changes in <code>aiml-deployment</code> and <code>contrast-api-gateway</code> that Ralph will now be able to discover, validate, and dispatch to Codex workers. The final gate is <code>mcp-p4sk</code>: a human-operated staging integration, rollback drill, and DBS pilot validation.
+  </div>
+</section>
+
+</main>
+
+<footer>
+  PR #135 &middot; AIML-767 &middot; mcp-contrast
+</footer>
+
+</body>
+</html>

--- a/scripts/ralph
+++ b/scripts/ralph
@@ -28,6 +28,7 @@ CONTROL_REPO="/Users/chrisedwards/projects/contrast/mcp-contrast"
 AIML_REPO="/Users/chrisedwards/projects/contrast/aiml-services"
 AIML_DEPLOYMENT_REPO="/Users/chrisedwards/projects/contrast/aiml-deployment"
 CONTRAST_API_GATEWAY_REPO="/Users/chrisedwards/projects/contrast/contrast-api-gateway"
+TEAMSERVER_REPO="/Users/chrisedwards/projects/contrast/teamserver"
 RESULT_DIR="$CONTROL_REPO/history/ralph-runs"
 BEADS_DIR="$CONTROL_REPO/.beads"
 SUPPORTED_REPO_LABELS=(
@@ -35,6 +36,7 @@ SUPPORTED_REPO_LABELS=(
   "repo:aiml-services"
   "repo:aiml-deployment"
   "repo:contrast-api-gateway"
+  "repo:teamserver"
 )
 
 usage() {
@@ -57,6 +59,7 @@ Supported repo labels:
   repo:aiml-services
   repo:aiml-deployment
   repo:contrast-api-gateway
+  repo:teamserver
 EOF
 }
 
@@ -80,6 +83,7 @@ repo_path_for_label() {
     repo:aiml-services) printf '%s\n' "$AIML_REPO" ;;
     repo:aiml-deployment) printf '%s\n' "$AIML_DEPLOYMENT_REPO" ;;
     repo:contrast-api-gateway) printf '%s\n' "$CONTRAST_API_GATEWAY_REPO" ;;
+    repo:teamserver) printf '%s\n' "$TEAMSERVER_REPO" ;;
     *) return 1 ;;
   esac
 }

--- a/scripts/ralph
+++ b/scripts/ralph
@@ -167,17 +167,6 @@ ready_json_for_parent() {
   fi
 }
 
-filter_agent_ready_json() {
-  jq '
-    map(
-      select(
-        ((.labels // []) | '"$human_only_label_filter"')
-        | not
-      )
-    )
-  '
-}
-
 has_human_only_label() {
   local jq_status
 
@@ -194,6 +183,31 @@ has_human_only_label() {
   fi
 
   die "failed to parse bead JSON while checking human-only labels"
+}
+
+# br ready --json intentionally returns a compact issue shape and may omit
+# labels/notes. Hydrate candidates before filtering so label decisions are made
+# from the complete bead record.
+hydrate_agent_ready_json() {
+  local ready_json="$1"
+  local hydrated="[]"
+  local candidate_id
+  local candidate_json
+  local candidate_issue
+
+  while IFS= read -r candidate_id; do
+    [[ -z "$candidate_id" ]] && continue
+
+    candidate_json="$(run_br show "$candidate_id" --json)"
+    if has_human_only_label "$candidate_json"; then
+      continue
+    fi
+
+    candidate_issue="$(jq '.[0]' <<<"$candidate_json")"
+    hydrated="$(jq --argjson issue "$candidate_issue" '. + [$issue]' <<<"$hydrated")"
+  done < <(jq -r '.[].id // empty' <<<"$ready_json")
+
+  printf '%s\n' "$hydrated"
 }
 
 bead_descends_from_parent() {
@@ -257,9 +271,9 @@ select_bead_id() {
 }
 
 # Eligibility gate: only task/bug/feature beads that are open or in_progress
-# (resumed), have exactly one repo:* label, and contain a description +
-# acceptance criteria. Rejects epics, deferred beads, ambiguous multi-repo
-# beads, and empty shells.
+# (resumed), have exactly one repo:* label, and contain a description plus
+# either acceptance criteria, triage notes, or the ready-for-agent label.
+# Rejects epics, deferred beads, ambiguous multi-repo beads, and empty shells.
 validate_bead_and_repo_label() {
   local bead_json="$1"
   local bead_id="$2"
@@ -269,6 +283,8 @@ validate_bead_and_repo_label() {
   local repo_label
   local description_len
   local acceptance_len
+  local notes_len
+  local is_ready_for_agent
 
   issue_type="$(json_string '.[0].issue_type // ""' <<<"$bead_json")"
   status="$(json_string '.[0].status // ""' <<<"$bead_json")"
@@ -276,6 +292,8 @@ validate_bead_and_repo_label() {
   repo_label="$(json_string '[.[0].labels[]? | select(startswith("repo:"))][0] // ""' <<<"$bead_json")"
   description_len="$(jq '([.[0].description // ""] | .[0] | length)' <<<"$bead_json")"
   acceptance_len="$(jq '([.[0].acceptance_criteria // ""] | .[0] | length)' <<<"$bead_json")"
+  notes_len="$(jq '([.[0].notes // ""] | .[0] | length)' <<<"$bead_json")"
+  is_ready_for_agent="$(jq '([.[0].labels[]? | select(. == "ready-for-agent")] | length) > 0' <<<"$bead_json")"
 
   [[ "$status" == "open" || "$status" == "in_progress" ]] || die "$bead_id has unexpected status: $status"
   if has_human_only_label "$bead_json"; then
@@ -290,7 +308,8 @@ validate_bead_and_repo_label() {
   [[ "$repo_count" == "1" ]] || die "$bead_id must have exactly one repo:* label; found $repo_count"
   repo_path_for_label "$repo_label" >/dev/null || die "$bead_id has unsupported repo label: $repo_label"
   [[ "$description_len" -gt 0 ]] || die "$bead_id has no description"
-  [[ "$acceptance_len" -gt 0 ]] || die "$bead_id has no acceptance criteria"
+  [[ "$acceptance_len" -gt 0 || "$notes_len" -gt 0 || "$is_ready_for_agent" == "true" ]] \
+    || die "$bead_id has no acceptance criteria, triage notes, or ready-for-agent label"
 
   printf '%s\n' "$repo_label"
 }
@@ -442,7 +461,7 @@ main() {
       printf 'ralph: resuming incomplete bead %s\n' "$bead_id"
     else
       ready_json="$(ready_json_for_parent "$parent" "$repo_filter")"
-      ready_json="$(filter_agent_ready_json <<<"$ready_json")"
+      ready_json="$(hydrate_agent_ready_json "$ready_json")"
       ready_count="$(jq 'length' <<<"$ready_json")"
       if [[ "$ready_count" == "0" ]]; then
         printf 'ralph: no agent-ready work for parent %s\n' "$parent"

--- a/scripts/ralph
+++ b/scripts/ralph
@@ -184,13 +184,35 @@ has_human_only_label() {
   ' >/dev/null <<<"$1"
 }
 
+bead_descends_from_parent() {
+  local bead_id="$1"
+  local requested_parent="$2"
+  local current="$bead_id"
+  local bead_json
+  local actual_parent
+
+  while [[ -n "$current" ]]; do
+    [[ "$current" == "$requested_parent" ]] && return 0
+
+    bead_json="$(run_br show "$current" --json)"
+    actual_parent="$(jq -r '.[0].parent // ""' <<<"$bead_json")"
+
+    [[ -z "$actual_parent" || "$actual_parent" == "$current" ]] && return 1
+    current="$actual_parent"
+  done
+
+  return 1
+}
+
 # Check for a bead ralph previously claimed but didn't finish. Resume it
 # before selecting new work. br list doesn't support --parent, so we query
 # all of ralph's in_progress agent-runnable beads and take the first one
-# (v1 is single-threaded, so there should be at most one).
+# that belongs under the requested parent.
 find_incomplete_bead() {
-  local repo_filter="$1"
+  local parent="$1"
+  local repo_filter="$2"
   local incomplete_json
+  local candidate_id
 
   if [[ -n "$repo_filter" ]]; then
     incomplete_json="$(run_br list --status in_progress --assignee ralph --label "$repo_filter" --json)"
@@ -198,16 +220,23 @@ find_incomplete_bead() {
     incomplete_json="$(run_br list --status in_progress --assignee ralph --json)"
   fi
 
-  jq -r '
+  while IFS= read -r candidate_id; do
+    [[ -z "$candidate_id" ]] && continue
+    if bead_descends_from_parent "$candidate_id" "$parent"; then
+      printf '%s\n' "$candidate_id"
+      return 0
+    fi
+  done < <(
+    jq -r '
     .issues
-    | map(
-        select(
-          ((.labels // []) | '"$human_only_label_filter"')
-          | not
-        )
+    | .[]
+    | select(
+        ((.labels // []) | '"$human_only_label_filter"')
+        | not
       )
-    | .[0].id // empty
+    | .id
   ' <<<"$incomplete_json"
+  )
 }
 
 # Pick the first ready bead sorted by priority, then creation time, then id.
@@ -395,7 +424,7 @@ main() {
     # (a) Find work. First check if ralph left a bead in_progress from a
     #     previous run (e.g. crash or timeout). If so, resume it. Otherwise
     #     ask br for the next unblocked child bead under the parent.
-    bead_id="$(find_incomplete_bead "$repo_filter")"
+    bead_id="$(find_incomplete_bead "$parent" "$repo_filter")"
 
     if [[ -n "$bead_id" ]]; then
       printf 'ralph: resuming incomplete bead %s\n' "$bead_id"

--- a/scripts/ralph
+++ b/scripts/ralph
@@ -22,17 +22,25 @@ set -euo pipefail
 
 # --- Paths ---
 # Control repo: where br runs and .beads/ lives (never committed).
-# AIML repo: second implementation target for cross-repo AIML-110 work.
+# Implementation repos: cross-repo AIML-110 work selected by repo:* labels.
 # Results: gitignored — may contain prompts, paths, and implementation details.
 CONTROL_REPO="/Users/chrisedwards/projects/contrast/mcp-contrast"
 AIML_REPO="/Users/chrisedwards/projects/contrast/aiml-services"
+AIML_DEPLOYMENT_REPO="/Users/chrisedwards/projects/contrast/aiml-deployment"
+CONTRAST_API_GATEWAY_REPO="/Users/chrisedwards/projects/contrast/contrast-api-gateway"
 RESULT_DIR="$CONTROL_REPO/history/ralph-runs"
 BEADS_DIR="$CONTROL_REPO/.beads"
+SUPPORTED_REPO_LABELS=(
+  "repo:mcp-contrast"
+  "repo:aiml-services"
+  "repo:aiml-deployment"
+  "repo:contrast-api-gateway"
+)
 
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/ralph <parent-bead-id> <max-iterations> [--repo repo:mcp-contrast|repo:aiml-services]
+  scripts/ralph <parent-bead-id> <max-iterations> [--repo <repo-label>]
 
 Runs a small AIML-110 implementation loop:
   - resumes any incomplete bead from a previous run before selecting new work
@@ -43,6 +51,12 @@ Runs a small AIML-110 implementation loop:
   - saves prompt/output under history/ralph-runs/
 
 Ralph requires clean relevant worktrees and refuses protected branches.
+
+Supported repo labels:
+  repo:mcp-contrast
+  repo:aiml-services
+  repo:aiml-deployment
+  repo:contrast-api-gateway
 EOF
 }
 
@@ -64,8 +78,21 @@ repo_path_for_label() {
   case "$1" in
     repo:mcp-contrast) printf '%s\n' "$CONTROL_REPO" ;;
     repo:aiml-services) printf '%s\n' "$AIML_REPO" ;;
+    repo:aiml-deployment) printf '%s\n' "$AIML_DEPLOYMENT_REPO" ;;
+    repo:contrast-api-gateway) printf '%s\n' "$CONTRAST_API_GATEWAY_REPO" ;;
     *) return 1 ;;
   esac
+}
+
+is_supported_repo_label() {
+  local label="$1"
+  local supported
+
+  for supported in "${SUPPORTED_REPO_LABELS[@]}"; do
+    [[ "$label" == "$supported" ]] && return 0
+  done
+
+  return 1
 }
 
 current_branch() {
@@ -124,7 +151,7 @@ human_only_label_filter='
 # br ready is the executable source of truth — a bead is only runnable if
 # br says all its dependencies are satisfied. --parent scopes to children
 # (and descendants) of the given bead. Optional repo label filter restricts
-# to one repo when AIML-110 work spans both.
+# to one repo when AIML-110 work spans multiple repositories.
 ready_json_for_parent() {
   local parent="$1"
   local repo_filter="$2"
@@ -238,8 +265,9 @@ write_prompt() {
 You are Codex, but this repository's coding rules live in CLAUDE.md.
 
 Before inspecting or editing implementation code:
+- Read the implementation repo's CLAUDE.md or AGENTS.md if present.
 - If the implementation repo is aiml-services, also read services/aiml-hosted-mcp-server/CLAUDE.md.
-- Follow those CLAUDE.md files as binding repository rules.
+- Follow those repository instruction files as binding rules.
 
 You are implementing exactly one bead: $bead_id.
 Do not select different work.
@@ -317,10 +345,7 @@ main() {
       --repo)
         [[ $# -ge 2 ]] || die "--repo requires a value"
         repo_filter="$2"
-        case "$repo_filter" in
-          repo:mcp-contrast | repo:aiml-services) ;;
-          *) die "unsupported repo filter: $repo_filter" ;;
-        esac
+        is_supported_repo_label "$repo_filter" || die "unsupported repo filter: $repo_filter"
         shift 2
         ;;
       *)
@@ -391,8 +416,9 @@ main() {
 
     [[ -d "$implementation_repo/.git" ]] || die "implementation repo not found: $implementation_repo"
 
-    # (c) Preflight: both repos must be clean (no uncommitted changes) and
-    #     the implementation repo must not be on a protected branch.
+    # (c) Preflight: the control and implementation repos must be clean
+    #     (no uncommitted changes), and the implementation repo must not be
+    #     on a protected branch.
     ensure_clean_repo "$CONTROL_REPO" "control repo"
     if [[ "$implementation_repo" != "$CONTROL_REPO" ]]; then
       ensure_clean_repo "$implementation_repo" "$repo_label"

--- a/scripts/ralph
+++ b/scripts/ralph
@@ -179,9 +179,21 @@ filter_agent_ready_json() {
 }
 
 has_human_only_label() {
-  jq -e '
+  local jq_status
+
+  if jq -e '
     (.[0].labels // []) | '"$human_only_label_filter"'
-  ' >/dev/null <<<"$1"
+  ' >/dev/null 2>/dev/null <<<"$1"; then
+    return 0
+  else
+    jq_status=$?
+  fi
+
+  if [[ "$jq_status" -eq 1 ]]; then
+    return 1
+  fi
+
+  die "failed to parse bead JSON while checking human-only labels"
 }
 
 bead_descends_from_parent() {

--- a/scripts/ralph-next-bead
+++ b/scripts/ralph-next-bead
@@ -2,13 +2,21 @@
 # ralph-next-bead — Transition between beads: PR the completed one, set up the next.
 #
 # Orchestrates claude -p calls to create PRs, walkthroughs, and stacked branches
-# across mcp-contrast and aiml-services repos.
+# across the repos used by AIML-110 / hosted MCP beads.
 
 set -euo pipefail
 
 CONTROL_REPO="/Users/chrisedwards/projects/contrast/mcp-contrast"
 AIML_REPO="/Users/chrisedwards/projects/contrast/aiml-services"
+AIML_DEPLOYMENT_REPO="/Users/chrisedwards/projects/contrast/aiml-deployment"
+CONTRAST_API_GATEWAY_REPO="/Users/chrisedwards/projects/contrast/contrast-api-gateway"
 BEADS_PATH="$CONTROL_REPO"
+REPOS=(
+  "$CONTROL_REPO|mcp-contrast"
+  "$AIML_REPO|aiml-services"
+  "$AIML_DEPLOYMENT_REPO|aiml-deployment"
+  "$CONTRAST_API_GATEWAY_REPO|contrast-api-gateway"
+)
 
 PR_TOOLS_SCRIPTS=$(ls -d "$HOME/.claude/plugins/cache/Contrast-Security-Inc/pr-tools"/*/scripts 2>/dev/null | sort -V | tail -1)
 if [[ -z "$PR_TOOLS_SCRIPTS" ]]; then
@@ -224,8 +232,9 @@ log "Completed bead: ${COMPLETED_BEAD_ID:-none}"
 log "Next bead: ${NEXT_BEAD_ID:-none}"
 log "Logs: $LOG_DIR"
 
-process_repo "$CONTROL_REPO" "mcp-contrast"
-process_repo "$AIML_REPO" "aiml-services"
+for repo_entry in "${REPOS[@]}"; do
+  process_repo "${repo_entry%%|*}" "${repo_entry##*|}"
+done
 
 log "============================================"
 log "  ralph-next-bead complete"

--- a/scripts/ralph-next-bead
+++ b/scripts/ralph-next-bead
@@ -124,9 +124,9 @@ repo_has_commits() {
   fi
 
   # Try stacked-pr-facts for the precise base branch, but fall back gracefully.
-  local facts base_branch="" facts_err
-  if facts_err=$(cd "$repo_dir" && bash "$PR_TOOLS_SCRIPTS/stacked-pr-facts.sh" detect-base-candidates 2>&1); then
-    base_branch=$(echo "$facts_err" | jq -r '
+  local base_branch="" facts_output
+  if facts_output=$(cd "$repo_dir" && bash "$PR_TOOLS_SCRIPTS/stacked-pr-facts.sh" detect-base-candidates 2>/dev/null); then
+    base_branch=$(echo "$facts_output" | jq -r '
       if .configuredParent != null and .configuredParent.branch != null then
         .configuredParent.branch
       else

--- a/scripts/ralph-next-bead
+++ b/scripts/ralph-next-bead
@@ -155,9 +155,10 @@ repo_has_commits() {
   elif count=$(cd "$repo_dir" && git rev-list --count "origin/$default_branch..HEAD" 2>/dev/null); then
     _RHC_BASE="$default_branch (fallback — origin/$base_branch not found)"
     _RHC_METHOD="fallback-origin-missing"
-  elif count=$(cd "$repo_dir" && git log --oneline HEAD --not --remotes 2>/dev/null | wc -l | tr -d ' '); then
+  elif [[ -n "$(cd "$repo_dir" && git remote)" ]] \
+      && count=$(cd "$repo_dir" && git log --oneline HEAD --not --remotes 2>/dev/null | wc -l | tr -d ' '); then
     _RHC_BASE="(all remotes)"
-    _RHC_METHOD="fallback-no-remotes"
+    _RHC_METHOD="fallback-all-remotes"
   else
     count="0"
     _RHC_METHOD="all-methods-failed"

--- a/scripts/ralph-next-bead
+++ b/scripts/ralph-next-bead
@@ -10,12 +10,14 @@ CONTROL_REPO="/Users/chrisedwards/projects/contrast/mcp-contrast"
 AIML_REPO="/Users/chrisedwards/projects/contrast/aiml-services"
 AIML_DEPLOYMENT_REPO="/Users/chrisedwards/projects/contrast/aiml-deployment"
 CONTRAST_API_GATEWAY_REPO="/Users/chrisedwards/projects/contrast/contrast-api-gateway"
+TEAMSERVER_REPO="/Users/chrisedwards/projects/contrast/teamserver"
 BEADS_PATH="$CONTROL_REPO"
 REPOS=(
   "$CONTROL_REPO|mcp-contrast"
   "$AIML_REPO|aiml-services"
   "$AIML_DEPLOYMENT_REPO|aiml-deployment"
   "$CONTRAST_API_GATEWAY_REPO|contrast-api-gateway"
+  "$TEAMSERVER_REPO|teamserver"
 )
 
 PR_TOOLS_SCRIPTS=$(ls -d "$HOME/.claude/plugins/cache/Contrast-Security-Inc/pr-tools"/*/scripts 2>/dev/null | sort -V | tail -1)

--- a/scripts/ralph-tail
+++ b/scripts/ralph-tail
@@ -7,7 +7,7 @@ RESULT_DIR="${1:-/Users/chrisedwards/projects/contrast/mcp-contrast/history/ralp
 POLL_INTERVAL=2
 
 get_latest() {
-  ls -dt "$RESULT_DIR"/*/ 2>/dev/null | head -1
+  ls -dt "$RESULT_DIR"/*/ 2>/dev/null | head -1 || true
 }
 
 tail_jsonl() {

--- a/scripts/stack-review
+++ b/scripts/stack-review
@@ -1,0 +1,728 @@
+#!/usr/bin/env bash
+# stack-review — collect GOAT review findings across an open PR stack, then
+# filter them against the final stack state with Codex.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+RESULT_ROOT="$REPO_ROOT/history/stack-review"
+STREAM_TEXT='select(.type == "assistant").message.content[]? | select(.type == "text").text // empty | . + "\n"'
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/stack-review run [options]
+  scripts/stack-review discover [options]
+  scripts/stack-review collect --run <run-dir> [--force]
+  scripts/stack-review check-current --run <run-dir> [options]
+  scripts/stack-review summarize --run <run-dir>
+
+Options:
+  --target <branch-or-pr>       Stack target. Defaults to the current branch's PR.
+  --final-branch <branch>       Final code state. Defaults to the last open PR head branch.
+  --context-file <path>         Extra context injected into GOAT and Codex prompts.
+  --prs-file <path>             Fallback explicit PR list, one PR URL or number per line.
+  --out <dir>                   Output run directory. Defaults under history/stack-review/.
+  --run <dir>                   Existing run directory for subcommands.
+  --force                       Rerun steps whose outputs already exist.
+  --no-restore                  For run/check-current, leave repo on the final branch.
+  -h, --help                    Show this help.
+
+Examples:
+  scripts/stack-review run --context-file history/review-context.txt
+  scripts/stack-review run --target 135 --final-branch AIML-767-final
+  scripts/stack-review collect --run history/stack-review/2026-05-26T20-10-00
+EOF
+}
+
+die() {
+  printf 'stack-review: %s\n' "$*" >&2
+  exit 1
+}
+
+log() {
+  printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*" >&2
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+abs_path() {
+  local path="$1"
+  local dir
+  local base
+
+  if [[ "$path" = /* ]]; then
+    printf '%s\n' "$path"
+    return 0
+  fi
+
+  dir="$(dirname -- "$path")"
+  base="$(basename -- "$path")"
+  printf '%s/%s\n' "$(cd "$dir" && pwd)" "$base"
+}
+
+timestamp() {
+  date +%Y-%m-%dT%H-%M-%S
+}
+
+find_pr_tools_scripts() {
+  local scripts_dir
+  scripts_dir="$(find "$HOME/.claude/plugins/cache/Contrast-Security-Inc/pr-tools" -mindepth 2 -maxdepth 2 -type d -name scripts 2>/dev/null | sort -V | tail -1 || true)"
+  [[ -n "$scripts_dir" ]] || die "pr-tools plugin not found. Install via /plugin install pr-tools@Contrast-Security-Inc"
+  [[ -x "$scripts_dir/stacked-pr-facts.sh" || -f "$scripts_dir/stacked-pr-facts.sh" ]] || die "stacked-pr-facts.sh not found in $scripts_dir"
+  printf '%s\n' "$scripts_dir"
+}
+
+ensure_clean_repo() {
+  local status
+  status="$(git -C "$REPO_ROOT" status --porcelain)"
+  [[ -z "$status" ]] || die "repo is not clean; commit/stash/clean changes before running:
+$status"
+}
+
+preflight() {
+  require_command git
+  require_command gh
+  require_command jq
+  require_command claude
+  require_command codex
+  find_pr_tools_scripts >/dev/null
+  gh auth status >/dev/null 2>&1 || die "gh is not authenticated; run gh auth login"
+  if ! command -v gemini >/dev/null 2>&1; then
+    printf 'stack-review: warning: gemini not found; GOAT review should degrade if that leg is unavailable\n' >&2
+  fi
+}
+
+make_run_dir() {
+  local out="$1"
+
+  if [[ -z "$out" ]]; then
+    out="$RESULT_ROOT/$(timestamp)"
+  fi
+
+  mkdir -p "$out"
+  abs_path "$out"
+}
+
+snapshot_context() {
+  local context_file="$1"
+  local run_dir="$2"
+
+  if [[ -n "$context_file" ]]; then
+    [[ -f "$context_file" ]] || die "context file not found: $context_file"
+    cp "$context_file" "$run_dir/context.txt"
+  else
+    : >"$run_dir/context.txt"
+  fi
+}
+
+write_run_config() {
+  local run_dir="$1"
+  local target="$2"
+  local final_branch="$3"
+  local prs_file="$4"
+
+  jq -n \
+    --arg target "$target" \
+    --arg final_branch "$final_branch" \
+    --arg prs_file "$prs_file" \
+    --arg created_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{
+      target: (if $target == "" then null else $target end),
+      final_branch: $final_branch,
+      prs_file: (if $prs_file == "" then null else $prs_file end),
+      created_at: $created_at
+    }' \
+    >"$run_dir/run-config.json"
+}
+
+discover_from_stack() {
+  local target="$1"
+  local run_dir="$2"
+  local pr_tools_scripts
+
+  pr_tools_scripts="$(find_pr_tools_scripts)"
+  log "Discovering PR stack with pr-tools"
+  if [[ -n "$target" ]]; then
+    bash "$pr_tools_scripts/stacked-pr-facts.sh" build-stack "$target" >"$run_dir/stack.json"
+  else
+    bash "$pr_tools_scripts/stacked-pr-facts.sh" build-stack >"$run_dir/stack.json"
+  fi
+
+  jq -c '
+    .nodes[]
+    | select(.number != null)
+    | select(.url != null)
+    | select(.state == "OPEN")
+    | {
+        number,
+        url,
+        title,
+        state,
+        isDraft,
+        headRefName,
+        baseRefName
+      }
+  ' "$run_dir/stack.json" >"$run_dir/review-order.jsonl"
+}
+
+discover_from_prs_file() {
+  local prs_file="$1"
+  local run_dir="$2"
+  local item
+
+  [[ -f "$prs_file" ]] || die "PR list file not found: $prs_file"
+  log "Discovering PRs from $prs_file"
+  jq -n '{source:"prs-file", nodes:[]}' >"$run_dir/stack.json"
+  : >"$run_dir/review-order.jsonl"
+
+  while IFS= read -r item || [[ -n "$item" ]]; do
+    item="${item%%#*}"
+    item="$(printf '%s' "$item" | xargs)"
+    [[ -n "$item" ]] || continue
+
+    gh pr view "$item" \
+      --json number,url,title,state,isDraft,headRefName,baseRefName \
+      --jq 'select(.state == "OPEN") | {number,url,title,state,isDraft,headRefName,baseRefName}' \
+      >>"$run_dir/review-order.jsonl"
+  done <"$prs_file"
+}
+
+infer_final_branch() {
+  local run_dir="$1"
+
+  jq -r 'select(.headRefName != null) | .headRefName' "$run_dir/review-order.jsonl" | tail -1
+}
+
+discover() {
+  local target="$1"
+  local final_branch="$2"
+  local context_file="$3"
+  local prs_file="$4"
+  local out="$5"
+  local run_dir
+  local count
+
+  run_dir="$(make_run_dir "$out")"
+  snapshot_context "$context_file" "$run_dir"
+
+  if [[ -n "$prs_file" ]]; then
+    discover_from_prs_file "$prs_file" "$run_dir"
+  else
+    discover_from_stack "$target" "$run_dir"
+  fi
+
+  count="$(jq -s 'length' "$run_dir/review-order.jsonl")"
+  [[ "$count" -gt 0 ]] || die "no OPEN PRs found to review"
+
+  if [[ -z "$final_branch" ]]; then
+    final_branch="$(infer_final_branch "$run_dir")"
+  fi
+  [[ -n "$final_branch" && "$final_branch" != "null" ]] || die "could not infer final branch"
+
+  write_run_config "$run_dir" "$target" "$final_branch" "$prs_file"
+  log "Discovered $count PR(s)"
+  log "Final branch: $final_branch"
+  log "Run directory: $run_dir"
+  printf '%s\n' "$run_dir"
+}
+
+goat_prompt() {
+  local pr_url="$1"
+  local context_file="$2"
+
+  printf '/goat-review-pr %s\n\n' "$pr_url"
+
+  if [[ -s "$context_file" ]]; then
+    printf '%s\n\n' "$(cat "$context_file")"
+  fi
+
+  cat <<'EOF'
+This is running non-interactively.
+Do not post inline PR comments.
+Do not ask whether to post comments.
+Do not edit files.
+Do not update beads.
+
+After the GOAT REVIEW report, emit a machine-readable issue list.
+
+Use these exact markers:
+
+BEGIN_STACK_REVIEW_ISSUES_JSONL
+<jsonl>
+END_STACK_REVIEW_ISSUES_JSONL
+
+Include findings with Verdict FIX or CONSIDER.
+Exclude findings with Verdict SKIP.
+Emit one valid JSON object per line.
+If there are no included findings, emit no lines between the markers.
+Do not wrap the JSONL in Markdown fences.
+
+Each object must include:
+- severity: CRITICAL, HIGH, MEDIUM, or LOW
+- goat_finding_id
+- goat_verdict: FIX or CONSIDER
+- title
+- file
+- line
+- area
+- description
+- evidence
+- suggested_fix
+- flagged_by
+
+Descriptions must be detailed enough to understand and fix later without rereading the full review.
+EOF
+}
+
+run_claude_goat() {
+  local prompt_file="$1"
+  local raw_file="$2"
+  local text_file="$3"
+  local status
+
+  set +e
+  claude \
+    --permission-mode bypassPermissions \
+    --verbose \
+    --print \
+    --output-format stream-json \
+    -p "$(cat "$prompt_file")" \
+  | { grep --line-buffered '^{' || true; } \
+  | tee "$raw_file" \
+  | jq --unbuffered -rj "$STREAM_TEXT" \
+  | tee "$text_file"
+  status=${PIPESTATUS[0]}
+  set -e
+
+  return "$status"
+}
+
+extract_goat_issues() {
+  local text_file="$1"
+  local raw_issues="$2"
+  local issues_file="$3"
+  local pr_number="$4"
+  local pr_url="$5"
+  local pr_title="$6"
+  local head_branch="$7"
+  local base_branch="$8"
+  local begin_count
+  local end_count
+
+  begin_count="$(grep -c '^BEGIN_STACK_REVIEW_ISSUES_JSONL$' "$text_file" || true)"
+  end_count="$(grep -c '^END_STACK_REVIEW_ISSUES_JSONL$' "$text_file" || true)"
+  [[ "$begin_count" -gt 0 && "$end_count" -gt 0 ]] || die "missing JSONL markers in $text_file"
+
+  awk '
+    /^BEGIN_STACK_REVIEW_ISSUES_JSONL$/ { in_block=1; next }
+    /^END_STACK_REVIEW_ISSUES_JSONL$/ { in_block=0; exit }
+    in_block { print }
+  ' "$text_file" >"$raw_issues"
+
+  if [[ -s "$raw_issues" ]]; then
+    jq -s -e '
+      all(.[]; type == "object"
+        and has("severity")
+        and has("goat_finding_id")
+        and has("goat_verdict")
+        and has("title")
+        and has("file")
+        and has("line")
+        and has("area")
+        and has("description")
+        and has("evidence")
+        and has("suggested_fix")
+        and has("flagged_by"))
+    ' "$raw_issues" >/dev/null || die "invalid GOAT issue schema in $raw_issues"
+
+    jq -c \
+      --argjson pr "$pr_number" \
+      --arg pr_url "$pr_url" \
+      --arg pr_title "$pr_title" \
+      --arg head_branch "$head_branch" \
+      --arg base_branch "$base_branch" \
+      '. + {
+        id: ("pr" + ($pr | tostring) + "-" + (.goat_finding_id | tostring)),
+        pr: $pr,
+        pr_url: $pr_url,
+        pr_title: $pr_title,
+        head_branch: $head_branch,
+        base_branch: $base_branch
+      }' "$raw_issues" >"$issues_file"
+  else
+    : >"$issues_file"
+  fi
+}
+
+collect() {
+  local run_dir="$1"
+  local force="$2"
+  local row
+
+  [[ -d "$run_dir" ]] || die "run directory not found: $run_dir"
+  [[ -f "$run_dir/review-order.jsonl" ]] || die "missing review-order.jsonl in $run_dir"
+  [[ -f "$run_dir/context.txt" ]] || : >"$run_dir/context.txt"
+
+  while IFS= read -r row || [[ -n "$row" ]]; do
+    [[ -n "$row" ]] || continue
+
+    local pr_number pr_url pr_title head_branch base_branch
+    local prefix prompt_file raw_file text_file raw_issues issues_file
+
+    pr_number="$(jq -r '.number' <<<"$row")"
+    pr_url="$(jq -r '.url' <<<"$row")"
+    pr_title="$(jq -r '.title // ""' <<<"$row")"
+    head_branch="$(jq -r '.headRefName // ""' <<<"$row")"
+    base_branch="$(jq -r '.baseRefName // ""' <<<"$row")"
+    prefix="$run_dir/pr-$pr_number"
+    prompt_file="$prefix.prompt.txt"
+    raw_file="$prefix.claude.raw.jsonl"
+    text_file="$prefix.goat.txt"
+    raw_issues="$prefix.issues.raw.jsonl"
+    issues_file="$prefix.issues.jsonl"
+
+    if [[ -f "$issues_file" && "$force" != "true" ]]; then
+      log "Skipping PR #$pr_number; issues file already exists"
+      continue
+    fi
+
+    log "Checking out PR #$pr_number"
+    gh pr checkout "$pr_number"
+
+    goat_prompt "$pr_url" "$run_dir/context.txt" >"$prompt_file"
+
+    log "Running GOAT review for PR #$pr_number"
+    run_claude_goat "$prompt_file" "$raw_file" "$text_file" || die "Claude GOAT review failed for PR #$pr_number"
+    extract_goat_issues "$text_file" "$raw_issues" "$issues_file" "$pr_number" "$pr_url" "$pr_title" "$head_branch" "$base_branch"
+    log "Collected $(jq -s 'length' "$issues_file") issue(s) for PR #$pr_number"
+  done <"$run_dir/review-order.jsonl"
+
+  while IFS= read -r row || [[ -n "$row" ]]; do
+    [[ -n "$row" ]] || continue
+    local pr_number
+    pr_number="$(jq -r '.number' <<<"$row")"
+    [[ -f "$run_dir/pr-$pr_number.issues.jsonl" ]] || die "missing collected issues for PR #$pr_number"
+  done <"$run_dir/review-order.jsonl"
+}
+
+codex_prompt() {
+  local issues_file="$1"
+  local current_file="$2"
+  local uncertain_file="$3"
+  local context_file="$4"
+
+  cat <<EOF
+You are checking whether prior GOAT PR review findings still apply to the current final code.
+
+Input file:
+$issues_file
+
+Write:
+$current_file
+$uncertain_file
+
+EOF
+
+  if [[ -s "$context_file" ]]; then
+    cat "$context_file"
+    printf '\n\n'
+  fi
+
+  cat <<'EOF'
+Rules:
+- Put still-applicable issues in current.
+- Put unclear or maybe-still-applicable issues in uncertain.
+- Omit fixed, obsolete, removed, or no-longer-applicable issues.
+- Preserve the original issue fields.
+- Add current_file, current_line, and current_area if the location changed or can be identified.
+- Write valid JSONL.
+- Do not modify source files.
+EOF
+}
+
+validate_jsonl() {
+  local file="$1"
+  if [[ -s "$file" ]]; then
+    jq -c . "$file" >/dev/null || die "invalid JSONL: $file"
+  fi
+}
+
+run_codex_applicability() {
+  local prompt_file="$1"
+  local raw_file="$2"
+  local status
+
+  set +e
+  codex -a never exec \
+    -p yolo \
+    -C "$REPO_ROOT" \
+    --json \
+    - <"$prompt_file" >"$raw_file" 2>&1
+  status=$?
+  set -e
+
+  return "$status"
+}
+
+check_current() {
+  local run_dir="$1"
+  local final_branch_override="$2"
+  local force="$3"
+  local final_branch
+  local final_sha
+  local row
+
+  [[ -d "$run_dir" ]] || die "run directory not found: $run_dir"
+  [[ -f "$run_dir/review-order.jsonl" ]] || die "missing review-order.jsonl in $run_dir"
+  [[ -f "$run_dir/context.txt" ]] || : >"$run_dir/context.txt"
+
+  if [[ -n "$final_branch_override" ]]; then
+    final_branch="$final_branch_override"
+  else
+    final_branch="$(jq -r '.final_branch // ""' "$run_dir/run-config.json" 2>/dev/null || true)"
+    if [[ -z "$final_branch" || "$final_branch" == "null" ]]; then
+      final_branch="$(infer_final_branch "$run_dir")"
+    fi
+  fi
+  [[ -n "$final_branch" && "$final_branch" != "null" ]] || die "could not determine final branch"
+
+  log "Checking out final branch $final_branch"
+  git -C "$REPO_ROOT" checkout "$final_branch"
+  final_sha="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+
+  jq -n \
+    --arg final_branch "$final_branch" \
+    --arg final_sha "$final_sha" \
+    --arg checked_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{final_branch:$final_branch, final_sha:$final_sha, checked_at:$checked_at}' \
+    >"$run_dir/final-state.json"
+
+  while IFS= read -r row || [[ -n "$row" ]]; do
+    [[ -n "$row" ]] || continue
+
+    local pr_number prefix issues_file current_file uncertain_file prompt_file raw_file
+    pr_number="$(jq -r '.number' <<<"$row")"
+    prefix="$run_dir/pr-$pr_number"
+    issues_file="$prefix.issues.jsonl"
+    current_file="$prefix.current.jsonl"
+    uncertain_file="$prefix.uncertain.jsonl"
+    prompt_file="$prefix.codex.prompt.txt"
+    raw_file="$prefix.codex.raw.jsonl"
+
+    [[ -f "$issues_file" ]] || die "missing issues file for PR #$pr_number: $issues_file"
+
+    if [[ -f "$current_file" && -f "$uncertain_file" && "$force" != "true" ]]; then
+      log "Skipping PR #$pr_number applicability; outputs already exist"
+      continue
+    fi
+
+    if [[ ! -s "$issues_file" ]]; then
+      : >"$current_file"
+      : >"$uncertain_file"
+      log "PR #$pr_number has no issues; wrote empty applicability outputs"
+      continue
+    fi
+
+    codex_prompt "$issues_file" "$current_file" "$uncertain_file" "$run_dir/context.txt" >"$prompt_file"
+    log "Running Codex applicability check for PR #$pr_number"
+    run_codex_applicability "$prompt_file" "$raw_file" || die "Codex applicability check failed for PR #$pr_number"
+
+    [[ -f "$current_file" ]] || die "Codex did not write $current_file"
+    [[ -f "$uncertain_file" ]] || die "Codex did not write $uncertain_file"
+    validate_jsonl "$current_file"
+    validate_jsonl "$uncertain_file"
+  done <"$run_dir/review-order.jsonl"
+}
+
+combine_outputs() {
+  local run_dir="$1"
+  local row
+
+  : >"$run_dir/current-all.jsonl"
+  : >"$run_dir/uncertain-all.jsonl"
+
+  while IFS= read -r row || [[ -n "$row" ]]; do
+    [[ -n "$row" ]] || continue
+    local pr_number
+    pr_number="$(jq -r '.number' <<<"$row")"
+    [[ -f "$run_dir/pr-$pr_number.current.jsonl" ]] || die "missing current output for PR #$pr_number"
+    [[ -f "$run_dir/pr-$pr_number.uncertain.jsonl" ]] || die "missing uncertain output for PR #$pr_number"
+    cat "$run_dir/pr-$pr_number.current.jsonl" >>"$run_dir/current-all.jsonl"
+    cat "$run_dir/pr-$pr_number.uncertain.jsonl" >>"$run_dir/uncertain-all.jsonl"
+  done <"$run_dir/review-order.jsonl"
+
+  validate_jsonl "$run_dir/current-all.jsonl"
+  validate_jsonl "$run_dir/uncertain-all.jsonl"
+}
+
+append_issue_section() {
+  local title="$1"
+  local file="$2"
+  local summary_file="$3"
+  local count
+
+  count="$(jq -s 'length' "$file")"
+  {
+    printf '\n## %s\n\n' "$title"
+    if [[ "$count" -eq 0 ]]; then
+      printf '(none)\n'
+    else
+      for severity in CRITICAL HIGH MEDIUM LOW; do
+        local severity_count
+        severity_count="$(jq -s --arg severity "$severity" '[.[] | select(.severity == $severity)] | length' "$file")"
+        [[ "$severity_count" -gt 0 ]] || continue
+        printf '\n### %s\n\n' "$severity"
+        jq -r --arg severity "$severity" '
+          select(.severity == $severity)
+          | "- `\(.id // "unknown")` `\((.current_file // .file // "unknown")):\((.current_line // .line // "unknown"))` \(.title // "Untitled")\n  PR: #\(.pr // "unknown") | Verdict: \(.goat_verdict // "unknown")\n  Fix: \(.suggested_fix // "")\n"
+        ' "$file"
+      done
+    fi
+  } >>"$summary_file"
+}
+
+summarize() {
+  local run_dir="$1"
+  local summary_file="$run_dir/summary.md"
+  local final_branch=""
+  local final_sha=""
+  local current_count
+  local uncertain_count
+
+  [[ -d "$run_dir" ]] || die "run directory not found: $run_dir"
+  [[ -f "$run_dir/current-all.jsonl" ]] || combine_outputs "$run_dir"
+  [[ -f "$run_dir/uncertain-all.jsonl" ]] || combine_outputs "$run_dir"
+
+  if [[ -f "$run_dir/final-state.json" ]]; then
+    final_branch="$(jq -r '.final_branch // ""' "$run_dir/final-state.json")"
+    final_sha="$(jq -r '.final_sha // ""' "$run_dir/final-state.json")"
+  fi
+
+  current_count="$(jq -s 'length' "$run_dir/current-all.jsonl")"
+  uncertain_count="$(jq -s 'length' "$run_dir/uncertain-all.jsonl")"
+
+  {
+    printf '# Stack Review Summary\n\n'
+    printf "Run directory: \`%s\`\n\n" "$run_dir"
+    if [[ -n "$final_branch" ]]; then
+      printf "Final branch: \`%s\`\n\n" "$final_branch"
+    fi
+    if [[ -n "$final_sha" ]]; then
+      printf "Final SHA: \`%s\`\n\n" "$final_sha"
+    fi
+    printf 'Current issues: %s\n\n' "$current_count"
+    printf 'Uncertain issues: %s\n' "$uncertain_count"
+  } >"$summary_file"
+
+  append_issue_section "Current Issues" "$run_dir/current-all.jsonl" "$summary_file"
+  append_issue_section "Uncertain" "$run_dir/uncertain-all.jsonl" "$summary_file"
+  log "Wrote $summary_file"
+}
+
+restore_branch() {
+  local original_branch="$1"
+  local should_restore="$2"
+
+  [[ "$should_restore" == "true" ]] || return 0
+  [[ -n "$original_branch" ]] || return 0
+  log "Restoring original branch $original_branch"
+  git -C "$REPO_ROOT" checkout "$original_branch"
+}
+
+parse_options() {
+  TARGET=""
+  FINAL_BRANCH=""
+  CONTEXT_FILE=""
+  PRS_FILE=""
+  OUT_DIR=""
+  RUN_DIR=""
+  FORCE="false"
+  RESTORE="true"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --target) TARGET="$2"; shift 2 ;;
+      --final-branch) FINAL_BRANCH="$2"; shift 2 ;;
+      --context-file) CONTEXT_FILE="$2"; shift 2 ;;
+      --prs-file) PRS_FILE="$2"; shift 2 ;;
+      --out) OUT_DIR="$2"; shift 2 ;;
+      --run) RUN_DIR="$2"; shift 2 ;;
+      --force) FORCE="true"; shift ;;
+      --no-restore) RESTORE="false"; shift ;;
+      -h|--help) usage; exit 0 ;;
+      *) die "unknown argument: $1" ;;
+    esac
+  done
+
+  if [[ -n "$RUN_DIR" ]]; then
+    RUN_DIR="$(abs_path "$RUN_DIR")"
+  fi
+  if [[ -n "$CONTEXT_FILE" ]]; then
+    CONTEXT_FILE="$(abs_path "$CONTEXT_FILE")"
+  fi
+  if [[ -n "$PRS_FILE" ]]; then
+    PRS_FILE="$(abs_path "$PRS_FILE")"
+  fi
+}
+
+main() {
+  local command="${1:-}"
+  [[ -n "$command" ]] || { usage; exit 1; }
+  shift || true
+
+  case "$command" in
+    run)
+      parse_options "$@"
+      preflight
+      ensure_clean_repo
+      local original_branch run_dir
+      original_branch="$(git -C "$REPO_ROOT" branch --show-current)"
+      run_dir="$(discover "$TARGET" "$FINAL_BRANCH" "$CONTEXT_FILE" "$PRS_FILE" "$OUT_DIR" | tail -1)"
+      collect "$run_dir" "$FORCE"
+      check_current "$run_dir" "$FINAL_BRANCH" "$FORCE"
+      combine_outputs "$run_dir"
+      summarize "$run_dir"
+      restore_branch "$original_branch" "$RESTORE"
+      log "Complete: $run_dir"
+      ;;
+    discover)
+      parse_options "$@"
+      preflight
+      discover "$TARGET" "$FINAL_BRANCH" "$CONTEXT_FILE" "$PRS_FILE" "$OUT_DIR"
+      ;;
+    collect)
+      parse_options "$@"
+      preflight
+      [[ -n "$RUN_DIR" ]] || die "collect requires --run"
+      collect "$RUN_DIR" "$FORCE"
+      ;;
+    check-current)
+      parse_options "$@"
+      preflight
+      [[ -n "$RUN_DIR" ]] || die "check-current requires --run"
+      local original_branch
+      original_branch="$(git -C "$REPO_ROOT" branch --show-current)"
+      check_current "$RUN_DIR" "$FINAL_BRANCH" "$FORCE"
+      combine_outputs "$RUN_DIR"
+      restore_branch "$original_branch" "$RESTORE"
+      ;;
+    summarize)
+      parse_options "$@"
+      require_command jq
+      [[ -n "$RUN_DIR" ]] || die "summarize requires --run"
+      combine_outputs "$RUN_DIR"
+      summarize "$RUN_DIR"
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      die "unknown command: $command"
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/stack-review
+++ b/scripts/stack-review
@@ -4,7 +4,10 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+INVOCATION_DIR="$(pwd)"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(git -C "$INVOCATION_DIR" rev-parse --show-toplevel 2>/dev/null || printf '%s\n' "$SCRIPT_REPO_ROOT")"
 RESULT_ROOT="$REPO_ROOT/history/stack-review"
 STREAM_TEXT='select(.type == "assistant").message.content[]? | select(.type == "text").text // empty | . + "\n"'
 
@@ -22,6 +25,7 @@ Options:
   --final-branch <branch>       Final code state. Defaults to the last open PR head branch.
   --context-file <path>         Extra context injected into GOAT and Codex prompts.
   --prs-file <path>             Fallback explicit PR list, one PR URL or number per line.
+  --repo <path>                 Target repo. Defaults to the Git repo you run from.
   --out <dir>                   Output run directory. Defaults under history/stack-review/.
   --run <dir>                   Existing run directory for subcommands.
   --force                       Rerun steps whose outputs already exist.
@@ -31,6 +35,7 @@ Options:
 Examples:
   scripts/stack-review run --context-file history/review-context.txt
   scripts/stack-review run --target 135 --final-branch AIML-767-final
+  /path/to/mcp-contrast/scripts/stack-review run --repo /path/to/other-repo
   scripts/stack-review collect --run history/stack-review/2026-05-26T20-10-00
 EOF
 }
@@ -95,6 +100,19 @@ preflight() {
   fi
 }
 
+configure_repo_root() {
+  local repo_path="$1"
+
+  if [[ -n "$repo_path" ]]; then
+    [[ -d "$repo_path" ]] || die "repo path not found: $repo_path"
+    REPO_ROOT="$(git -C "$repo_path" rev-parse --show-toplevel 2>/dev/null)" || die "not a git repo: $repo_path"
+  else
+    REPO_ROOT="$(git -C "$INVOCATION_DIR" rev-parse --show-toplevel 2>/dev/null)" || die "not in a git repo; run from a repo or pass --repo"
+  fi
+
+  RESULT_ROOT="$REPO_ROOT/history/stack-review"
+}
+
 make_run_dir() {
   local out="$1"
 
@@ -146,9 +164,9 @@ discover_from_stack() {
   pr_tools_scripts="$(find_pr_tools_scripts)"
   log "Discovering PR stack with pr-tools"
   if [[ -n "$target" ]]; then
-    bash "$pr_tools_scripts/stacked-pr-facts.sh" build-stack "$target" >"$run_dir/stack.json"
+    (cd "$REPO_ROOT" && bash "$pr_tools_scripts/stacked-pr-facts.sh" build-stack "$target") >"$run_dir/stack.json"
   else
-    bash "$pr_tools_scripts/stacked-pr-facts.sh" build-stack >"$run_dir/stack.json"
+    (cd "$REPO_ROOT" && bash "$pr_tools_scripts/stacked-pr-facts.sh" build-stack) >"$run_dir/stack.json"
   fi
 
   jq -c '
@@ -183,9 +201,9 @@ discover_from_prs_file() {
     item="$(printf '%s' "$item" | xargs)"
     [[ -n "$item" ]] || continue
 
-    gh pr view "$item" \
+    (cd "$REPO_ROOT" && gh pr view "$item" \
       --json number,url,title,state,isDraft,headRefName,baseRefName \
-      --jq 'select(.state == "OPEN") | {number,url,title,state,isDraft,headRefName,baseRefName}' \
+      --jq 'select(.state == "OPEN") | {number,url,title,state,isDraft,headRefName,baseRefName}') \
       >>"$run_dir/review-order.jsonl"
   done <"$prs_file"
 }
@@ -284,12 +302,12 @@ run_claude_goat() {
   local status
 
   set +e
-  claude \
-    --permission-mode bypassPermissions \
-    --verbose \
-    --print \
-    --output-format stream-json \
-    -p "$(cat "$prompt_file")" \
+  (cd "$REPO_ROOT" && claude \
+      --permission-mode bypassPermissions \
+      --verbose \
+      --print \
+      --output-format stream-json \
+      -p "$(cat "$prompt_file")") \
   | { grep --line-buffered '^{' || true; } \
   | tee "$raw_file" \
   | jq --unbuffered -rj "$STREAM_TEXT" \
@@ -390,7 +408,7 @@ collect() {
     fi
 
     log "Checking out PR #$pr_number"
-    gh pr checkout "$pr_number"
+    (cd "$REPO_ROOT" && gh pr checkout "$pr_number")
 
     goat_prompt "$pr_url" "$run_dir/context.txt" >"$prompt_file"
 
@@ -637,6 +655,7 @@ parse_options() {
   FINAL_BRANCH=""
   CONTEXT_FILE=""
   PRS_FILE=""
+  REPO_PATH=""
   OUT_DIR=""
   RUN_DIR=""
   FORCE="false"
@@ -648,6 +667,7 @@ parse_options() {
       --final-branch) FINAL_BRANCH="$2"; shift 2 ;;
       --context-file) CONTEXT_FILE="$2"; shift 2 ;;
       --prs-file) PRS_FILE="$2"; shift 2 ;;
+      --repo) REPO_PATH="$2"; shift 2 ;;
       --out) OUT_DIR="$2"; shift 2 ;;
       --run) RUN_DIR="$2"; shift 2 ;;
       --force) FORCE="true"; shift ;;
@@ -666,6 +686,9 @@ parse_options() {
   if [[ -n "$PRS_FILE" ]]; then
     PRS_FILE="$(abs_path "$PRS_FILE")"
   fi
+  if [[ -n "$REPO_PATH" ]]; then
+    REPO_PATH="$(abs_path "$REPO_PATH")"
+  fi
 }
 
 main() {
@@ -676,6 +699,7 @@ main() {
   case "$command" in
     run)
       parse_options "$@"
+      configure_repo_root "$REPO_PATH"
       preflight
       ensure_clean_repo
       local original_branch run_dir
@@ -690,17 +714,20 @@ main() {
       ;;
     discover)
       parse_options "$@"
+      configure_repo_root "$REPO_PATH"
       preflight
       discover "$TARGET" "$FINAL_BRANCH" "$CONTEXT_FILE" "$PRS_FILE" "$OUT_DIR"
       ;;
     collect)
       parse_options "$@"
+      configure_repo_root "$REPO_PATH"
       preflight
       [[ -n "$RUN_DIR" ]] || die "collect requires --run"
       collect "$RUN_DIR" "$FORCE"
       ;;
     check-current)
       parse_options "$@"
+      configure_repo_root "$REPO_PATH"
       preflight
       [[ -n "$RUN_DIR" ]] || die "check-current requires --run"
       local original_branch


### PR DESCRIPTION
<!-- pr-tools:stacked:v1 -->
<!-- pr-tools:parent-pr=134 -->
<!-- pr-tools:parent-branch=AIML-766-s12-full-tool-parity-release-hardening -->
<!-- pr-tools:parent-base=AIML-765-s11-isolation-load-tests -->
<!-- pr-tools:boundary-commit=b1b2c09e9b1e427297fa64e1a4dc08c24eaff0b0 -->
<!-- pr-tools:managed:start -->
> ⚠️ **DO NOT MERGE** - This PR is stacked on #134. Merge that first.
>
> **Stack Context**
> - Parent PR: #134
> - Parent branch: `AIML-766-s12-full-tool-parity-release-hardening`
> - Promotion target: `AIML-765-s11-isolation-load-tests`
<!-- pr-tools:managed:end -->

> **Reviewer walkthrough:** Run this to open the interactive walkthrough in your browser:
> ```
> gh api 'repos/Contrast-Security-OSS/mcp-contrast/contents/docs/pr-walkthrough/pr-135-support-p3-repos-in-ralph.html?ref=AIML-767-p3-deploy-eks-dbs-pilot' -H "Accept: application/vnd.github.raw" > /tmp/pr-135-walkthrough.html && (open /tmp/pr-135-walkthrough.html || xdg-open /tmp/pr-135-walkthrough.html)
> ```
> Walks through how Ralph and ralph-next-bead are extended to support the four repos needed for Phase 3 cross-repo EKS deployment.


**Jira:** [AIML-767](https://contrast.atlassian.net/browse/AIML-767)

## Summary
Extend Ralph and ralph-next-bead scripts to support the additional repositories needed for Phase 3 cross-repo deployment work (aiml-deployment, contrast-api-gateway).

- Ralph can now select and execute beads labeled with `repo:aiml-deployment` or `repo:contrast-api-gateway`
- ralph-next-bead processes PRs and branch transitions across all four implementation repos

## Why This Change Exists
- Phase 3 (AIML-767) spans four repos: mcp-contrast, aiml-services, aiml-deployment, and contrast-api-gateway
- Ralph was previously hardcoded to only support mcp-contrast and aiml-services
- Without this change, Ralph cannot autonomously pick up deployment and gateway beads

## What Changed
### `scripts/ralph`
- Added `AIML_DEPLOYMENT_REPO` and `CONTRAST_API_GATEWAY_REPO` path constants
- Added `SUPPORTED_REPO_LABELS` array and `is_supported_repo_label()` helper to replace hardcoded case statement for `--repo` validation
- Extended `repo_path_for_label()` to map the two new repo labels to local paths
- Updated prompt template to read CLAUDE.md or AGENTS.md from any implementation repo (not just aiml-services)

### `scripts/ralph-next-bead`
- Added the two new repo path constants
- Replaced hardcoded `process_repo` calls with a `REPOS` array loop so all four repos are processed during bead transitions

## Testing
- Script-level changes only; no compiled code. Verified syntax with `bash -n` on both scripts.


[AIML-767]: https://contrast.atlassian.net/browse/AIML-767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
