### PR TITLE
AIML-853 Fix duplicate servers in list_applications_by_cve

### DIFF
--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
@@ -20,6 +20,7 @@ import com.contrast.labs.ai.mcp.contrast.sdkextension.data.App;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.CveData;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.Library;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.LibraryExtended;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.data.Server;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleTool;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleToolResponse;
 import com.contrast.labs.ai.mcp.contrast.tool.base.WarningCollector;
@@ -27,8 +28,11 @@ import com.contrast.labs.ai.mcp.contrast.tool.library.params.ListApplicationsByC
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.model.ToolContext;
@@ -90,6 +94,7 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
     if (cveData == null) {
       return null; // SingleTool converts this to notFound response
     }
+    dedupeServersById(cveData);
 
     var vulnerableLibs =
         cveData.getLibraries() != null ? cveData.getLibraries() : Collections.<Library>emptyList();
@@ -146,5 +151,24 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
             }
           });
     }
+  }
+
+  private static void dedupeServersById(CveData cveData) {
+    if (cveData.getServers() == null) {
+      return;
+    }
+
+    var dedupedServers =
+        cveData.getServers().stream()
+            .collect(
+                Collectors.toMap(
+                    Server::getServer_id,
+                    Function.identity(),
+                    (first, duplicate) -> first,
+                    LinkedHashMap::new))
+            .values()
+            .stream()
+            .toList();
+    cveData.setServers(dedupedServers);
   }
 }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/params/ListApplicationsByCveParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/params/ListApplicationsByCveParams.java
@@ -17,6 +17,7 @@ package com.contrast.labs.ai.mcp.contrast.tool.library.params;
 
 import com.contrast.labs.ai.mcp.contrast.tool.base.BaseToolParams;
 import com.contrast.labs.ai.mcp.contrast.tool.validation.ToolValidationContext;
+import java.util.Locale;
 import java.util.regex.Pattern;
 import org.springframework.util.StringUtils;
 
@@ -32,16 +33,18 @@ public class ListApplicationsByCveParams extends BaseToolParams {
   public static ListApplicationsByCveParams of(String cveId) {
     var params = new ListApplicationsByCveParams();
     var ctx = new ToolValidationContext();
+    var normalizedCveId =
+        StringUtils.hasText(cveId) ? cveId.trim().toUpperCase(Locale.ROOT) : cveId;
 
-    ctx.require(cveId, "cveId");
-    if (StringUtils.hasText(cveId) && !CVE_PATTERN.matcher(cveId).matches()) {
+    ctx.require(normalizedCveId, "cveId");
+    if (StringUtils.hasText(normalizedCveId) && !CVE_PATTERN.matcher(normalizedCveId).matches()) {
       ctx.errorIf(
           true,
           "cveId must be in CVE format (e.g., CVE-2021-44228). "
               + "Format: CVE-YYYY-NNNNN where YYYY is the year and NNNNN is a sequence number.");
     }
 
-    params.cveId = cveId;
+    params.cveId = normalizedCveId;
     params.setValidationResult(ctx);
     return params;
   }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
@@ -26,6 +26,7 @@ import com.contrast.labs.ai.mcp.contrast.sdkextension.data.App;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.CveData;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.Library;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.LibraryExtended;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.data.Server;
 import com.contrastsecurity.exceptions.HttpResponseException;
 import com.contrastsecurity.exceptions.ResourceNotFoundException;
 import java.io.IOException;
@@ -147,6 +148,22 @@ class ListApplicationsByCveToolTest {
   }
 
   @Test
+  void listApplicationsByCve_should_dedupe_top_level_servers_by_server_id() throws Exception {
+    var cveData = cveData(app("Orders", APP_ID), vulnerableLibrary(LIBRARY_HASH));
+    cveData.setServers(List.of(server(92326), server(92326), server(92327)));
+
+    when(contrastApiClient.getApplicationsByCve(eq(CVE_ID))).thenReturn(cveData);
+    when(contrastApiClient.getAllLibraries(eq(APP_ID))).thenReturn(List.of());
+
+    var result = tool.listApplicationsByCve(CVE_ID, null);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.data().getServers())
+        .extracting(Server::getServer_id)
+        .containsExactly(92326, 92327);
+  }
+
+  @Test
   void listApplicationsByCve_should_handle_null_libraries_list_gracefully() throws Exception {
     var app = app("Orders", APP_ID);
     var cveData = new CveData();
@@ -258,5 +275,11 @@ class ListApplicationsByCveToolTest {
     library.setClassCount(42);
     library.setClassesUsed(7);
     return library;
+  }
+
+  private static Server server(int serverId) {
+    var server = new Server();
+    server.setServer_id(serverId);
+    return server;
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
@@ -150,7 +150,11 @@ class ListApplicationsByCveToolTest {
   @Test
   void listApplicationsByCve_should_dedupe_top_level_servers_by_server_id() throws Exception {
     var cveData = cveData(app("Orders", APP_ID), vulnerableLibrary(LIBRARY_HASH));
-    cveData.setServers(List.of(server(92326), server(92326), server(92327)));
+    cveData.setServers(
+        List.of(
+            server(92326, "first-server"),
+            server(92326, "duplicate-server"),
+            server(92327, "another-server")));
 
     when(contrastApiClient.getApplicationsByCve(eq(CVE_ID))).thenReturn(cveData);
     when(contrastApiClient.getAllLibraries(eq(APP_ID))).thenReturn(List.of());
@@ -161,6 +165,23 @@ class ListApplicationsByCveToolTest {
     assertThat(result.data().getServers())
         .extracting(Server::getServer_id)
         .containsExactly(92326, 92327);
+    assertThat(result.data().getServers())
+        .extracting(Server::getName)
+        .containsExactly("first-server", "another-server");
+  }
+
+  @Test
+  void listApplicationsByCve_should_preserve_empty_top_level_servers_list() throws Exception {
+    var cveData = cveData(app("Orders", APP_ID), vulnerableLibrary(LIBRARY_HASH));
+    cveData.setServers(List.of());
+
+    when(contrastApiClient.getApplicationsByCve(eq(CVE_ID))).thenReturn(cveData);
+    when(contrastApiClient.getAllLibraries(eq(APP_ID))).thenReturn(List.of());
+
+    var result = tool.listApplicationsByCve(CVE_ID, null);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.data().getServers()).isEmpty();
   }
 
   @Test
@@ -278,8 +299,13 @@ class ListApplicationsByCveToolTest {
   }
 
   private static Server server(int serverId) {
+    return server(serverId, null);
+  }
+
+  private static Server server(int serverId, String name) {
     var server = new Server();
     server.setServer_id(serverId);
+    server.setName(name);
     return server;
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/params/ListApplicationsByCveParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/params/ListApplicationsByCveParamsTest.java
@@ -33,6 +33,14 @@ class ListApplicationsByCveParamsTest {
     assertThat(params.warnings()).isEmpty();
   }
 
+  @Test
+  void of_should_normalize_cve_id_before_validation() {
+    var params = ListApplicationsByCveParams.of(" cve-2021-44228 ");
+
+    assertThat(params.isValid()).isTrue();
+    assertThat(params.cveId()).isEqualTo("CVE-2021-44228");
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"CVE-2023-12345", "CVE-1999-0001", "CVE-2024-123456"})
   void of_should_accept_various_valid_cve_formats(String cveId) {
@@ -51,8 +59,7 @@ class ListApplicationsByCveParamsTest {
   }
 
   @ParameterizedTest
-  @ValueSource(
-      strings = {"not-a-cve", "CVE2021-44228", "CVE-21-44228", "CVE-2021-123", "cve-2021-44228"})
+  @ValueSource(strings = {"not-a-cve", "CVE2021-44228", "CVE-21-44228", "CVE-2021-123"})
   void of_should_reject_invalid_cve_format(String invalidCve) {
     var params = ListApplicationsByCveParams.of(invalidCve);
 


### PR DESCRIPTION
**Jira:** [AIML-853](https://contrast.atlassian.net/browse/AIML-853), [TS-42992](https://contrast.atlassian.net/browse/TS-42992)

## Summary
Work around a TeamServer API bug ([TS-42992](https://contrast.atlassian.net/browse/TS-42992)) where the CVE flat response returns duplicate entries in the `servers` array, and normalize CVE ID input so agents don't need to worry about casing.

- Deduplicate servers by ID in `list_applications_by_cve` before building the response
- Normalize CVE ID input (trim whitespace, uppercase) so `cve-2021-44228` is accepted
- Workaround can be removed when TS-42992 is fixed upstream

## Why This Change Exists
The TeamServer `/ng/organizations/{orgId}/cves/{cveId}` endpoint uses `Collectors.toSet()` on DTOs that lack `equals`/`hashCode`, so the same server appears multiple times when it is reachable through multiple library/app paths. This inflates the server list returned to agents. Only certain developers can modify TeamServer code and the fix is unlikely to land soon, so we work around it on the MCP side.

## What Changed
### `ListApplicationsByCveTool`
- `ListApplicationsByCveTool.java` — Added `dedupeServersById()` using `Collectors.toMap()` keyed on `server_id` to collapse duplicates before response building

### `ListApplicationsByCveParams`
- `ListApplicationsByCveParams.java` — Normalize CVE ID with `trim().toUpperCase(Locale.ROOT)` before validation, so lowercase or whitespace-padded input is accepted

### Tests
- `ListApplicationsByCveToolTest.java` — Added `listApplicationsByCve_should_dedupe_top_level_servers_by_server_id` verifying duplicates are collapsed
- `ListApplicationsByCveParamsTest.java` — Added `of_should_normalize_cve_id_before_validation` and removed `cve-2021-44228` from the invalid-format test since it now normalizes to valid

## Testing
- Unit tests cover deduplication (duplicate server IDs collapsed, distinct IDs preserved) and CVE ID normalization (lowercase + whitespace accepted)
- `make check-test` passes

## Risks / Follow-ups
- The `dedupeServersById` workaround should be removed when [TS-42992](https://contrast.atlassian.net/browse/TS-42992) is fixed in TeamServer
- TS-42992 also notes the same deduplication issue exists for `apps`, and separately that `CveImpactedApplication` fields like `lastSeen` and CVSS sub-fields are not populated. Those are tracked separately.


[AIML-853]: https://contrast.atlassian.net/browse/AIML-853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TS-42992]: https://contrast.atlassian.net/browse/TS-42992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TS-42992]: https://contrast.atlassian.net/browse/TS-42992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TS-42992]: https://contrast.atlassian.net/browse/TS-42992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
