### PR TITLE
AIML-853 Fix search attack sort syntax

### DIFF
--- a/MCP_STANDARDS.md
+++ b/MCP_STANDARDS.md
@@ -117,6 +117,15 @@ Tools returning analytical data (reports, coverage, metadata) may use `get_*` ev
 - **Plural** for comma-separated: `severities`, `statuses`, `environments`
 - **Singular** for single values: `appId`, `keyword`, `sort`
 
+### Sort Convention
+- Use a single optional `sort` string parameter when a tool exposes caller-controlled ordering.
+- Public MCP sort syntax is `property,DIRECTION`.
+- Valid directions are `ASC` and `DESC`.
+- Validate the property with a tool-specific allowlist before calling downstream services.
+- Translate to backend-specific sort syntax inside the tool/client adapter. Do not expose backend-specific conventions such as `-property`, `sortBy` + `sortDirection`, or raw cursor sort internals as the MCP-facing contract.
+
+**Example:** `sort="startTime,DESC"`
+
 ### Required vs Optional
 - `@NonNull` - required
 - `@Nullable` - optional

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksTool.java
@@ -116,9 +116,8 @@ public class SearchAttacksTool extends PaginatedTool<AttackFilterParams, AttackS
           Boolean includeIpBlacklist,
       @ToolParam(
               description =
-                  "Sort field for ordering results. Valid fields: sourceIP, status, startTime,"
-                      + " endTime, type. Use '-' prefix for descending order (e.g., '-startTime')."
-                      + " Default: -startTime",
+                  "Sort as property,DIRECTION. Valid properties: sourceIP, status, startTime,"
+                      + " endTime, type. Valid directions: ASC, DESC. Default: startTime,DESC",
               required = false)
           String sort,
       @ToolParam(

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParams.java
@@ -18,8 +18,11 @@ package com.contrast.labs.ai.mcp.contrast.tool.attack.params;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.adr.AttacksFilterBody;
 import com.contrast.labs.ai.mcp.contrast.tool.base.BaseToolParams;
 import com.contrast.labs.ai.mcp.contrast.tool.validation.ToolValidationContext;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.Getter;
 import org.springframework.util.StringUtils;
 
@@ -30,7 +33,7 @@ import org.springframework.util.StringUtils;
  * <p>Usage:
  *
  * <pre>{@code
- * var params = AttackFilterParams.of("ACTIVE", "EXPLOITED", "sql", false, null, null, "-startTime");
+ * var params = AttackFilterParams.of("ACTIVE", "EXPLOITED", "sql", false, null, null, "startTime,DESC");
  * if (!params.isValid()) {
  *   // Handle errors
  * }
@@ -50,11 +53,13 @@ public class AttackFilterParams extends BaseToolParams {
           "EXPLOITED", "PROBED", "BLOCKED", "BLOCKED_PERIMETER", "PROBED_PERIMETER", "SUSPICIOUS");
 
   /**
-   * Valid sort fields for attacks API (from TeamServer NgAttackRestController). Use '-' prefix for
-   * descending order. Default is -startTime when not specified.
+   * Valid sort fields for attacks API (from TeamServer NgAttackRestController). MCP callers use
+   * property,DIRECTION. Default is startTime,DESC when not specified.
    */
   public static final Set<String> VALID_SORT_FIELDS =
       Set.of("sourceIP", "status", "startTime", "endTime", "type");
+
+  private static final Set<String> VALID_SORT_DIRECTIONS = Set.of("ASC", "DESC");
 
   private String quickFilter;
   private List<String> statusFilters;
@@ -77,7 +82,7 @@ public class AttackFilterParams extends BaseToolParams {
    * @param includeSuppressed Include suppressed attacks (null = use smart default of false)
    * @param includeBotBlockers Include bot blocker attacks
    * @param includeIpBlacklist Include IP blacklist attacks
-   * @param sort Sort field (e.g., "startTime", "-startTime" for descending)
+   * @param sort Sort field (e.g., "startTime,DESC")
    * @param rules Comma-separated list of rule IDs (e.g., "sql-injection,xss-reflected")
    * @return AttackFilterParams with validation state
    */
@@ -127,29 +132,44 @@ public class AttackFilterParams extends BaseToolParams {
     params.includeBotBlockers = includeBotBlockers;
     params.includeIpBlacklist = includeIpBlacklist;
 
-    // Parse sort with allowlist validation (case-sensitive to match API)
-    if (StringUtils.hasText(sort)) {
-      String trimmedSort = sort.trim();
-      // Extract base field (strip '-' prefix for validation)
-      String baseField = trimmedSort.startsWith("-") ? trimmedSort.substring(1) : trimmedSort;
-
-      if (VALID_SORT_FIELDS.contains(baseField)) {
-        params.sort = trimmedSort;
-      } else {
-        ctx.errorIf(
-            true,
-            String.format(
-                "Invalid sort field '%s'. Valid fields: %s. Use '-' prefix for descending order"
-                    + " (e.g., '-startTime'). Default: -startTime",
-                baseField, VALID_SORT_FIELDS.stream().sorted().toList()));
-      }
-    }
+    params.sort = parseSort(ctx, sort);
 
     // Parse rules (comma-separated list of rule IDs)
     params.rules = ctx.stringListParam(rules, "rules").get();
 
     params.setValidationResult(ctx);
     return params;
+  }
+
+  private static String parseSort(ToolValidationContext ctx, String sort) {
+    if (!StringUtils.hasText(sort)) {
+      return null;
+    }
+
+    var trimmedSort = sort.trim();
+    var parts = Arrays.stream(trimmedSort.split(",", -1)).map(String::trim).toList();
+    if (parts.size() != 2) {
+      ctx.errorIf(true, sortError(trimmedSort));
+      return null;
+    }
+
+    var property = parts.getFirst();
+    var direction = parts.get(1).toUpperCase(Locale.ROOT);
+    var valid = VALID_SORT_FIELDS.contains(property) && VALID_SORT_DIRECTIONS.contains(direction);
+    if (!valid) {
+      ctx.errorIf(true, sortError(trimmedSort));
+      return null;
+    }
+    return "DESC".equals(direction) ? "-" + property : property;
+  }
+
+  private static String sortError(String sort) {
+    return String.format(
+        "Invalid sort: '%s'. Expected format: property,DIRECTION. Valid properties: %s. Valid"
+            + " directions: %s.",
+        sort,
+        VALID_SORT_FIELDS.stream().sorted().collect(Collectors.joining(", ")),
+        VALID_SORT_DIRECTIONS.stream().sorted().collect(Collectors.joining(", ")));
   }
 
   /**

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParams.java
@@ -24,6 +24,8 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.Getter;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 
 /**
@@ -67,7 +69,7 @@ public class AttackFilterParams extends BaseToolParams {
   private Boolean includeSuppressed;
   private Boolean includeBotBlockers;
   private Boolean includeIpBlacklist;
-  private String sort;
+  @Nullable private String sort;
   private List<String> rules;
 
   /** Private constructor - use static factory method {@link #of}. */
@@ -141,7 +143,8 @@ public class AttackFilterParams extends BaseToolParams {
     return params;
   }
 
-  private static String parseSort(ToolValidationContext ctx, String sort) {
+  private static @Nullable String parseSort(
+      @NonNull ToolValidationContext ctx, @Nullable String sort) {
     if (!StringUtils.hasText(sort)) {
       return null;
     }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksToolTest.java
@@ -74,7 +74,7 @@ class SearchAttacksToolTest {
             true,
             false,
             true,
-            "-status",
+            "status,DESC",
             "sql-injection",
             null);
 
@@ -114,7 +114,7 @@ class SearchAttacksToolTest {
 
     var result =
         tool.searchAttacks(
-            1, 10, null, null, null, null, null, null, "-startTime", null, toolContext);
+            1, 10, null, null, null, null, null, null, "startTime,DESC", null, toolContext);
     Method method =
         SearchAttacksTool.class.getDeclaredMethod(
             "searchAttacks",
@@ -154,7 +154,8 @@ class SearchAttacksToolTest {
         .thenReturn(response);
 
     var result =
-        tool.searchAttacks(1, 250, null, null, null, null, null, null, "-startTime", null, null);
+        tool.searchAttacks(
+            1, 250, null, null, null, null, null, null, "startTime,DESC", null, null);
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.pageSize()).isEqualTo(100);
@@ -168,7 +169,8 @@ class SearchAttacksToolTest {
     when(contrastApiClient.searchAttacks(any(), eq(50), eq(0), eq("-startTime"))).thenReturn(null);
 
     var result =
-        tool.searchAttacks(1, null, null, null, null, null, null, null, "-startTime", null, null);
+        tool.searchAttacks(
+            1, null, null, null, null, null, null, null, "startTime,DESC", null, null);
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.items()).isEmpty();
@@ -181,7 +183,7 @@ class SearchAttacksToolTest {
         .thenThrow(apiFailure(403));
 
     var result =
-        tool.searchAttacks(1, 10, null, null, null, null, null, null, "-startTime", null, null);
+        tool.searchAttacks(1, 10, null, null, null, null, null, null, "startTime,DESC", null, null);
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors())
@@ -197,7 +199,7 @@ class SearchAttacksToolTest {
         .thenThrow(apiFailure(429));
 
     var result =
-        tool.searchAttacks(1, 10, null, null, null, null, null, null, "-startTime", null, null);
+        tool.searchAttacks(1, 10, null, null, null, null, null, null, "startTime,DESC", null, null);
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors()).containsExactly("Rate limit exceeded. Retry after a brief pause.");
@@ -210,7 +212,7 @@ class SearchAttacksToolTest {
         .thenThrow(apiFailure(503));
 
     var result =
-        tool.searchAttacks(1, 10, null, null, null, null, null, null, "-startTime", null, null);
+        tool.searchAttacks(1, 10, null, null, null, null, null, null, "startTime,DESC", null, null);
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors())

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParamsTest.java
@@ -17,14 +17,31 @@ package com.contrast.labs.ai.mcp.contrast.tool.attack.params;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.contrast.labs.ai.mcp.contrast.tool.validation.ToolValidationContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 
 /** Unit tests for AttackFilterParams validation. */
 class AttackFilterParamsTest {
 
   // ========== Valid Input Tests ==========
+
+  @Test
+  void parseSort_should_document_nullability_contract() throws Exception {
+    var parseSort =
+        AttackFilterParams.class.getDeclaredMethod(
+            "parseSort", ToolValidationContext.class, String.class);
+
+    assertThat(parseSort.isAnnotationPresent(Nullable.class)).isTrue();
+    assertThat(parseSort.getParameters()[0].isAnnotationPresent(NonNull.class)).isTrue();
+    assertThat(parseSort.getParameters()[1].isAnnotationPresent(Nullable.class)).isTrue();
+    assertThat(
+            AttackFilterParams.class.getDeclaredField("sort").isAnnotationPresent(Nullable.class))
+        .isTrue();
+  }
 
   @Test
   void of_should_accept_null_filters_with_defaults() {

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParamsTest.java
@@ -114,120 +114,108 @@ class AttackFilterParamsTest {
   class SortFieldValidationTests {
 
     @Test
-    void of_should_accept_all_valid_sort_fields() {
-      for (String field : AttackFilterParams.VALID_SORT_FIELDS) {
-        var params = AttackFilterParams.of(null, null, null, null, null, null, field, null);
-        assertThat(params.isValid()).as("Sort field '%s' should be valid", field).isTrue();
-        assertThat(params.getSort()).isEqualTo(field);
-      }
+    void of_should_accept_canonical_property_direction_sort() {
+      var ascending = AttackFilterParams.of(null, null, null, null, null, null, "status,ASC", null);
+      var descending =
+          AttackFilterParams.of(null, null, null, null, null, null, "status,DESC", null);
+
+      assertThat(ascending.isValid()).isTrue();
+      assertThat(ascending.getSort()).isEqualTo("status");
+      assertThat(descending.isValid()).isTrue();
+      assertThat(descending.getSort()).isEqualTo("-status");
     }
 
     @Test
-    void of_should_accept_all_valid_sort_fields_with_descending_prefix() {
-      for (String field : AttackFilterParams.VALID_SORT_FIELDS) {
-        String descending = "-" + field;
-        var params = AttackFilterParams.of(null, null, null, null, null, null, descending, null);
-        assertThat(params.isValid()).as("Sort field '%s' should be valid", descending).isTrue();
-        assertThat(params.getSort()).isEqualTo(descending);
-      }
-    }
-
-    @Test
-    void of_should_accept_startTime_ascending() {
-      var params = AttackFilterParams.of(null, null, null, null, null, null, "startTime", null);
-
-      assertThat(params.isValid()).isTrue();
-      assertThat(params.getSort()).isEqualTo("startTime");
-    }
-
-    @Test
-    void of_should_accept_startTime_descending() {
-      var params = AttackFilterParams.of(null, null, null, null, null, null, "-startTime", null);
+    void of_should_trim_and_normalize_canonical_sort_direction() {
+      var params =
+          AttackFilterParams.of(null, null, null, null, null, null, "  startTime , desc  ", null);
 
       assertThat(params.isValid()).isTrue();
       assertThat(params.getSort()).isEqualTo("-startTime");
     }
 
     @Test
-    void of_should_accept_endTime() {
-      var params = AttackFilterParams.of(null, null, null, null, null, null, "endTime", null);
+    void of_should_accept_all_valid_sort_fields_with_canonical_direction() {
+      for (String field : AttackFilterParams.VALID_SORT_FIELDS) {
+        var ascending =
+            AttackFilterParams.of(null, null, null, null, null, null, field + ",ASC", null);
+        var descending =
+            AttackFilterParams.of(null, null, null, null, null, null, field + ",DESC", null);
 
-      assertThat(params.isValid()).isTrue();
-      assertThat(params.getSort()).isEqualTo("endTime");
+        assertThat(ascending.isValid()).as("Sort field '%s,ASC' should be valid", field).isTrue();
+        assertThat(ascending.getSort()).isEqualTo(field);
+        assertThat(descending.isValid()).as("Sort field '%s,DESC' should be valid", field).isTrue();
+        assertThat(descending.getSort()).isEqualTo("-" + field);
+      }
     }
 
     @Test
-    void of_should_accept_status() {
+    void of_should_reject_sort_without_direction() {
       var params = AttackFilterParams.of(null, null, null, null, null, null, "status", null);
 
-      assertThat(params.isValid()).isTrue();
-      assertThat(params.getSort()).isEqualTo("status");
+      assertThat(params.isValid()).isFalse();
+      assertThat(params.errors().get(0))
+          .contains("Invalid sort")
+          .contains("Expected format: property,DIRECTION");
     }
 
     @Test
-    void of_should_accept_sourceIP() {
-      var params = AttackFilterParams.of(null, null, null, null, null, null, "sourceIP", null);
-
-      assertThat(params.isValid()).isTrue();
-      assertThat(params.getSort()).isEqualTo("sourceIP");
-    }
-
-    @Test
-    void of_should_accept_type() {
-      var params = AttackFilterParams.of(null, null, null, null, null, null, "type", null);
-
-      assertThat(params.isValid()).isTrue();
-      assertThat(params.getSort()).isEqualTo("type");
-    }
-
-    @Test
-    void of_should_reject_severity_not_valid_sort_field() {
-      var params = AttackFilterParams.of(null, null, null, null, null, null, "severity", null);
+    void of_should_reject_sort_with_descending_prefix() {
+      var params = AttackFilterParams.of(null, null, null, null, null, null, "-status", null);
 
       assertThat(params.isValid()).isFalse();
-      assertThat(params.errors().get(0)).contains("Invalid sort field").contains("severity");
+      assertThat(params.errors().get(0))
+          .contains("Invalid sort")
+          .contains("Expected format: property,DIRECTION");
     }
 
     @Test
-    void of_should_reject_probes_not_valid_sort_field() {
-      var params = AttackFilterParams.of(null, null, null, null, null, null, "probes", null);
+    void of_should_reject_invalid_canonical_sort_direction() {
+      var params = AttackFilterParams.of(null, null, null, null, null, null, "status,DOWN", null);
 
       assertThat(params.isValid()).isFalse();
-      assertThat(params.errors()).anyMatch(e -> e.contains("Invalid sort field"));
+      assertThat(params.errors().get(0))
+          .contains("Invalid sort")
+          .contains("Expected format: property,DIRECTION")
+          .contains("ASC")
+          .contains("DESC");
     }
 
     @Test
-    void of_should_reject_invalid_field_with_descending_prefix() {
-      var params = AttackFilterParams.of(null, null, null, null, null, null, "-invalidField", null);
+    void of_should_reject_canonical_sort_with_too_many_parts() {
+      var params =
+          AttackFilterParams.of(null, null, null, null, null, null, "status,DESC,startTime", null);
 
       assertThat(params.isValid()).isFalse();
-      assertThat(params.errors().get(0)).contains("Invalid sort field").contains("invalidField");
+      assertThat(params.errors().get(0)).contains("Invalid sort").contains("status,DESC,startTime");
     }
 
     @Test
     void of_should_be_case_sensitive_starttime_lowercase_invalid() {
       // API is case-sensitive - must match exact camelCase
-      var params = AttackFilterParams.of(null, null, null, null, null, null, "starttime", null);
+      var params =
+          AttackFilterParams.of(null, null, null, null, null, null, "starttime,DESC", null);
 
       assertThat(params.isValid()).isFalse();
-      assertThat(params.errors()).anyMatch(e -> e.contains("Invalid sort field"));
+      assertThat(params.errors()).anyMatch(e -> e.contains("Invalid sort"));
     }
 
     @Test
     void of_should_be_case_sensitive_STARTTIME_uppercase_invalid() {
-      var params = AttackFilterParams.of(null, null, null, null, null, null, "STARTTIME", null);
+      var params =
+          AttackFilterParams.of(null, null, null, null, null, null, "STARTTIME,DESC", null);
 
       assertThat(params.isValid()).isFalse();
-      assertThat(params.errors()).anyMatch(e -> e.contains("Invalid sort field"));
+      assertThat(params.errors()).anyMatch(e -> e.contains("Invalid sort"));
     }
 
     @Test
     void of_should_include_valid_fields_in_error_message() {
-      var params = AttackFilterParams.of(null, null, null, null, null, null, "badField", null);
+      var params = AttackFilterParams.of(null, null, null, null, null, null, "badField,DESC", null);
 
       assertThat(params.isValid()).isFalse();
       assertThat(params.errors().get(0))
-          .contains("Valid fields:")
+          .contains("Valid properties:")
           .contains("startTime")
           .contains("endTime")
           .contains("status")
@@ -237,11 +225,11 @@ class AttackFilterParamsTest {
 
     @Test
     void of_should_list_valid_fields_in_alphabetical_order() {
-      var params = AttackFilterParams.of(null, null, null, null, null, null, "badField", null);
+      var params = AttackFilterParams.of(null, null, null, null, null, null, "badField,DESC", null);
 
       assertThat(params.isValid()).isFalse();
       // Verify fields are in consistent alphabetical order for predictable UX
-      assertThat(params.errors().get(0)).contains("[endTime, sourceIP, startTime, status, type]");
+      assertThat(params.errors().get(0)).contains("endTime, sourceIP, startTime, status, type");
     }
 
     @Test
@@ -270,7 +258,8 @@ class AttackFilterParamsTest {
 
     @Test
     void of_should_trim_whitespace_from_valid_sort() {
-      var params = AttackFilterParams.of(null, null, null, null, null, null, "  startTime  ", null);
+      var params =
+          AttackFilterParams.of(null, null, null, null, null, null, "  startTime,ASC  ", null);
 
       assertThat(params.isValid()).isTrue();
       assertThat(params.getSort()).isEqualTo("startTime");
@@ -280,7 +269,8 @@ class AttackFilterParamsTest {
   @Test
   void of_should_accept_combined_valid_filters() {
     var params =
-        AttackFilterParams.of("EFFECTIVE", "EXPLOITED", "xss", true, true, false, "-status", null);
+        AttackFilterParams.of(
+            "EFFECTIVE", "EXPLOITED", "xss", true, true, false, "status,DESC", null);
 
     assertThat(params.isValid()).isTrue();
     assertThat(params.getQuickFilter()).isEqualTo("EFFECTIVE");
@@ -316,14 +306,14 @@ class AttackFilterParamsTest {
   void of_should_collect_multiple_errors() {
     var params =
         AttackFilterParams.of(
-            "BAD_FILTER", "BAD_STATUS", null, null, null, null, "invalidField", null);
+            "BAD_FILTER", "BAD_STATUS", null, null, null, null, "invalidField,DESC", null);
 
     assertThat(params.isValid()).isFalse();
     assertThat(params.errors()).hasSize(3);
     assertThat(params.errors())
         .anyMatch(e -> e.contains("Invalid quickFilter"))
         .anyMatch(e -> e.contains("Invalid statusFilter"))
-        .anyMatch(e -> e.contains("Invalid sort field"));
+        .anyMatch(e -> e.contains("Invalid sort"));
   }
 
   // ========== SDK Conversion Tests ==========
@@ -331,7 +321,8 @@ class AttackFilterParamsTest {
   @Test
   void toAttacksFilterBody_should_convert_all_filters() {
     var params =
-        AttackFilterParams.of("EFFECTIVE", "BLOCKED", "sql", false, true, false, "-status", null);
+        AttackFilterParams.of(
+            "EFFECTIVE", "BLOCKED", "sql", false, true, false, "status,DESC", null);
 
     var filterBody = params.toAttacksFilterBody();
 

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksLocalParityTest.java
@@ -74,7 +74,7 @@ class SearchAttacksLocalParityTest {
 
     var result =
         tool.searchAttacks(
-            3, 25, "ACTIVE", "EXPLOITED", "SQL", true, false, true, "-status", "sql-injection");
+            3, 25, "ACTIVE", "EXPLOITED", "SQL", true, false, true, "status,DESC", "sql-injection");
     var responseJson = objectMapper.writeValueAsString(result);
 
     var filterCaptor = ArgumentCaptor.forClass(AttacksFilterBody.class);

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksToolIT.java
@@ -159,7 +159,7 @@ class SearchAttacksToolIT {
   void searchAttacks_should_handle_sort() {
     var response =
         searchAttacksTool.searchAttacks(
-            1, 10, null, null, null, null, null, null, "-startTime", null);
+            1, 10, null, null, null, null, null, null, "startTime,DESC", null);
 
     assertThat(response).as("Response should not be null").isNotNull();
     assertThat(response.errors()).as("Should have no errors").isEmpty();
@@ -167,7 +167,7 @@ class SearchAttacksToolIT {
         .as("requires seeded attacks to verify sort order — see INTEGRATION_TESTS.md")
         .isNotEmpty();
     assertThat(response.items())
-        .as("sort=-startTime must return items ordered by startTimeMs descending")
+        .as("sort=startTime,DESC must return items ordered by startTimeMs descending")
         .isSortedAccordingTo(Comparator.comparingLong(AttackSummary::startTimeMs).reversed());
   }
 
@@ -252,16 +252,16 @@ class SearchAttacksToolIT {
     // validation error listing valid options, NOT a generic "Contrast API error"
     var response =
         searchAttacksTool.searchAttacks(
-            1, 10, null, null, null, null, null, null, "severity", null);
+            1, 10, null, null, null, null, null, null, "severity,DESC", null);
 
     assertThat(response).as("Response should not be null").isNotNull();
     assertThat(response.errors()).as("Should have validation errors").isNotEmpty();
     assertThat(response.errors())
-        .as("Should contain 'Invalid sort field' not generic API error")
-        .anyMatch(e -> e.contains("Invalid sort field"));
+        .as("Should contain 'Invalid sort' not generic API error")
+        .anyMatch(e -> e.contains("Invalid sort"));
     assertThat(response.errors())
         .as("Should list valid sort fields")
-        .anyMatch(e -> e.contains("Valid fields:"));
+        .anyMatch(e -> e.contains("Valid properties:"));
     assertThat(response.errors())
         .as("Error message should NOT be generic API error")
         .noneMatch(e -> e.contains("Contrast API error"));
@@ -271,17 +271,19 @@ class SearchAttacksToolIT {
   @ValueSource(strings = {"sourceIP", "status", "startTime", "endTime", "type"})
   void searchAttacks_should_accept_all_valid_sort_fields(String sortField) {
     var response =
-        searchAttacksTool.searchAttacks(1, 10, null, null, null, null, null, null, sortField, null);
+        searchAttacksTool.searchAttacks(
+            1, 10, null, null, null, null, null, null, sortField + ",ASC", null);
 
     assertThat(response).as("Response should not be null").isNotNull();
     assertThat(response.errors()).as("Should have no errors for sort: " + sortField).isEmpty();
     assertThat(response.items()).as("Items should not be null").isNotNull();
   }
 
-  @ParameterizedTest(name = "valid sort field descending: -{0}")
+  @ParameterizedTest(name = "valid sort field descending: {0},DESC")
   @ValueSource(strings = {"sourceIP", "status", "startTime", "endTime", "type"})
-  void searchAttacks_should_accept_all_valid_sort_fields_with_descending_prefix(String sortField) {
-    String descending = "-" + sortField;
+  void searchAttacks_should_accept_all_valid_sort_fields_with_descending_direction(
+      String sortField) {
+    String descending = sortField + ",DESC";
     var response =
         searchAttacksTool.searchAttacks(
             1, 10, null, null, null, null, null, null, descending, null);
@@ -292,7 +294,16 @@ class SearchAttacksToolIT {
   }
 
   @ParameterizedTest(name = "invalid sort field: {0}")
-  @ValueSource(strings = {"severity", "probes", "NEWEST", "OLDEST", "invalidField"})
+  @ValueSource(
+      strings = {
+        "severity,DESC",
+        "probes,DESC",
+        "NEWEST,DESC",
+        "OLDEST,DESC",
+        "invalidField,DESC",
+        "status",
+        "-status"
+      })
   void searchAttacks_should_reject_invalid_sort_fields(String sortField) {
     var response =
         searchAttacksTool.searchAttacks(1, 10, null, null, null, null, null, null, sortField, null);
@@ -303,7 +314,7 @@ class SearchAttacksToolIT {
         .isNotEmpty();
     assertThat(response.errors())
         .as("Should be validation error not API error")
-        .anyMatch(e -> e.contains("Invalid sort field"));
+        .anyMatch(e -> e.contains("Invalid sort"));
   }
 
   // ========== Keyword and Rules Parameter Tests (Bug Fix: AIML-385) ==========

--- a/test-plans/test-plan-search_attacks.md
+++ b/test-plans/test-plan-search_attacks.md
@@ -34,7 +34,7 @@ Search for attacks from Contrast ADR with flexible filtering, pagination, and so
 | `includeIpBlacklist` | Boolean | Include attacks from blacklisted IPs | false |
 | `page` | Integer | Page number (1-indexed) | null (no pagination) |
 | `pageSize` | Integer | Results per page | 25 |
-| `sort` | String | Sort field with optional `-` prefix for descending. Valid: `startTime`, `endTime`, `sourceIP`, `status`, `type` | "-startTime" |
+| `sort` | String | Sort as `property,DIRECTION`. Valid properties: `startTime`, `endTime`, `sourceIP`, `status`, `type`. Valid directions: `ASC`, `DESC` | `startTime,DESC` |
 
 ### Response Structure: AttackSummary
 
@@ -84,7 +84,7 @@ Search for attacks from Contrast ADR with flexible filtering, pagination, and so
 - Returns list of AttackSummary objects
 - Uses default `status="ALL"`
 - Uses default `includeSuppressed=false`, `includeBotBlockers=false`, `includeIpBlacklist=false`
-- Uses default `sort="-startTime"` (most recent first)
+- Uses default `sort="startTime,DESC"` (most recent first)
 - No pagination (returns all matching attacks)
 - Each AttackSummary contains all required fields
 
@@ -576,10 +576,10 @@ Test sequence:
 
 ### 6. Sorting
 
-#### Test Case 6.1: Sort - "-startTime" (Default, Descending)
+#### Test Case 6.1: Sort - "startTime,DESC" (Default, Descending)
 **Objective:** Sort by newest attacks first (descending start time).
 
-**Parameters:** `sort="-startTime"`
+**Parameters:** `sort="startTime,DESC"`
 
 **Expected Result:**
 - Returns attacks ordered by most recent first
@@ -589,10 +589,10 @@ Test sequence:
 
 ---
 
-#### Test Case 6.2: Sort - "startTime" (Ascending)
+#### Test Case 6.2: Sort - "startTime,ASC" (Ascending)
 **Objective:** Sort by oldest attacks first (ascending start time).
 
-**Parameters:** `sort="startTime"`
+**Parameters:** `sort="startTime,ASC"`
 
 **Expected Result:**
 - Returns attacks ordered by oldest first
@@ -602,10 +602,10 @@ Test sequence:
 
 ---
 
-#### Test Case 6.3: Sort - "status"
+#### Test Case 6.3: Sort - "status,ASC" and "status,DESC"
 **Objective:** Sort by attack status.
 
-**Parameters:** `sort="status"` or `sort="-status"`
+**Parameters:** `sort="status,ASC"` or `sort="status,DESC"`
 
 **Expected Result:**
 - Returns attacks ordered by status field
@@ -614,10 +614,10 @@ Test sequence:
 
 ---
 
-#### Test Case 6.4: Sort - "sourceIP"
+#### Test Case 6.4: Sort - "sourceIP,ASC" and "sourceIP,DESC"
 **Objective:** Sort by source IP address.
 
-**Parameters:** `sort="sourceIP"` or `sort="-sourceIP"`
+**Parameters:** `sort="sourceIP,ASC"` or `sort="sourceIP,DESC"`
 
 **Expected Result:**
 - Returns attacks ordered by source IP address
@@ -632,18 +632,20 @@ Test sequence:
 **Parameters:**
 ```
 Test cases:
-- sort="INVALID"
-- sort="invalid"
-- sort="UNKNOWN_SORT"
-- sort="severity" (not supported)
-- sort="probes" (not supported)
+- sort="INVALID,DESC"
+- sort="invalid,DESC"
+- sort="UNKNOWN_SORT,DESC"
+- sort="severity,DESC" (not supported)
+- sort="probes,DESC" (not supported)
+- sort="startTime," (missing direction)
+- sort="DESC" (missing property)
 ```
 
 **Expected Result:**
 - Returns validation error (not generic API error)
-- Error message lists valid sort fields: `startTime`, `endTime`, `sourceIP`, `status`, `type`
-- Error explains `-` prefix convention for descending order
-- Example: "Invalid sort field 'INVALID'. Valid fields: [endTime, sourceIP, startTime, status, type]. Use '-' prefix for descending order (e.g., '-startTime')."
+- Error message lists valid sort properties: `startTime`, `endTime`, `sourceIP`, `status`, `type`
+- Error explains `property,DIRECTION` format and valid directions: `ASC`, `DESC`
+- Example: "Invalid sort: 'INVALID,DESC'. Expected format: property,DIRECTION. Valid properties: endTime, sourceIP, startTime, status, type. Valid directions: ASC, DESC."
 
 ---
 
@@ -653,9 +655,9 @@ Test cases:
 **Parameters:** `sort=null` (or omit parameter)
 
 **Expected Result:**
-- Uses default sort order (`-startTime`)
+- Uses default sort order (`startTime,DESC`)
 - Results sorted by most recent first (descending start time)
-- Same behavior as explicitly passing `sort="-startTime"`
+- Same behavior as explicitly passing `sort="startTime,DESC"`
 
 ---
 
@@ -664,7 +666,7 @@ Test cases:
 
 **Parameters:**
 ```
-sort="-startTime"
+sort="startTime,DESC"
 page=1
 pageSize=10
 ```
@@ -1194,7 +1196,7 @@ pageSize=5
 ```
 status="BLOCKED"
 keyword="sql"
-sort="-startTime"
+sort="startTime,DESC"
 ```
 
 **Expected Result:**
@@ -1216,7 +1218,7 @@ includeBotBlockers=false
 includeIpBlacklist=false
 page=2
 pageSize=20
-sort="-startTime"
+sort="startTime,DESC"
 ```
 
 **Expected Result:**
@@ -1236,7 +1238,7 @@ includeBotBlockers=true
 includeIpBlacklist=true
 page=1
 pageSize=10
-sort="-startTime"
+sort="startTime,DESC"
 ```
 
 **Expected Result:**
@@ -1373,7 +1375,7 @@ Test cases:
 status="PROBED"
 keyword="sql"
 includeSuppressed=true
-sort="-startTime"
+sort="startTime,DESC"
 ```
 
 **Expected Result:**


### PR DESCRIPTION
**Jira:** [AIML-853](https://contrast.atlassian.net/browse/AIML-853)

## Summary
Align the `search_attacks` sort parameter with the `property,DIRECTION` convention used by all other MCP tools, replacing the inconsistent `-prefix` descending syntax.

- AI agents no longer need to learn a one-off sort convention for attacks
- Invalid sort input now produces a clear error message with the expected format
- Codifies the sort convention in MCP_STANDARDS.md for future tools

## Why This Change Exists
The `search_attacks` tool accepted `-startTime` for descending sort while every other tool in the MCP server uses `property,DIRECTION` (e.g., `startTime,DESC`). This inconsistency confused AI agents that had learned the standard convention from other tools, causing unnecessary retries and validation failures. This was finding #7 from the hosted MCP server exploratory testing round.

## What Changed
### Sort parameter parsing (`AttackFilterParams`)
- `AttackFilterParams` now expects `property,DIRECTION` format (e.g., `startTime,DESC`, `status,ASC`)
- Internally converts to the SDK's `-prefix` format so the API contract is unchanged
- Direction is case-insensitive (`desc`, `DESC`, `Desc` all work)
- Whitespace around commas and at edges is trimmed
- Error messages now show the expected format, valid properties, and valid directions

### Tool description (`SearchAttacksTool`)
- `@ToolParam` description updated to document the `property,DIRECTION` format

### MCP Standards (`MCP_STANDARDS.md`)
- Added "Sort Convention" section codifying `property,DIRECTION` as the standard

### Tests
- All unit tests, parity tests, and integration tests updated to use the new format
- New test cases for missing direction, legacy `-prefix` rejection, invalid direction, and too many parts
- Integration tests expanded to cover `status` (bare field without direction) and `-status` (legacy prefix) as invalid inputs

## Testing
- `make check-test` passes (unit + static analysis)
- Integration tests updated and passing with the new sort format
- Parameterized tests cover all five valid sort fields in both ASC and DESC directions


[AIML-853]: https://contrast.atlassian.net/browse/AIML-853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ