### PR TITLE
Updating Wiz Scan Policy for OSS Repos

### DIFF
--- a/.github/workflows/wiz-scan.yaml
+++ b/.github/workflows/wiz-scan.yaml
@@ -15,7 +15,7 @@ jobs:
       run:
         shell: bash
     env:
-      POLICY: "Block-VM" # Set the desired Wiz CLI policy to use
+      POLICY: "Contrast-OSS,EOL-Scan" # Set the desired Wiz CLI policy to use
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Labs is making a change to the OSS Repo Wiz Scan Policy.  
This change better aligns with Best Practices and Industry Standards for product that is available to Customers for usage within their environments.

Change Made: 
- Wiz Scan Policy: Block-VM --> Contrast-OSS
- Wiz Scan Policy: Added: EOL-Scan

