### PR TITLE
AIML-822 Hardcode public Artifactory release URL

### DIFF
--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -167,11 +167,9 @@ jobs:
         env:
           CONTRAST_JFROG_URL: ${{ vars.CONTRAST_JFROG_URL }}
           JFROG_OIDC_PROVIDER_NAME: ${{ vars.JFROG_OIDC_PROVIDER_NAME }}
-          CONTRAST_PUBLIC_MAVEN_RELEASE_URL: ${{ vars.CONTRAST_PUBLIC_MAVEN_RELEASE_URL }}
         run: |
           test -n "$CONTRAST_JFROG_URL" || { echo "Missing repository variable CONTRAST_JFROG_URL"; exit 1; }
           test -n "$JFROG_OIDC_PROVIDER_NAME" || { echo "Missing repository variable JFROG_OIDC_PROVIDER_NAME"; exit 1; }
-          test -n "$CONTRAST_PUBLIC_MAVEN_RELEASE_URL" || { echo "Missing repository variable CONTRAST_PUBLIC_MAVEN_RELEASE_URL"; exit 1; }
 
       - name: Set up JFrog CLI
         id: setup-jfrog-cli
@@ -183,7 +181,6 @@ jobs:
 
       - name: Publish contrast-mcp-core to public Artifactory
         env:
-          ORG_GRADLE_PROJECT_contrastPublicMavenReleaseUrl: ${{ vars.CONTRAST_PUBLIC_MAVEN_RELEASE_URL }}
           ORG_GRADLE_PROJECT_contrastArtifactoryUser: ${{ steps.setup-jfrog-cli.outputs.oidc-user }}
           ORG_GRADLE_PROJECT_contrastArtifactoryPassword: ${{ steps.setup-jfrog-cli.outputs.oidc-token }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.CODE_SIGNING_PKEY }}

--- a/contrast-mcp-core/build.gradle
+++ b/contrast-mcp-core/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 }
 
 def publicMavenReleaseRepositoryName = 'contrastPublicRelease'
-def publicMavenReleaseUrl = 'https://contrastsecurity.jfrog.io/artifactory/contrast-mcp-release'
+def publicMavenReleaseUrl = mcpCoreArtifactProperty('publicMavenReleaseUrl')
 
 publishing {
     publications {
@@ -165,6 +165,17 @@ tasks.register('verifyCorePublicationMetadata') {
 }
 
 check.dependsOn tasks.named('verifyCorePublicationMetadata')
+
+String mcpCoreArtifactProperty(String name) {
+    def propertiesFile = rootProject.file('gradle/contrast-mcp-core-artifact.properties')
+    def properties = new Properties()
+    propertiesFile.withInputStream { properties.load(it) }
+    def value = properties.getProperty(name)?.trim()
+    if (!value) {
+        throw new GradleException("Missing required property ${name} in ${propertiesFile.path}")
+    }
+    value
+}
 
 private static String textOf(def xpath, def element, String name) {
     xpath.evaluate("*[local-name()='${name}']/text()", element)

--- a/contrast-mcp-core/build.gradle
+++ b/contrast-mcp-core/build.gradle
@@ -23,11 +23,7 @@ dependencies {
 }
 
 def publicMavenReleaseRepositoryName = 'contrastPublicRelease'
-def publicMavenReleaseUrlPropertyName = 'contrastPublicMavenReleaseUrl'
-def publicMavenReleaseUrlDefault = 'https://contrastsecurity.jfrog.io/artifactory/contrast-mcp-release'
-def configuredPublicMavenReleaseUrl = providers.gradleProperty(publicMavenReleaseUrlPropertyName)
-    .map { it.trim() }
-    .getOrElse(publicMavenReleaseUrlDefault)
+def publicMavenReleaseUrl = 'https://contrastsecurity.jfrog.io/artifactory/contrast-mcp-release'
 
 publishing {
     publications {
@@ -49,7 +45,7 @@ publishing {
     repositories {
         maven {
             name = publicMavenReleaseRepositoryName
-            url = uri(configuredPublicMavenReleaseUrl ?: publicMavenReleaseUrlFallback)
+            url = uri(publicMavenReleaseUrl)
             credentials {
                 username = findProperty('contrastArtifactoryUser') ?: ''
                 password = findProperty('contrastArtifactoryPassword') ?: ''
@@ -81,10 +77,6 @@ tasks.withType(PublishToMavenRepository).configureEach {
         doFirst {
             if (version.toString().endsWith('-SNAPSHOT')) {
                 throw new GradleException('Public Maven release publication requires a non-SNAPSHOT version.')
-            }
-            if (!configuredPublicMavenReleaseUrl) {
-                throw new GradleException(
-                    "Public Maven release publication requires a non-empty ${publicMavenReleaseUrlPropertyName}.")
             }
             if (!signingKey) {
                 throw new GradleException(

--- a/contrast-mcp-core/build.gradle
+++ b/contrast-mcp-core/build.gradle
@@ -24,10 +24,10 @@ dependencies {
 
 def publicMavenReleaseRepositoryName = 'contrastPublicRelease'
 def publicMavenReleaseUrlPropertyName = 'contrastPublicMavenReleaseUrl'
-def publicMavenReleaseUrlFallback = 'https://public-maven-release-url-required.invalid'
+def publicMavenReleaseUrlDefault = 'https://contrastsecurity.jfrog.io/artifactory/contrast-mcp-release'
 def configuredPublicMavenReleaseUrl = providers.gradleProperty(publicMavenReleaseUrlPropertyName)
     .map { it.trim() }
-    .getOrElse('')
+    .getOrElse(publicMavenReleaseUrlDefault)
 
 publishing {
     publications {
@@ -82,12 +82,9 @@ tasks.withType(PublishToMavenRepository).configureEach {
             if (version.toString().endsWith('-SNAPSHOT')) {
                 throw new GradleException('Public Maven release publication requires a non-SNAPSHOT version.')
             }
-            def propertyValue = providers.gradleProperty(publicMavenReleaseUrlPropertyName)
-                .map { it.trim() }
-                .getOrElse('')
-            if (!propertyValue) {
+            if (!configuredPublicMavenReleaseUrl) {
                 throw new GradleException(
-                    "Missing Gradle property ${publicMavenReleaseUrlPropertyName} for remote publication.")
+                    "Public Maven release publication requires a non-empty ${publicMavenReleaseUrlPropertyName}.")
             }
             if (!signingKey) {
                 throw new GradleException(

--- a/gradle/contrast-mcp-core-artifact.properties
+++ b/gradle/contrast-mcp-core-artifact.properties
@@ -1,0 +1,1 @@
+publicMavenReleaseUrl=https://contrastsecurity.jfrog.io/artifactory/contrast-mcp-release


### PR DESCRIPTION
## Summary

Hardcode the non-secret public Maven release repository URL as checked-in build configuration so local Gradle commands and the release workflow do not depend on GitHub repository variables or Gradle property overrides.

Changes:
* Store the public release repository URL once in `gradle/contrast-mcp-core-artifact.properties`.
* Load that URL from `contrast-mcp-core/build.gradle` for the `contrastPublicRelease` Maven repository.
* Remove the `contrastPublicMavenReleaseUrl` Gradle property override path.
* Stop requiring and exporting `CONTRAST_PUBLIC_MAVEN_RELEASE_URL` in `gradle-release.yml`.

## Verification

* `git diff --check`
* YAML parse for `.github/workflows/gradle-release.yml`
* `./gradlew --no-daemon :contrast-mcp-core:verifyCorePublicationMetadata`
* `./gradlew --no-daemon :contrast-mcp-core:publishToMavenLocal`
* `make check-test` passed earlier on this PR: 773 tests, 0 failures, 0 errors, 0 skipped.
* `rg` confirms the full Artifactory URL appears only in `gradle/contrast-mcp-core-artifact.properties`.

## Beads

* `mcp-hiau` closed with verification evidence.
* `mcp-z07v` closed with verification evidence.