### PR TITLE
AIML-853 Add timestamp parameter validation to core framework

### DIFF
--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelper.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelper.java
@@ -15,6 +15,7 @@
  */
 package com.contrast.labs.ai.mcp.contrast.tool.base;
 
+import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -34,6 +35,9 @@ import org.springframework.util.StringUtils;
  */
 @Slf4j
 public class FilterHelper {
+  private static final long MIN_EPOCH_MILLIS = 0L;
+  private static final long MAX_EPOCH_MILLIS = 253402300799999L;
+
   /** Result of parsing with optional validation message for AI feedback */
   public static class ParseResult<T> {
     private final T value;
@@ -114,7 +118,7 @@ public class FilterHelper {
             String.format(
                 "Invalid %s date '%s'. Expected ISO format (YYYY-MM-DD) like '2025-01-15' or epoch"
                     + " timestamp like '1705276800000'.",
-                paramName, dateStr);
+                paramName, sanitizeForMessage(dateStr));
         log.warn(message);
         return new ParseResult<>(null, message);
       }
@@ -137,28 +141,49 @@ public class FilterHelper {
     var trimmed = timestampStr.trim();
     try {
       long timestamp = Long.parseLong(trimmed);
+      if (!isSupportedTimestampMillis(timestamp)) {
+        return invalidTimestampResult(timestampStr, paramName);
+      }
       return new ParseResult<>(new Date(timestamp));
     } catch (NumberFormatException e) {
       Date parsed = parseIsoTimestamp(trimmed);
       if (parsed != null) {
         return new ParseResult<>(parsed);
       }
-      String message =
-          String.format(
-              "Invalid %s timestamp '%s'. Expected ISO timestamp like '2025-01-15T10:30:00Z',"
-                  + " which must include a time, or epoch timestamp like '1705276800000'.",
-              paramName, timestampStr);
-      log.warn(message);
-      return new ParseResult<>(null, message);
+      return invalidTimestampResult(timestampStr, paramName);
     }
   }
 
   private static Date parseIsoTimestamp(String timestampStr) {
     try {
-      return Date.from(OffsetDateTime.parse(timestampStr).toInstant());
-    } catch (DateTimeParseException e) {
+      Instant instant = OffsetDateTime.parse(timestampStr).toInstant();
+      long epochMillis = instant.toEpochMilli();
+      if (!isSupportedTimestampMillis(epochMillis)) {
+        return null;
+      }
+      return Date.from(instant);
+    } catch (DateTimeException | ArithmeticException e) {
       return null;
     }
+  }
+
+  private static boolean isSupportedTimestampMillis(long epochMillis) {
+    return epochMillis >= MIN_EPOCH_MILLIS && epochMillis <= MAX_EPOCH_MILLIS;
+  }
+
+  private static ParseResult<Date> invalidTimestampResult(String timestampStr, String paramName) {
+    String message =
+        String.format(
+            "Invalid %s timestamp '%s'. Expected ISO timestamp with date, time, and timezone offset"
+                + " like '2025-01-15T10:30:00Z', or epoch timestamp between %d and %d millis"
+                + " like '1705276800000'.",
+            paramName, sanitizeForMessage(timestampStr), MIN_EPOCH_MILLIS, MAX_EPOCH_MILLIS);
+    log.warn(message);
+    return new ParseResult<>(null, message);
+  }
+
+  private static String sanitizeForMessage(String value) {
+    return value.replace("\r", "\\r").replace("\n", "\\n");
   }
 
   /**

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelper.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelper.java
@@ -17,6 +17,7 @@ package com.contrast.labs.ai.mcp.contrast.tool.base;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -117,6 +118,56 @@ public class FilterHelper {
         log.warn(message);
         return new ParseResult<>(null, message);
       }
+    }
+  }
+
+  /**
+   * Parse timestamp string in ISO datetime format, ISO date format (YYYY-MM-DD), or epoch timestamp
+   * (milliseconds). Returns validation message if format is invalid.
+   *
+   * @param timestampStr timestamp string in ISO datetime, ISO date, or epoch timestamp format
+   * @param paramName parameter name for error messages (e.g., "startTime")
+   * @return ParseResult with Date object and optional validation message
+   */
+  public static ParseResult<Date> parseTimestampWithValidation(
+      String timestampStr, String paramName) {
+    if (!StringUtils.hasText(timestampStr)) {
+      return new ParseResult<>(null);
+    }
+    var trimmed = timestampStr.trim();
+    try {
+      long timestamp = Long.parseLong(trimmed);
+      return new ParseResult<>(new Date(timestamp));
+    } catch (NumberFormatException e) {
+      Date parsed = parseIsoTimestamp(trimmed);
+      if (parsed != null) {
+        return new ParseResult<>(parsed);
+      }
+      String message =
+          String.format(
+              "Invalid %s timestamp '%s'. Expected ISO timestamp like '2025-01-15T10:30:00Z',"
+                  + " ISO date (YYYY-MM-DD) like '2025-01-15', or epoch timestamp like"
+                  + " '1705276800000'.",
+              paramName, timestampStr);
+      log.warn(message);
+      return new ParseResult<>(null, message);
+    }
+  }
+
+  private static Date parseIsoTimestamp(String timestampStr) {
+    try {
+      return Date.from(OffsetDateTime.parse(timestampStr).toInstant());
+    } catch (DateTimeParseException e) {
+      return parseIsoTimestampDate(timestampStr);
+    }
+  }
+
+  private static Date parseIsoTimestampDate(String timestampStr) {
+    try {
+      LocalDate localDate = LocalDate.parse(timestampStr);
+      return Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
+    } catch (DateTimeParseException e) {
+      return null;
     }
   }
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelper.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelper.java
@@ -122,10 +122,10 @@ public class FilterHelper {
   }
 
   /**
-   * Parse timestamp string in ISO datetime format, ISO date format (YYYY-MM-DD), or epoch timestamp
-   * (milliseconds). Returns validation message if format is invalid.
+   * Parse timestamp string in ISO datetime format or epoch timestamp (milliseconds). Returns
+   * validation message if format is invalid.
    *
-   * @param timestampStr timestamp string in ISO datetime, ISO date, or epoch timestamp format
+   * @param timestampStr timestamp string in ISO datetime or epoch timestamp format
    * @param paramName parameter name for error messages (e.g., "startTime")
    * @return ParseResult with Date object and optional validation message
    */
@@ -146,8 +146,7 @@ public class FilterHelper {
       String message =
           String.format(
               "Invalid %s timestamp '%s'. Expected ISO timestamp like '2025-01-15T10:30:00Z',"
-                  + " ISO date (YYYY-MM-DD) like '2025-01-15', or epoch timestamp like"
-                  + " '1705276800000'.",
+                  + " which must include a time, or epoch timestamp like '1705276800000'.",
               paramName, timestampStr);
       log.warn(message);
       return new ParseResult<>(null, message);
@@ -157,15 +156,6 @@ public class FilterHelper {
   private static Date parseIsoTimestamp(String timestampStr) {
     try {
       return Date.from(OffsetDateTime.parse(timestampStr).toInstant());
-    } catch (DateTimeParseException e) {
-      return parseIsoTimestampDate(timestampStr);
-    }
-  }
-
-  private static Date parseIsoTimestampDate(String timestampStr) {
-    try {
-      LocalDate localDate = LocalDate.parse(timestampStr);
-      return Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
     } catch (DateTimeParseException e) {
       return null;
     }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/TimestampSpec.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/TimestampSpec.java
@@ -19,8 +19,8 @@ import com.contrast.labs.ai.mcp.contrast.tool.base.FilterHelper;
 import java.util.Date;
 
 /**
- * Fluent validation spec for timestamp parameters. Parses ISO timestamp strings, ISO dates, or
- * epoch timestamps with helpful error messages.
+ * Fluent validation spec for timestamp parameters. Parses ISO timestamp strings or epoch timestamps
+ * with helpful error messages.
  */
 public class TimestampSpec {
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/TimestampSpec.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/TimestampSpec.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool.validation;
+
+import com.contrast.labs.ai.mcp.contrast.tool.base.FilterHelper;
+import java.util.Date;
+
+/**
+ * Fluent validation spec for timestamp parameters. Parses ISO timestamp strings, ISO dates, or
+ * epoch timestamps with helpful error messages.
+ */
+public class TimestampSpec {
+
+  private final ToolValidationContext ctx;
+  private final String value;
+  private final String name;
+
+  TimestampSpec(ToolValidationContext ctx, String value, String name) {
+    this.ctx = ctx;
+    this.value = value;
+    this.name = name;
+  }
+
+  /**
+   * Validates and returns the parsed timestamp.
+   *
+   * @return validated Date, or null if no value or parse error
+   */
+  public Date get() {
+    FilterHelper.ParseResult<Date> result = FilterHelper.parseTimestampWithValidation(value, name);
+
+    if (result.hasValidationMessage()) {
+      ctx.addError(result.getValidationMessage());
+      return null;
+    }
+
+    return result.getValue();
+  }
+}

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContext.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContext.java
@@ -162,7 +162,7 @@ public class ToolValidationContext implements ToolParams {
     if (start != null && end != null && start.after(end)) {
       errors.add(
           String.format(
-              "Invalid timestamp range: %s must be before %s. "
+              "Invalid timestamp range: %s must be at or before %s. "
                   + "Example: %s='2025-01-01T00:00:00Z', %s='2025-01-02T00:00:00Z'",
               startName, endName, startName, endName));
     }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContext.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContext.java
@@ -112,7 +112,7 @@ public class ToolValidationContext implements ToolParams {
   /**
    * Creates a fluent spec for timestamp parameter validation.
    *
-   * @param value timestamp string in ISO datetime, ISO date (YYYY-MM-DD), or epoch milliseconds
+   * @param value timestamp string in ISO datetime or epoch milliseconds
    * @param name the parameter name for error messages
    * @return TimestampSpec for fluent configuration
    */

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContext.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContext.java
@@ -110,6 +110,17 @@ public class ToolValidationContext implements ToolParams {
   }
 
   /**
+   * Creates a fluent spec for timestamp parameter validation.
+   *
+   * @param value timestamp string in ISO datetime, ISO date (YYYY-MM-DD), or epoch milliseconds
+   * @param name the parameter name for error messages
+   * @return TimestampSpec for fluent configuration
+   */
+  public TimestampSpec timestampParam(String value, String name) {
+    return new TimestampSpec(this, value, name);
+  }
+
+  /**
    * Creates a fluent spec for metadata filter JSON parameter validation. Used for session metadata
    * and application metadata filters.
    *
@@ -135,6 +146,24 @@ public class ToolValidationContext implements ToolParams {
           String.format(
               "Invalid date range: %s must be before %s. "
                   + "Example: %s='2025-01-01', %s='2025-12-31'",
+              startName, endName, startName, endName));
+    }
+  }
+
+  /**
+   * Validates that a timestamp range is logically consistent (start before end).
+   *
+   * @param start the start timestamp (may be null)
+   * @param end the end timestamp (may be null)
+   * @param startName the start parameter name for error messages
+   * @param endName the end parameter name for error messages
+   */
+  public void validateTimestampRange(Date start, Date end, String startName, String endName) {
+    if (start != null && end != null && start.after(end)) {
+      errors.add(
+          String.format(
+              "Invalid timestamp range: %s must be before %s. "
+                  + "Example: %s='2025-01-01T00:00:00Z', %s='2025-01-02T00:00:00Z'",
               startName, endName, startName, endName));
     }
   }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/TimestampSpecTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/TimestampSpecTest.java
@@ -34,7 +34,6 @@ class TimestampSpecTest {
   void get_should_parse_iso_instant() {
     var result = ctx.timestampParam("2025-01-01T00:00:00Z", "startTime").get();
 
-    assertThat(result).isNotNull();
     assertThat(result.toInstant()).isEqualTo(Instant.parse("2025-01-01T00:00:00Z"));
     assertThat(ctx.isValid()).isTrue();
   }
@@ -43,7 +42,6 @@ class TimestampSpecTest {
   void get_should_parse_iso_timestamp_with_numeric_offset() {
     var result = ctx.timestampParam("2025-01-01T00:00:00-05:00", "startTime").get();
 
-    assertThat(result).isNotNull();
     assertThat(result.toInstant()).isEqualTo(Instant.parse("2025-01-01T05:00:00Z"));
     assertThat(ctx.isValid()).isTrue();
   }
@@ -56,7 +54,18 @@ class TimestampSpecTest {
     assertThat(ctx.isValid()).isFalse();
     assertThat(ctx.errors()).hasSize(1);
     assertThat(ctx.errors().get(0)).contains("Invalid startTime timestamp");
-    assertThat(ctx.errors().get(0)).contains("must include a time");
+    assertThat(ctx.errors().get(0)).contains("date, time, and timezone offset");
+  }
+
+  @Test
+  void get_should_reject_iso_timestamp_without_timezone_offset() {
+    var result = ctx.timestampParam("2025-01-15T10:30:00", "startTime").get();
+
+    assertThat(result).isNull();
+    assertThat(ctx.isValid()).isFalse();
+    assertThat(ctx.errors()).hasSize(1);
+    assertThat(ctx.errors().get(0)).contains("Invalid startTime timestamp");
+    assertThat(ctx.errors().get(0)).contains("date, time, and timezone offset");
   }
 
   @Test
@@ -64,9 +73,30 @@ class TimestampSpecTest {
     long epochMillis = 1705276800000L;
     var result = ctx.timestampParam(String.valueOf(epochMillis), "startTime").get();
 
-    assertThat(result).isNotNull();
     assertThat(result.getTime()).isEqualTo(epochMillis);
     assertThat(ctx.isValid()).isTrue();
+  }
+
+  @Test
+  void get_should_reject_negative_epoch_timestamp() {
+    var result = ctx.timestampParam("-1", "startTime").get();
+
+    assertThat(result).isNull();
+    assertThat(ctx.isValid()).isFalse();
+    assertThat(ctx.errors()).hasSize(1);
+    assertThat(ctx.errors().get(0)).contains("Invalid startTime timestamp");
+    assertThat(ctx.errors().get(0)).contains("between 0 and 253402300799999");
+  }
+
+  @Test
+  void get_should_reject_epoch_timestamp_after_supported_iso_year_range() {
+    var result = ctx.timestampParam(String.valueOf(Long.MAX_VALUE), "startTime").get();
+
+    assertThat(result).isNull();
+    assertThat(ctx.isValid()).isFalse();
+    assertThat(ctx.errors()).hasSize(1);
+    assertThat(ctx.errors().get(0)).contains("Invalid startTime timestamp");
+    assertThat(ctx.errors().get(0)).contains("between 0 and 253402300799999");
   }
 
   @Test
@@ -94,7 +124,19 @@ class TimestampSpecTest {
     assertThat(ctx.errors()).hasSize(1);
     assertThat(ctx.errors().get(0)).contains("Invalid startTime timestamp");
     assertThat(ctx.errors().get(0)).contains("ISO timestamp");
-    assertThat(ctx.errors().get(0)).contains("must include a time");
+    assertThat(ctx.errors().get(0)).contains("date, time, and timezone offset");
     assertThat(ctx.errors().get(0)).contains("epoch timestamp");
+  }
+
+  @Test
+  void get_should_sanitize_control_characters_in_validation_message() {
+    var result = ctx.timestampParam("bad\nvalue\rnext", "startTime").get();
+
+    assertThat(result).isNull();
+    assertThat(ctx.isValid()).isFalse();
+    assertThat(ctx.errors()).hasSize(1);
+    assertThat(ctx.errors().get(0)).doesNotContain("\n");
+    assertThat(ctx.errors().get(0)).doesNotContain("\r");
+    assertThat(ctx.errors().get(0)).contains("bad\\nvalue\\rnext");
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/TimestampSpecTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/TimestampSpecTest.java
@@ -18,8 +18,6 @@ package com.contrast.labs.ai.mcp.contrast.tool.validation;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -51,13 +49,14 @@ class TimestampSpecTest {
   }
 
   @Test
-  void get_should_parse_iso_date_as_start_of_day() {
+  void get_should_reject_iso_date_without_time() {
     var result = ctx.timestampParam("2025-01-15", "startTime").get();
 
-    assertThat(result).isNotNull();
-    var localDate = result.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
-    assertThat(localDate).isEqualTo(LocalDate.of(2025, 1, 15));
-    assertThat(ctx.isValid()).isTrue();
+    assertThat(result).isNull();
+    assertThat(ctx.isValid()).isFalse();
+    assertThat(ctx.errors()).hasSize(1);
+    assertThat(ctx.errors().get(0)).contains("Invalid startTime timestamp");
+    assertThat(ctx.errors().get(0)).contains("must include a time");
   }
 
   @Test
@@ -95,7 +94,7 @@ class TimestampSpecTest {
     assertThat(ctx.errors()).hasSize(1);
     assertThat(ctx.errors().get(0)).contains("Invalid startTime timestamp");
     assertThat(ctx.errors().get(0)).contains("ISO timestamp");
-    assertThat(ctx.errors().get(0)).contains("YYYY-MM-DD");
+    assertThat(ctx.errors().get(0)).contains("must include a time");
     assertThat(ctx.errors().get(0)).contains("epoch timestamp");
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/TimestampSpecTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/TimestampSpecTest.java
@@ -17,13 +17,13 @@ package com.contrast.labs.ai.mcp.contrast.tool.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.util.Date;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class DateSpecTest {
+class TimestampSpecTest {
 
   private ToolValidationContext ctx;
 
@@ -33,8 +33,26 @@ class DateSpecTest {
   }
 
   @Test
-  void get_should_parse_iso_date() {
-    var result = ctx.dateParam("2025-01-15", "startDate").get();
+  void get_should_parse_iso_instant() {
+    var result = ctx.timestampParam("2025-01-01T00:00:00Z", "startTime").get();
+
+    assertThat(result).isNotNull();
+    assertThat(result.toInstant()).isEqualTo(Instant.parse("2025-01-01T00:00:00Z"));
+    assertThat(ctx.isValid()).isTrue();
+  }
+
+  @Test
+  void get_should_parse_iso_timestamp_with_numeric_offset() {
+    var result = ctx.timestampParam("2025-01-01T00:00:00-05:00", "startTime").get();
+
+    assertThat(result).isNotNull();
+    assertThat(result.toInstant()).isEqualTo(Instant.parse("2025-01-01T05:00:00Z"));
+    assertThat(ctx.isValid()).isTrue();
+  }
+
+  @Test
+  void get_should_parse_iso_date_as_start_of_day() {
+    var result = ctx.timestampParam("2025-01-15", "startTime").get();
 
     assertThat(result).isNotNull();
     var localDate = result.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
@@ -45,7 +63,7 @@ class DateSpecTest {
   @Test
   void get_should_parse_epoch_timestamp() {
     long epochMillis = 1705276800000L;
-    var result = ctx.dateParam(String.valueOf(epochMillis), "startDate").get();
+    var result = ctx.timestampParam(String.valueOf(epochMillis), "startTime").get();
 
     assertThat(result).isNotNull();
     assertThat(result.getTime()).isEqualTo(epochMillis);
@@ -53,17 +71,8 @@ class DateSpecTest {
   }
 
   @Test
-  void get_should_reject_iso_datetime() {
-    var result = ctx.dateParam("2025-01-01T00:00:00Z", "startDate").get();
-
-    assertThat(result).isNull();
-    assertThat(ctx.isValid()).isFalse();
-    assertThat(ctx.errors().get(0)).contains("Invalid startDate date");
-  }
-
-  @Test
   void get_should_return_null_when_null() {
-    var result = ctx.dateParam(null, "startDate").get();
+    var result = ctx.timestampParam(null, "startTime").get();
 
     assertThat(result).isNull();
     assertThat(ctx.isValid()).isTrue();
@@ -71,7 +80,7 @@ class DateSpecTest {
 
   @Test
   void get_should_return_null_when_blank() {
-    var result = ctx.dateParam("   ", "startDate").get();
+    var result = ctx.timestampParam("   ", "startTime").get();
 
     assertThat(result).isNull();
     assertThat(ctx.isValid()).isTrue();
@@ -79,39 +88,14 @@ class DateSpecTest {
 
   @Test
   void get_should_add_error_for_invalid_format() {
-    var result = ctx.dateParam("not-a-date", "startDate").get();
+    var result = ctx.timestampParam("not-a-timestamp", "startTime").get();
 
     assertThat(result).isNull();
     assertThat(ctx.isValid()).isFalse();
     assertThat(ctx.errors()).hasSize(1);
-    assertThat(ctx.errors().get(0)).contains("Invalid startDate date");
+    assertThat(ctx.errors().get(0)).contains("Invalid startTime timestamp");
+    assertThat(ctx.errors().get(0)).contains("ISO timestamp");
     assertThat(ctx.errors().get(0)).contains("YYYY-MM-DD");
     assertThat(ctx.errors().get(0)).contains("epoch timestamp");
-  }
-
-  @Test
-  void get_should_add_error_for_invalid_date() {
-    var result = ctx.dateParam("2025-13-45", "lastSeen").get();
-
-    assertThat(result).isNull();
-    assertThat(ctx.isValid()).isFalse();
-    assertThat(ctx.errors()).hasSize(1);
-  }
-
-  @Test
-  void get_should_trim_whitespace() {
-    var result = ctx.dateParam("  2025-01-15  ", "startDate").get();
-
-    assertThat(result).isNotNull();
-    assertThat(ctx.isValid()).isTrue();
-  }
-
-  @Test
-  void get_should_parse_different_dates() {
-    Date startDate = ctx.dateParam("2025-01-01", "startDate").get();
-    Date endDate = ctx.dateParam("2025-12-31", "endDate").get();
-
-    assertThat(startDate).isBefore(endDate);
-    assertThat(ctx.isValid()).isTrue();
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContextTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContextTest.java
@@ -112,6 +112,59 @@ class ToolValidationContextTest {
     assertThat(ctx.isValid()).isTrue();
   }
 
+  // -- validateTimestampRange tests --
+
+  @Test
+  void validateTimestampRange_should_add_error_when_start_after_end() {
+    Date start = new Date(1705363200000L); // 2024-01-16
+    Date end = new Date(1705276800000L); // 2024-01-15
+
+    ctx.validateTimestampRange(start, end, "startTime", "endTime");
+
+    assertThat(ctx.isValid()).isFalse();
+    assertThat(ctx.errors())
+        .containsExactly(
+            "Invalid timestamp range: startTime must be before endTime. "
+                + "Example: startTime='2025-01-01T00:00:00Z', "
+                + "endTime='2025-01-02T00:00:00Z'");
+  }
+
+  @Test
+  void validateTimestampRange_should_pass_when_start_before_end() {
+    Date start = new Date(1705276800000L); // 2024-01-15
+    Date end = new Date(1705363200000L); // 2024-01-16
+
+    ctx.validateTimestampRange(start, end, "startTime", "endTime");
+
+    assertThat(ctx.isValid()).isTrue();
+    assertThat(ctx.errors()).isEmpty();
+  }
+
+  @Test
+  void validateTimestampRange_should_pass_when_start_is_null() {
+    Date end = new Date(1705363200000L);
+
+    ctx.validateTimestampRange(null, end, "startTime", "endTime");
+
+    assertThat(ctx.isValid()).isTrue();
+  }
+
+  @Test
+  void validateTimestampRange_should_pass_when_end_is_null() {
+    Date start = new Date(1705276800000L);
+
+    ctx.validateTimestampRange(start, null, "startTime", "endTime");
+
+    assertThat(ctx.isValid()).isTrue();
+  }
+
+  @Test
+  void validateTimestampRange_should_pass_when_both_null() {
+    ctx.validateTimestampRange(null, null, "startTime", "endTime");
+
+    assertThat(ctx.isValid()).isTrue();
+  }
+
   // -- requireIfPresent tests --
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContextTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContextTest.java
@@ -141,6 +141,17 @@ class ToolValidationContextTest {
   }
 
   @Test
+  void validateTimestampRange_should_pass_when_start_equals_end() {
+    Date start = new Date(1705276800000L); // 2024-01-15
+    Date end = new Date(1705276800000L); // 2024-01-15
+
+    ctx.validateTimestampRange(start, end, "startTime", "endTime");
+
+    assertThat(ctx.isValid()).isTrue();
+    assertThat(ctx.errors()).isEmpty();
+  }
+
+  @Test
   void validateTimestampRange_should_pass_when_start_is_null() {
     Date end = new Date(1705363200000L);
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContextTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContextTest.java
@@ -124,7 +124,7 @@ class ToolValidationContextTest {
     assertThat(ctx.isValid()).isFalse();
     assertThat(ctx.errors())
         .containsExactly(
-            "Invalid timestamp range: startTime must be before endTime. "
+            "Invalid timestamp range: startTime must be at or before endTime. "
                 + "Example: startTime='2025-01-01T00:00:00Z', "
                 + "endTime='2025-01-02T00:00:00Z'");
   }


### PR DESCRIPTION
**Jira:** [AIML-853](https://contrast.atlassian.net/browse/AIML-853)

## Summary
Add timestamp parameter validation to the MCP core validation framework, supporting the hosted MCP server's need to validate `startTime`/`endTime` inputs on `search_issues` and `get_issue_count`.

- New `TimestampSpec` and `timestampParam(...)` fluent validation for ISO timestamp and epoch millisecond inputs
- New `validateTimestampRange(...)` to reject reversed ranges before they reach downstream APIs
- Timestamp parsing in `FilterHelper` accepts values such as `2025-01-15T10:30:00Z`, `2025-01-15T10:30:00-05:00`, and `1705276800000`
- Date-only strings and offset-less ISO datetimes are rejected with guidance that timestamp inputs need date, time, and timezone offset
- Epoch millis are bounded to `0..253402300799999` to reject negative and unrealistic far-future values
- Invalid-value messages sanitize CR/LF before logging to avoid forged log lines

## Why This Change Exists
The hosted MCP server (aiml-services PR #237) needs to validate `startTime`/`endTime` parameters on issue search tools. The existing `dateParam(...)` in the core validation framework handles date-only strings (`yyyy-MM-dd`) and should keep behaving that way. Rather than shoehorn timestamps into the date validator, this PR adds a purpose-built timestamp validation path that keeps date-only and time-bearing parameters separate.

## What Changed
### Validation framework
- `ToolValidationContext` — added `timestampParam(value, name)` factory method and `validateTimestampRange(start, end, startName, endName)`
- `TimestampSpec` — new fluent spec that delegates to `FilterHelper.parseTimestampWithValidation`

### FilterHelper
- `FilterHelper` — added `parseTimestampWithValidation(timestampStr, paramName)` and private ISO timestamp parsing helpers
- Timestamp validation requires an ISO timestamp with timezone offset or bounded epoch millis
- Invalid timestamp messages now name the timezone requirement directly and sanitize control characters before logging
- Invalid date messages also sanitize control characters before logging; date parsing semantics are otherwise unchanged

### Tests
- `TimestampSpecTest` covers ISO instant, numeric offset, epoch millis, null/blank passthrough, date-only rejection, offset-less datetime rejection, negative/far-future epoch rejection, CR/LF sanitization, and garbage input
- `ToolValidationContextTest` covers range validation including start after end, start before end, equal endpoints, and nulls
- `DateSpecTest` confirms ISO datetimes are still rejected by the date-only path

## Testing
Verified with focused checks and the full core test task:

```bash
./gradlew :contrast-mcp-core:spotlessApply \
  :contrast-mcp-core:checkstyleMain \
  :contrast-mcp-core:checkstyleTest \
  :contrast-mcp-core:test \
  --tests com.contrast.labs.ai.mcp.contrast.tool.validation.TimestampSpecTest \
  --tests com.contrast.labs.ai.mcp.contrast.tool.validation.ToolValidationContextTest \
  --tests com.contrast.labs.ai.mcp.contrast.tool.validation.DateSpecTest

./gradlew :contrast-mcp-core:test
```


[AIML-853]: https://contrast.atlassian.net/browse/AIML-853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
