### PR TITLE
AIML-976 Lead README with Hosted MCP Server, add hosted install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Contrast MCP Server connects Contrast Security to your AI coding agent so yo
 It comes in two forms.
 
 - **[Hosted MCP Server](#hosted-mcp-server-recommended)** is a remote MCP server that Contrast runs for you. It is the simplest path for Contrast SaaS customers, with browser-based OAuth sign-in and nothing to install. **Recommended for most users.**
-- **[Local MCP Server](#local-mcp-server)** is the open-source server in this repository that you run yourself with API keys. It is the right choice for on-premises and EOP (Enterprise On-Premises) instances, or when you need raw SARIF scan output.
+- **[Local MCP Server](#local-mcp-server)** is the open-source server in this repository that you run yourself with API keys. It is the right choice for on-premises and EOP (Enterprise On-Premises) instances.
 
 > [!WARNING]
 > **CRITICAL SECURITY WARNING:** Exposing Contrast vulnerability data to an AI service that trains on your prompts can leak sensitive information. Only use the Contrast MCP Server with environments that contractually guarantee data isolation and prohibit model training on your inputs.
@@ -81,7 +81,7 @@ Your client discovers the OAuth configuration automatically through the `WWW-Aut
 | Codex CLI | Working |
 | GitHub Copilot CLI | Working |
 | opencode | Working |
-| Claude Desktop | Working (requires an HTTPS endpoint) |
+| Claude Desktop | Working |
 | Gemini CLI | Not yet supported, OAuth compatibility issue |
 | VS Code Copilot plugin | Not yet supported, OAuth compatibility issue |
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The hosted server provides read-only tools across the domains below. Your agent 
 #### Libraries (SCA)
 | Tool | Description |
 |------|-------------|
-| `list_application_libraries` | List libraries used by an application with class usage statistics |
+| `list_application_libraries` | List libraries used by an application with class usage statistics and vulnerability counts |
 | `list_applications_by_cve` | Find applications affected by a specific CVE |
 
 #### Protection (ADR/Protect)
@@ -194,7 +194,7 @@ The Local MCP Server provides 13 tools for security analysis and vulnerability m
 #### Libraries (SCA)
 | Tool | Description |
 |------|-------------|
-| `list_application_libraries` | List libraries used by an application with vulnerability counts |
+| `list_application_libraries` | List libraries used by an application with class usage statistics and vulnerability counts |
 | `list_applications_by_cve` | Find applications affected by a specific CVE |
 
 #### Protection (ADR/Protect)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Add the server to Claude Code by pointing it at your Contrast host followed by `
 claude mcp add --transport http contrast-hosted-mcp https://app.contrastsecurity.com/mcp
 ```
 
-Replace `app.contrastsecurity.com` with your organization's Contrast URL if you use a dedicated instance. The first time your agent calls a tool, your browser opens for sign-in. You log in with your existing Contrast credentials, choose an organization, and approve read access. Your session refreshes on its own, so you typically sign in once and keep working.
+Replace `app.contrastsecurity.com` with your organization's Contrast URL if you use a dedicated instance. The first time your agent calls a tool, your browser opens for sign-in. If sign-in does not start automatically, run `/mcp` in Claude Code and choose Authenticate for `contrast-hosted-mcp`. You log in with your existing Contrast credentials, choose an organization, and approve read access. Your session refreshes on its own, so you typically sign in once and keep working.
 
 For step-by-step setup for Claude Desktop, the Codex CLI, the GitHub Copilot CLI, and opencode, see the [Hosted MCP Server installation guide](docs/installation-guides/install-hosted.md).
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ claude mcp add --transport http contrast-hosted-mcp https://app.contrastsecurity
 
 Replace `app.contrastsecurity.com` with your organization's Contrast URL if you use a dedicated instance. The first time your agent calls a tool, your browser opens for sign-in. If sign-in does not start automatically, run `/mcp` in Claude Code and choose Authenticate for `contrast-hosted-mcp`. You log in with your existing Contrast credentials, choose an organization, and approve read access. Your session refreshes on its own, so you typically sign in once and keep working.
 
-For step-by-step setup for Claude Desktop, the Codex CLI, the GitHub Copilot CLI, and opencode, see the [Hosted MCP Server installation guide](docs/installation-guides/install-hosted.md).
+For step-by-step setup for Claude Code, Claude Desktop, the Codex CLI, the GitHub Copilot CLI, and opencode, see the [Hosted MCP Server installation guide](docs/installation-guides/install-hosted.md).
 
 ### Connection details
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ These tools require the Contrast unified data platform (NorthStar) to be enabled
 | `get_observation` | Get full details for a specific observation |
 | `list_issue_observations` | List observations linked to an issue (cursor-paginated) |
 | `list_incident_observations` | List observations linked to an incident (cursor-paginated) |
+| `get_incident_observation_count` | Count observations linked to an incident without paging |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,15 @@
 [![Java CI with Gradle](https://github.com/Contrast-Security-OSS/mcp-contrast/actions/workflows/build.yml/badge.svg)](https://github.com/Contrast-Security-OSS/mcp-contrast/actions/workflows/build.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-The Contrast MCP Server allows you to connect Contrast Security to your AI coding agent to automatically remediate vulnerabilities, update insecure libraries, and analyze security coverage—all through natural language prompts.
+The Contrast MCP Server connects Contrast Security to your AI coding agent so you can remediate vulnerabilities, update insecure libraries, and analyze security coverage through natural language.
 
-- Remediate vulnerabilities directly from Contrast Assess data
-- Identify and update insecure third-party libraries with Contrast SCA insights
-- Review route coverage, Protect/ADR findings, and other security metadata on demand
+It comes in two forms.
+
+- **[Hosted MCP Server](#hosted-mcp-server-recommended)** is a remote MCP server that Contrast runs for you. It is the simplest path for Contrast SaaS customers, with browser-based OAuth sign-in and nothing to install. **Recommended for most users.**
+- **[Local MCP Server](#local-mcp-server)** is the open-source server in this repository that you run yourself with API keys. It is the right choice for on-premises and EOP (Enterprise On-Premises) instances, or when you need raw SARIF scan output.
 
 > [!WARNING]
-> **CRITICAL SECURITY WARNING:** Exposing Contrast vulnerability data to an AI service that trains on your prompts can leak sensitive information. Only use mcp-contrast with environments that contractually guarantee data isolation and prohibit model training on your inputs.
+> **CRITICAL SECURITY WARNING:** Exposing Contrast vulnerability data to an AI service that trains on your prompts can leak sensitive information. Only use the Contrast MCP Server with environments that contractually guarantee data isolation and prohibit model training on your inputs.
 >
 > **Verify AI Data Privacy:** Confirm that your service agreement prevents model training on your prompts and consult your security team before sharing Contrast data.
 >
@@ -18,21 +19,170 @@ The Contrast MCP Server allows you to connect Contrast Security to your AI codin
 >
 > **POTENTIALLY SAFE:** Enterprise services with contractual privacy guarantees (e.g., Google Cloud AI, AWS Bedrock, Azure OpenAI).
 
-## What's New
+## Contents
 
-See [CHANGELOG.md](CHANGELOG.md) for the complete release history, including breaking changes and new features.
+- [Hosted MCP Server (recommended)](#hosted-mcp-server-recommended)
+  - [Prerequisites](#prerequisites)
+  - [Connect](#connect)
+  - [Connection details](#connection-details)
+  - [Supported clients](#supported-clients)
+  - [Security and privacy](#security-and-privacy)
+  - [Available tools](#available-tools-hosted)
+- [Local MCP Server](#local-mcp-server)
+  - [Available tools](#available-tools-local)
+  - [Quick start](#quick-start)
+  - [More setup and troubleshooting](#more-setup-and-troubleshooting)
+- [Sample prompts](#sample-prompts)
+- [Data privacy](#data-privacy)
 
-## Available Tools
+## Hosted MCP Server (recommended)
 
-The Contrast MCP Server provides 13 tools for security analysis and vulnerability management:
+The Hosted MCP Server, a remote MCP server that Contrast operates for you, is the easiest way to connect an AI agent to Contrast. You point your client at one URL, sign in through your browser, and your agent can start asking questions about your security data. There are no API keys to copy around, no container or JAR to keep updated, and no local process to run.
 
-### Applications
+The hosted server is read-only and is available now for Contrast SaaS.
+
+### Prerequisites
+
+- A Contrast SaaS account with access to at least one organization
+- An MCP client that supports Streamable HTTP transport and OAuth 2.0 with PKCE (see [Supported clients](#supported-clients))
+- A modern web browser for the OAuth sign-in
+
+### Connect
+
+Add the server to Claude Code by pointing it at your Contrast host followed by `/mcp`.
+
+```bash
+claude mcp add --transport http contrast-hosted-mcp https://app.contrastsecurity.com/mcp
+```
+
+Replace `app.contrastsecurity.com` with your organization's Contrast URL if you use a dedicated instance. The first time your agent calls a tool, your browser opens for sign-in. You log in with your existing Contrast credentials, choose an organization, and approve read access. Your session refreshes on its own, so you typically sign in once and keep working.
+
+For step-by-step setup for Claude Desktop, the Codex CLI, the GitHub Copilot CLI, and opencode, see the [Hosted MCP Server installation guide](docs/installation-guides/install-hosted.md).
+
+### Connection details
+
+Any MCP client that supports Streamable HTTP transport and OAuth 2.0 with PKCE can connect.
+
+| Setting | Value |
+|---------|-------|
+| Endpoint URL | `https://<your-contrast-host>/mcp` (for example `https://app.contrastsecurity.com/mcp`) |
+| Transport | Streamable HTTP (stateless) |
+| HTTP method | `POST` |
+| Authentication | OAuth 2.0 with PKCE (S256) |
+| OAuth scopes | `openid`, `profile`, `offline_access` |
+
+Your client discovers the OAuth configuration automatically through the `WWW-Authenticate` response header, which points to the standard `/.well-known/oauth-protected-resource` metadata document. Clients that support Dynamic Client Registration can register at `/oauth2/connect/register` on the Contrast origin.
+
+### Supported clients
+
+| Client | Status |
+|--------|--------|
+| Claude Code CLI | Working |
+| Codex CLI | Working |
+| GitHub Copilot CLI | Working |
+| opencode | Working |
+| Claude Desktop | Working (requires an HTTPS endpoint) |
+| Gemini CLI | Not yet supported, OAuth compatibility issue |
+| VS Code Copilot plugin | Not yet supported, OAuth compatibility issue |
+
+Support for more clients is in progress as their OAuth handling matures. If your client fails during OAuth registration before the login page appears, that is usually a client compatibility issue rather than a problem with your account.
+
+### Security and privacy
+
+The hosted server changes how access works without changing what you are allowed to see.
+
+- **OAuth, not API keys.** You sign in through your browser, so there are no long-lived keys to distribute or store on developer machines.
+- **Read-only.** Every hosted tool is read-only. You cannot modify, update, or delete data through the hosted server.
+- **Organization-scoped.** Each session is bound to the single organization you select at sign-in, so there is no organization ID to guess or get wrong.
+- **Your existing permissions apply.** Every request carries your identity to Contrast, which enforces the same role-based access control as the web interface. If you cannot see something in Contrast, your agent cannot see it either.
+- **No data storage.** The hosted server stores none of your data, and your token never appears in a tool response.
+
+The shared warning above still applies. Tool results become part of your AI conversation, so follow your organization's policy on what security data can be sent to your chosen AI client and model.
+
+### Available tools (hosted)
+
+The hosted server provides read-only tools across the domains below. Your agent calls them automatically based on your questions.
+
+<details>
+<summary>Show hosted tools</summary>
+
+#### Authentication
+| Tool | Description |
+|------|-------------|
+| `get_user_info` | Show who you are signed in as and which organization is active |
+
+#### Vulnerabilities (Assess)
+| Tool | Description |
+|------|-------------|
+| `search_vulnerabilities` | Search vulnerabilities across all applications |
+| `search_app_vulnerabilities` | Search vulnerabilities within a specific application with session filtering |
+| `get_vulnerability` | Get detailed vulnerability info including remediation guidance |
+| `list_vulnerability_types` | List all available vulnerability types for filtering |
+
+#### Applications
 | Tool | Description |
 |------|-------------|
 | `search_applications` | Search applications by name, tag, or metadata filters |
 | `get_session_metadata` | Get session metadata fields available for an application |
 
-### Vulnerabilities
+#### Libraries (SCA)
+| Tool | Description |
+|------|-------------|
+| `list_application_libraries` | List libraries used by an application with class usage statistics |
+| `list_applications_by_cve` | Find applications affected by a specific CVE |
+
+#### Protection (ADR/Protect)
+| Tool | Description |
+|------|-------------|
+| `search_attacks` | Search attack events with filtering by status, type, and rules |
+| `get_protect_rules` | Get protection rules configured for an application |
+
+#### Coverage
+| Tool | Description |
+|------|-------------|
+| `get_route_coverage` | Get route coverage data showing exercised vs discovered routes |
+
+#### SAST (Scan)
+| Tool | Description |
+|------|-------------|
+| `get_scan_project` | Get SAST project details and vulnerability counts |
+
+#### Issues, Incidents, and Observations
+These tools require the Contrast unified data platform (NorthStar) to be enabled for your organization.
+
+| Tool | Description |
+|------|-------------|
+| `search_issues` | Search and filter security issues across your organization |
+| `get_issue` | Get full details for a specific issue |
+| `get_issue_summary` | Get a concise summary of a specific issue |
+| `get_issue_count` | Count issues matching filters without fetching full details |
+| `list_issue_incidents` | List incidents linked to an issue |
+| `list_issues_by_library` | List open issues associated with an application library |
+| `search_incidents` | Search and filter incidents |
+| `get_incident` | Get full details for a specific incident |
+| `get_incident_summary` | Get a concise summary of a specific incident |
+| `list_incident_issues` | List issues linked to an incident |
+| `get_observation` | Get full details for a specific observation |
+| `list_issue_observations` | List observations linked to an issue (cursor-paginated) |
+| `list_incident_observations` | List observations linked to an incident (cursor-paginated) |
+
+</details>
+
+## Local MCP Server
+
+The Local MCP Server is the open-source server in this repository. Your MCP client launches it as a local process over stdio, it authenticates with Contrast API and service keys, and it connects to your own Contrast instance, including on-premises and EOP. Use it when you cannot use the hosted server, or when you need raw SARIF scan output.
+
+### Available tools (local)
+
+The Local MCP Server provides 13 tools for security analysis and vulnerability management.
+
+#### Applications
+| Tool | Description |
+|------|-------------|
+| `search_applications` | Search applications by name, tag, or metadata filters |
+| `get_session_metadata` | Get session metadata fields available for an application |
+
+#### Vulnerabilities
 | Tool | Description |
 |------|-------------|
 | `search_vulnerabilities` | Search vulnerabilities across all applications (org-level) |
@@ -40,42 +190,42 @@ The Contrast MCP Server provides 13 tools for security analysis and vulnerabilit
 | `get_vulnerability` | Get detailed vulnerability info including stack trace and remediation guidance |
 | `list_vulnerability_types` | List all available vulnerability types for filtering |
 
-### Libraries (SCA)
+#### Libraries (SCA)
 | Tool | Description |
 |------|-------------|
 | `list_application_libraries` | List libraries used by an application with vulnerability counts |
 | `list_applications_by_cve` | Find applications affected by a specific CVE |
 
-### Protection (ADR/Protect)
+#### Protection (ADR/Protect)
 | Tool | Description |
 |------|-------------|
 | `search_attacks` | Search attack events with filtering by status, type, and rules |
 | `get_protect_rules` | Get protection rules configured for an application |
 
-### Coverage
+#### Coverage
 | Tool | Description |
 |------|-------------|
 | `get_route_coverage` | Get route coverage data showing exercised vs discovered routes |
 
-### SAST (Scan)
+#### SAST (Scan)
 | Tool | Description |
 |------|-------------|
 | `get_scan_project` | Get SAST project details and vulnerability counts |
 | `get_scan_results` | Get SAST scan results in SARIF format |
 
-## Quick Start
+### Quick start
 
-### Prerequisites
+#### Prerequisites
 - Docker (recommended) or Java 21+ for JAR deployment
 - Contrast API credentials ([how to get API credentials](https://docs.contrastsecurity.com/en/personal-keys.html))
 
-### VS Code (GitHub Copilot) - One-Click Install
+#### VS Code (GitHub Copilot) - One-Click Install
 
 [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_contrast--mcp-0098FF?style=for-the-badge&logo=visualstudiocode&logoColor=ffffff)](vscode:mcp/install?%7B%22name%22%3A%22contrast%22%2C%22type%22%3A%22stdio%22%2C%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%22-e%22%2C%22CONTRAST_HOST_NAME%22%2C%22-e%22%2C%22CONTRAST_API_KEY%22%2C%22-e%22%2C%22CONTRAST_SERVICE_KEY%22%2C%22-e%22%2C%22CONTRAST_USERNAME%22%2C%22-e%22%2C%22CONTRAST_ORG_ID%22%2C%22-i%22%2C%22--rm%22%2C%22contrast%2Fmcp-contrast%3Alatest%22%2C%22-t%22%2C%22stdio%22%5D%2C%22env%22%3A%7B%22CONTRAST_HOST_NAME%22%3A%22%24%7Binput%3Acontrast_host_name%7D%22%2C%22CONTRAST_ORG_ID%22%3A%22%24%7Binput%3Acontrast_org_id%7D%22%2C%22CONTRAST_USERNAME%22%3A%22%24%7Binput%3Acontrast_username%7D%22%2C%22CONTRAST_API_KEY%22%3A%22%24%7Binput%3Acontrast_api_key%7D%22%2C%22CONTRAST_SERVICE_KEY%22%3A%22%24%7Binput%3Acontrast_service_key%7D%22%7D%7D)
 
-Click the button above to automatically install in VS Code. For manual setup, see [VS Code (GitHub Copilot) Installation Guide](docs/installation-guides/install-vscode.md).
+Click the button above to automatically install in VS Code. For manual setup, see the [VS Code (GitHub Copilot) Installation Guide](docs/installation-guides/install-vscode.md).
 
-### IntelliJ IDEA (GitHub Copilot)
+#### IntelliJ IDEA (GitHub Copilot)
 
 Add this to your `mcp.json` configuration file and replace the placeholder values with your Contrast credentials:
 
@@ -116,14 +266,21 @@ Add this to your `mcp.json` configuration file and replace the placeholder value
 
 📖 [Full IntelliJ (GitHub Copilot) Installation Guide](docs/installation-guides/install-intellij.md) - Includes step-by-step setup and JAR deployment option
 
-### Other AI Assistants
+#### Other AI Assistants
 
 - **[Claude Code](docs/installation-guides/install-claude-code.md)** - Anthropic's official CLI tool
 - **[Claude Desktop](docs/installation-guides/install-claude-desktop.md)** - Standalone Claude application
 - **[Cline Plugin](docs/installation-guides/install-cline.md)** - VS Code alternative AI assistant
 - **[All Other MCP Hosts](docs/installation-guides/)** - Complete installation guides for oterm and more
 
-## Sample Prompts
+### More setup and troubleshooting
+
+Getting the JAR file (download, attestation verification, and build from source), proxy configuration, and troubleshooting have moved to the [Local MCP Server guide](docs/local-mcp-server.md).
+
+## Sample prompts
+
+These prompts work with either server.
+
 ### For the Developer
 #### Remediate Vulnerabilities in Code
 * Please list vulnerabilities for Application Y.
@@ -153,212 +310,7 @@ Add this to your `mcp.json` configuration file and replace the placeholder value
 * Please list the libraries for the application named xxx and tell me what version of commons-collections is being used.
 * Which vulnerabilities in Application X are being blocked by a Protect or ADR rule?
 
-## Getting the JAR File
-
-If you're using JAR deployment (instead of Docker), you'll need the JAR file:
-
-### Download (Recommended)
-
-Download the latest pre-built JAR from [GitHub Releases](https://github.com/Contrast-Security-OSS/mcp-contrast/releases/latest).
-
-The JAR file will be named `mcp-contrast-X.X.X.jar`.
-
-### Verifying the Download
-
-Each release JAR is signed with a [GitHub build provenance attestation](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds), which proves the JAR was built by this repository's release workflow. Verify a downloaded JAR with the [GitHub CLI](https://cli.github.com/):
-
-```bash
-gh attestation verify mcp-contrast-X.X.X.jar --repo Contrast-Security-OSS/mcp-contrast
-```
-
-A successful check confirms the JAR was produced by the official release workflow and has not been altered. No key import or fingerprint comparison is required. The GitHub CLI validates the attestation against the public Sigstore transparency log.
-
-### Build from Source
-
-Alternatively, you can build from source if you need the latest development version. Requires Java 21+:
-
-```bash
-./gradlew :contrast-mcp-stdio-app:bootJar
-```
-
-The built JAR will be located at `contrast-mcp-stdio-app/build/libs/mcp-contrast-X.X.X-SNAPSHOT.jar`
-
-## Proxy Configuration
-
-If you're behind a corporate firewall or proxy, you'll need to configure proxy settings for the MCP server to reach your Contrast instance. The configuration differs depending on whether you're using Docker or JAR deployment.
-
-### Java Process (JAR Deployment)
-
-Choose ONE of the following based on how you're running the JAR:
-
-#### Direct Java Command
-
-Use this if you're running the JAR directly from the command line or a script.
-
-Add these two system properties to your `java` command:
-
-```
--Dhttp_proxy_host=proxy.example.com
--Dhttp_proxy_port=8080
-```
-
-**Complete example:**
-```bash
-java \
-  -Dhttp_proxy_host=proxy.example.com \
-  -Dhttp_proxy_port=8080 \
-  -jar /path/to/mcp-contrast-X.X.X.jar \
-  --CONTRAST_HOST_NAME=example.contrastsecurity.com \
-  --CONTRAST_API_KEY=example \
-  --CONTRAST_SERVICE_KEY=example \
-  --CONTRAST_USERNAME=example@example.com \
-  --CONTRAST_ORG_ID=example
-```
-
-#### MCP Configuration File
-
-Use this if you're running the JAR through an MCP host (IntelliJ, Claude Desktop, Cline, etc.).
-
-Add these two lines to the beginning of your `args` array:
-
-```json
-"-Dhttp_proxy_host=proxy.example.com",
-"-Dhttp_proxy_port=8080",
-```
-
-**Complete example using IntelliJ's `mcp.json`:**
-```json
-{
-  "servers": {
-    "contrast": {
-      "command": "java",
-      "args": [
-        "-Dhttp_proxy_host=proxy.example.com",
-        "-Dhttp_proxy_port=8080",
-        "-jar",
-        "/path/to/mcp-contrast-X.X.X.jar",
-        "--CONTRAST_HOST_NAME=example.contrastsecurity.com",
-        "--CONTRAST_API_KEY=example",
-        "--CONTRAST_SERVICE_KEY=example",
-        "--CONTRAST_USERNAME=example@example.com",
-        "--CONTRAST_ORG_ID=example"
-      ]
-    }
-  }
-}
-```
-
-### Docker (Docker Deployment)
-
-Choose ONE of the following based on how you're running Docker:
-
-#### Direct Docker Run Command
-
-Use this if you're running Docker directly from the command line.
-
-Add these two environment variables to your `docker run` command:
-
-```bash
--e http_proxy_host="proxy.example.com" \
--e http_proxy_port="8080" \
-```
-
-**Complete example:**
-```bash
-docker run \
-  -e http_proxy_host="proxy.example.com" \
-  -e http_proxy_port="8080" \
-  -e CONTRAST_HOST_NAME=example.contrastsecurity.com \
-  -e CONTRAST_API_KEY=example \
-  -e CONTRAST_SERVICE_KEY=example \
-  -e CONTRAST_USERNAME=example \
-  -e CONTRAST_ORG_ID=example \
-  -i --rm \
-  contrast/mcp-contrast:latest \
-  -t stdio
-```
-
-#### MCP Configuration File
-
-Use this if you're running Docker through an MCP host (IntelliJ, VS Code, Claude Desktop, Cline, etc.).
-
-Add these proxy settings:
-
-Add to the `args` array (after the Contrast credentials):
-```json
-"-e", "http_proxy_host",
-"-e", "http_proxy_port",
-```
-
-Add to the `env` object:
-```json
-"http_proxy_host": "proxy.example.com",
-"http_proxy_port": "8080"
-```
-
-**Complete example using IntelliJ's `mcp.json`:**
-```json
-{
-  "servers": {
-    "contrast": {
-      "command": "docker",
-      "args": [
-        "run",
-        "-e", "CONTRAST_HOST_NAME",
-        "-e", "CONTRAST_API_KEY",
-        "-e", "CONTRAST_SERVICE_KEY",
-        "-e", "CONTRAST_USERNAME",
-        "-e", "CONTRAST_ORG_ID",
-        "-e", "http_proxy_host",
-        "-e", "http_proxy_port",
-        "-i", "--rm",
-        "contrast/mcp-contrast:latest",
-        "-t", "stdio"
-      ],
-      "env": {
-        "CONTRAST_HOST_NAME": "example.contrastsecurity.com",
-        "CONTRAST_API_KEY": "example",
-        "CONTRAST_SERVICE_KEY": "example",
-        "CONTRAST_USERNAME": "example@example.com",
-        "CONTRAST_ORG_ID": "example",
-        "http_proxy_host": "proxy.example.com",
-        "http_proxy_port": "8080"
-      }
-    }
-  }
-}
-```
-
-For VS Code with input variables, see the [VS Code Installation Guide](docs/installation-guides/install-vscode.md).
-
-## Common Issues
-If you are experiencing issues with the MCP server, here are some common troubleshooting steps:
-### Review Log
-A log will be created, by default under `/tmp/mcp-contrast.log` either locally or within the Docker container. You can view this log to see if there are any errors or issues with the MCP server.
-
-### Enable Debug Logging
-To enable debug logging you can add the following flag to the command line arguments when running the MCP server:
-`--logging.level.root=DEBUG`
-This can be added at this part of the docker command
-```
-        "--rm",
-        "contrast/mcp-contrast:latest",
-        "-t",
-        "--logging.level.root=DEBUG",
-        "stdio"
-        ],
-```
-
-### Certificate Issues
-If the SSL Certificate for the Teamserver URL is not trusted, you may see the following error:
-```
-Failed to list applications: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
-```
-If this occurs you will need to add the certificate to the Java Truststore and then add the following to the command line arguments when running the MCP server:
-`-Djavax.net.ssl.trustStore=/location/to/mcp-truststore.jks, -Djavax.net.ssl.trustStorePassword=yourpassword`
-More details on how to do this can be found in the [Java documentation](https://docs.oracle.com/cd/E19509-01/820-3503/6nf1il6er/index.html). Or ask your LLM to help you with this.
-
-## Data Privacy
+## Data privacy
 
 The Contrast MCP Server provides a bridge between your Contrast Data and the AI Agent/LLM of your choice.
 By using Contrast's MCP server you will be providing your Contrast Data to your AI Agent/LLM, it is your responsibility to ensure that the AI Agent/LLM you use complies with your data privacy policy.
@@ -368,3 +320,7 @@ Depending on what questions you ask the following information will be provided t
 * Vulnerability Details
 * Route Coverage data
 * ADR/Protect Attack Event Details
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for the complete release history, including breaking changes and new features.

--- a/docs/installation-guides/README.md
+++ b/docs/installation-guides/README.md
@@ -26,4 +26,4 @@ All guides support both deployment methods - choose the one that fits your envir
 - No Docker required
 - Direct process control for debugging
 - Works in Docker-restricted environments
-- Requires Java 21+ and JAR file ([download](../../README.md#getting-the-jar-file))
+- Requires Java 21+ and JAR file ([download](../local-mcp-server.md#getting-the-jar-file))

--- a/docs/installation-guides/README.md
+++ b/docs/installation-guides/README.md
@@ -1,6 +1,8 @@
-# Installation Guides
+# Local MCP Server installation guides
 
-Choose your MCP host to get started. Each guide provides step-by-step instructions for both Docker and JAR deployment.
+These guides cover the [Local MCP Server](../local-mcp-server.md), the open-source server you run yourself over stdio with Contrast API and service keys. Choose your MCP host to get started. Each guide provides step-by-step instructions for both Docker and JAR deployment.
+
+> **Looking for the Hosted MCP Server?** If you use Contrast SaaS, the [Hosted MCP Server](./install-hosted.md) is the easiest way to connect. It needs no local process, no keys, and no container. These local-server guides are for when you cannot use the hosted server, or when you need raw SARIF scan output.
 
 ## MCP Hosts
 

--- a/docs/installation-guides/install-claude-code.md
+++ b/docs/installation-guides/install-claude-code.md
@@ -1,6 +1,8 @@
 # Installing Contrast MCP Server in Claude Code
 
-This guide covers how to install and configure the Contrast MCP Server with Claude Code.
+This guide covers how to install and configure the Contrast Local MCP Server with Claude Code.
+
+> **This is a Local MCP Server guide.** It runs the open-source server as a local process using Contrast API and service keys. If you use Contrast SaaS, the [Hosted MCP Server](./install-hosted.md) is easier to set up and needs no local process or keys.
 
 > [!NOTE] Official Claude Code Documentation Reference
 > Anthropic's full Claude Code documentation for adding MCP servers can be found here: https://code.claude.com/docs/en/mcp

--- a/docs/installation-guides/install-claude-code.md
+++ b/docs/installation-guides/install-claude-code.md
@@ -60,7 +60,7 @@ Replace `/path/to/mcp-contrast-X.X.X.jar` with the actual path to your downloade
 
 **Getting the JAR file:**
 - **Download** from [GitHub Releases](https://github.com/Contrast-Security-OSS/mcp-contrast/releases/latest) (recommended)
-- **Build** from source ([instructions](../../README.md#build-from-source))
+- **Build** from source ([instructions](../local-mcp-server.md#build-from-source))
 
 
 ## Configuration Scopes
@@ -140,11 +140,11 @@ If you encounter issues:
 
 4. **Environment variable issues**: Ensure all required credentials are provided as `--env` flags
 
-For more troubleshooting help, see the [Common Issues](../../README.md#common-issues) section in the main README.
+For more troubleshooting help, see the [Common Issues](../local-mcp-server.md#common-issues) section in the Local MCP Server guide.
 
 ## Proxy Configuration
 
-If you're behind a corporate proxy, you'll need to configure Docker or Java to use your proxy settings. See the [Proxy Configuration](../../README.md#proxy-configuration) section in the main README for details.
+If you're behind a corporate proxy, you'll need to configure Docker or Java to use your proxy settings. See the [Proxy Configuration](../local-mcp-server.md#proxy-configuration) section in the Local MCP Server guide for details.
 
 ## Windows Users
 

--- a/docs/installation-guides/install-claude-desktop.md
+++ b/docs/installation-guides/install-claude-desktop.md
@@ -97,7 +97,7 @@ Replace `/path/to/mcp-contrast-X.X.X.jar` with the path to your downloaded or bu
 
 **Getting the JAR file:**
 - **Download** from [GitHub Releases](https://github.com/Contrast-Security-OSS/mcp-contrast/releases/latest) (recommended)
-- **Build** from source ([instructions](../../README.md#build-from-source))
+- **Build** from source ([instructions](../local-mcp-server.md#build-from-source))
 
 
 After saving the configuration, completely quit and restart Claude Desktop for the changes to take effect.
@@ -135,8 +135,8 @@ If you encounter issues:
 - **Windows**: `%APPDATA%\Claude\logs\mcp*.log`
 - **Linux**: `~/.config/Claude/logs/mcp*.log`
 
-For more troubleshooting help, see the [Common Issues](../../README.md#common-issues) section in the main README.
+For more troubleshooting help, see the [Common Issues](../local-mcp-server.md#common-issues) section in the Local MCP Server guide.
 
 ## Proxy Configuration
 
-If you're behind a corporate proxy, see the [Proxy Configuration](../../README.md#proxy-configuration) section in the main README.
+If you're behind a corporate proxy, see the [Proxy Configuration](../local-mcp-server.md#proxy-configuration) section in the Local MCP Server guide.

--- a/docs/installation-guides/install-claude-desktop.md
+++ b/docs/installation-guides/install-claude-desktop.md
@@ -1,6 +1,8 @@
 # Installing Contrast MCP Server in Claude Desktop
 
-This guide covers how to install and configure the Contrast MCP Server with Claude Desktop.
+This guide covers how to install and configure the Contrast Local MCP Server with Claude Desktop.
+
+> **This is a Local MCP Server guide.** It runs the open-source server as a local process using Contrast API and service keys. If you use Contrast SaaS, the [Hosted MCP Server](./install-hosted.md) is easier to set up and needs no local process or keys.
 
 > [!NOTE] Claude Desktop Documentation Reference
 > Anthropic's documentation for connecting local MCP servers can be found here: https://modelcontextprotocol.io/docs/develop/connect-local-servers

--- a/docs/installation-guides/install-cline.md
+++ b/docs/installation-guides/install-cline.md
@@ -1,6 +1,8 @@
 # Installing Contrast MCP Server in Cline
 
-This guide covers how to install and configure the Contrast MCP Server with the Cline plugin for VS Code.
+This guide covers how to install and configure the Contrast Local MCP Server with the Cline plugin for VS Code.
+
+> **This is a Local MCP Server guide.** It runs the open-source server as a local process using Contrast API and service keys. If you use Contrast SaaS, the [Hosted MCP Server](./install-hosted.md) is easier to set up and needs no local process or keys.
 
 > [!NOTE] Official Cline Documentation Reference
 > Cline's full documentation for configuring MCP servers can be found here: https://docs.cline.bot/mcp/configuring-mcp-servers

--- a/docs/installation-guides/install-cline.md
+++ b/docs/installation-guides/install-cline.md
@@ -104,7 +104,7 @@ Replace `/path/to/mcp-contrast-X.X.X.jar` with the path to your downloaded or bu
 
 **Getting the JAR file:**
 - **Download** from [GitHub Releases](https://github.com/Contrast-Security-OSS/mcp-contrast/releases/latest) (recommended)
-- **Build** from source ([instructions](../../README.md#build-from-source))
+- **Build** from source ([instructions](../local-mcp-server.md#build-from-source))
 
 
 **Save Configuration**
@@ -141,8 +141,8 @@ If you encounter issues:
    docker pull contrast/mcp-contrast:latest
    ```
 
-For more troubleshooting help, see the [Common Issues](../../README.md#common-issues) section in the main README.
+For more troubleshooting help, see the [Common Issues](../local-mcp-server.md#common-issues) section in the Local MCP Server guide.
 
 ## Proxy Configuration
 
-If you're behind a corporate proxy, see the [Proxy Configuration](../../README.md#proxy-configuration) section in the main README.
+If you're behind a corporate proxy, see the [Proxy Configuration](../local-mcp-server.md#proxy-configuration) section in the Local MCP Server guide.

--- a/docs/installation-guides/install-hosted.md
+++ b/docs/installation-guides/install-hosted.md
@@ -26,7 +26,7 @@ Verify it was added.
 claude mcp list
 ```
 
-You should see `contrast-hosted-mcp` in the list. The first time a tool is called, your browser opens for sign-in.
+You should see `contrast-hosted-mcp` in the list. The first time a tool is called, your browser opens for sign-in. If sign-in does not start automatically, run `/mcp` in Claude Code and choose Authenticate for `contrast-hosted-mcp`.
 
 ## Claude Desktop
 

--- a/docs/installation-guides/install-hosted.md
+++ b/docs/installation-guides/install-hosted.md
@@ -1,0 +1,105 @@
+# Hosted MCP Server installation guide
+
+The [Hosted MCP Server](../../README.md#hosted-mcp-server-recommended) is a remote MCP server that Contrast runs for you. You point your client at one URL, sign in through your browser, and your agent can start asking questions about your security data. There are no API keys to manage and nothing to install.
+
+This guide covers per-client setup. The steps are nearly identical across clients, because every client does the same two things. It points at a URL and completes a browser OAuth sign-in.
+
+## Before you start
+
+- A Contrast SaaS account with access to at least one organization
+- One of the [supported clients](#supported-clients) below
+- A modern web browser for the OAuth sign-in
+
+Your endpoint is your Contrast host followed by `/mcp`. The examples below use `https://app.contrastsecurity.com/mcp`. Replace `app.contrastsecurity.com` with your organization's Contrast URL if you use a dedicated instance.
+
+## Claude Code (CLI)
+
+Add the server.
+
+```bash
+claude mcp add --transport http contrast-hosted-mcp https://app.contrastsecurity.com/mcp
+```
+
+Verify it was added.
+
+```bash
+claude mcp list
+```
+
+You should see `contrast-hosted-mcp` in the list. The first time a tool is called, your browser opens for sign-in.
+
+## Claude Desktop
+
+Claude Desktop requires an HTTPS endpoint, so it works with your Contrast URL but not with a plain `http://localhost` address.
+
+1. Open **Claude Desktop** settings.
+2. Go to the **MCP Servers** section.
+3. Add a new server with these values.
+   - **Name** is `contrast-hosted-mcp`
+   - **Transport** is HTTP
+   - **URL** is `https://app.contrastsecurity.com/mcp`
+4. Save and restart Claude Desktop.
+
+## Codex CLI
+
+Add the server as an HTTP MCP server pointed at your Contrast endpoint, then trigger any Contrast tool to start the browser sign-in. Use the same endpoint URL shown above.
+
+## GitHub Copilot CLI
+
+Add the server as an HTTP MCP server pointed at your Contrast endpoint, then trigger any Contrast tool to start the browser sign-in. Use the same endpoint URL shown above.
+
+## opencode
+
+Add the server as an HTTP MCP server pointed at your Contrast endpoint, then trigger any Contrast tool to start the browser sign-in. Use the same endpoint URL shown above.
+
+## Other MCP clients
+
+Any MCP client that supports Streamable HTTP transport and OAuth 2.0 with PKCE can connect.
+
+| Setting | Value |
+|---------|-------|
+| Endpoint URL | `https://<your-contrast-host>/mcp` |
+| Transport | Streamable HTTP (stateless) |
+| HTTP method | `POST` |
+| Authentication | OAuth 2.0 with PKCE (S256) |
+| OAuth scopes | `openid`, `profile`, `offline_access` |
+
+Your client discovers the OAuth configuration automatically through the `WWW-Authenticate` response header, which points to the standard `/.well-known/oauth-protected-resource` metadata document. Clients that support Dynamic Client Registration can register at `/oauth2/connect/register` on the Contrast origin.
+
+## Signing in
+
+When you first use a Contrast tool, your browser opens for sign-in.
+
+1. Log in with your Contrast credentials, the same ones you use for the Contrast web interface.
+2. Select an organization if you belong to more than one.
+3. Approve read access.
+
+After signing in, the connection is active. Your access token refreshes on its own, so you typically do not sign in again during a session. Each session is scoped to one organization. To use a different organization, remove and re-add the connection, then sign in again and pick the other organization.
+
+> Never paste bearer tokens, refresh tokens, or other credentials into chat, tickets, or issue comments. If you expose a token, contact your Contrast administrator.
+
+## Verifying the connection
+
+Ask your agent to run `get_user_info`. A successful response shows your user identity and the organization you are connected to. In Claude Code you can simply say "Run get_user_info to check my connection."
+
+## Supported clients
+
+| Client | Status |
+|--------|--------|
+| Claude Code CLI | Working |
+| Codex CLI | Working |
+| GitHub Copilot CLI | Working |
+| opencode | Working |
+| Claude Desktop | Working (requires an HTTPS endpoint) |
+| Gemini CLI | Not yet supported, OAuth compatibility issue |
+| VS Code Copilot plugin | Not yet supported, OAuth compatibility issue |
+
+Support for more clients is in progress as their OAuth handling matures. If your client fails during OAuth registration before the login page appears, that is usually a client compatibility issue rather than a problem with your account.
+
+## Troubleshooting
+
+- **Sign-in completes but nothing happens.** Your client may not have finished the OAuth token exchange. Remove the connection, re-add it, and try again. Check that your browser is not blocking pop-ups or redirects from the Contrast domain.
+- **Token expired.** Access tokens are short-lived and refresh on their own. Retry the request. If it keeps failing, remove and re-add the connection for a fresh sign-in.
+- **503, MCP authentication is not available.** OAuth-based MCP access is not enabled for your Contrast environment. Contact Contrast to have it enabled.
+- **Authorization error from a tool.** The tools respect your Contrast role-based permissions. Confirm you selected the right organization with `get_user_info`, and check that your role allows the data you are requesting.
+- **Cannot connect at all.** Verify the endpoint URL ends with `/mcp`, confirm your client is in the supported list, and ensure you have network access to your Contrast instance.

--- a/docs/installation-guides/install-hosted.md
+++ b/docs/installation-guides/install-hosted.md
@@ -90,7 +90,7 @@ Ask your agent to run `get_user_info`. A successful response shows your user ide
 | Codex CLI | Working |
 | GitHub Copilot CLI | Working |
 | opencode | Working |
-| Claude Desktop | Working (requires an HTTPS endpoint) |
+| Claude Desktop | Working |
 | Gemini CLI | Not yet supported, OAuth compatibility issue |
 | VS Code Copilot plugin | Not yet supported, OAuth compatibility issue |
 

--- a/docs/installation-guides/install-intellij.md
+++ b/docs/installation-guides/install-intellij.md
@@ -1,6 +1,8 @@
 # Installing Contrast MCP Server in IntelliJ IDEA (GitHub Copilot)
 
-This guide covers how to install and configure the Contrast MCP Server in IntelliJ IDEA using GitHub Copilot.
+This guide covers how to install and configure the Contrast Local MCP Server in IntelliJ IDEA using GitHub Copilot.
+
+> **This is a Local MCP Server guide.** It runs the open-source server as a local process using Contrast API and service keys. If you use Contrast SaaS, the [Hosted MCP Server](./install-hosted.md) is easier to set up and needs no local process or keys.
 
 ## Prerequisites
 

--- a/docs/installation-guides/install-intellij.md
+++ b/docs/installation-guides/install-intellij.md
@@ -88,7 +88,7 @@ If you prefer to run the JAR directly (requires Java 21+):
 
 **Getting the JAR file:**
 - **Download** from [GitHub Releases](https://github.com/Contrast-Security-OSS/mcp-contrast/releases/latest) (recommended)
-- **Build** from source ([instructions](../../README.md#build-from-source))
+- **Build** from source ([instructions](../local-mcp-server.md#build-from-source))
 
 Replace `/path/to/mcp-contrast-X.X.X.jar` with the path to your downloaded or built JAR file.
 
@@ -120,8 +120,8 @@ If you encounter issues:
    docker pull contrast/mcp-contrast:latest
    ```
 
-For more troubleshooting help, see the [Common Issues](../../README.md#common-issues) section in the main README.
+For more troubleshooting help, see the [Common Issues](../local-mcp-server.md#common-issues) section in the Local MCP Server guide.
 
 ## Proxy Configuration
 
-If you're behind a corporate proxy, see the [Proxy Configuration](../../README.md#proxy-configuration) section in the main README.
+If you're behind a corporate proxy, see the [Proxy Configuration](../local-mcp-server.md#proxy-configuration) section in the Local MCP Server guide.

--- a/docs/installation-guides/install-oterm.md
+++ b/docs/installation-guides/install-oterm.md
@@ -1,6 +1,8 @@
 # Installing Contrast MCP Server in oterm
 
-This guide covers how to install and configure the Contrast MCP Server with oterm, a terminal wrapper for Ollama.
+This guide covers how to install and configure the Contrast Local MCP Server with oterm, a terminal wrapper for Ollama.
+
+> **This is a Local MCP Server guide.** It runs the open-source server as a local process using Contrast API and service keys. If you use Contrast SaaS, the [Hosted MCP Server](./install-hosted.md) is easier to set up and needs no local process or keys.
 
 ## Prerequisites
 

--- a/docs/installation-guides/install-oterm.md
+++ b/docs/installation-guides/install-oterm.md
@@ -93,7 +93,7 @@ If you prefer to run the JAR directly (requires Java 21+):
 
 **Getting the JAR file:**
 - **Download** from [GitHub Releases](https://github.com/Contrast-Security-OSS/mcp-contrast/releases/latest) (recommended)
-- **Build** from source ([instructions](../../README.md#build-from-source))
+- **Build** from source ([instructions](../local-mcp-server.md#build-from-source))
 
 Replace `/path/to/mcp-contrast-X.X.X.jar` with the path to your downloaded or built JAR file.
 
@@ -134,11 +134,11 @@ If you encounter issues:
    docker pull contrast/mcp-contrast:latest
    ```
 
-For more troubleshooting help, see the [Common Issues](../../README.md#common-issues) section in the main README.
+For more troubleshooting help, see the [Common Issues](../local-mcp-server.md#common-issues) section in the Local MCP Server guide.
 
 ## Proxy Configuration
 
-If you're behind a corporate proxy, see the [Proxy Configuration](../../README.md#proxy-configuration) section in the main README.
+If you're behind a corporate proxy, see the [Proxy Configuration](../local-mcp-server.md#proxy-configuration) section in the Local MCP Server guide.
 
 ## Benefits of Using oterm
 

--- a/docs/installation-guides/install-vscode.md
+++ b/docs/installation-guides/install-vscode.md
@@ -129,7 +129,7 @@ If you prefer to run the JAR directly (requires Java 21+):
 
 **Getting the JAR file:**
 - **Download** from [GitHub Releases](https://github.com/Contrast-Security-OSS/mcp-contrast/releases/latest) (recommended)
-- **Build** from source ([instructions](../../README.md#build-from-source))
+- **Build** from source ([instructions](../local-mcp-server.md#build-from-source))
 
 Replace `/path/to/mcp-contrast-X.X.X.jar` with the path to your downloaded or built JAR file and update the credential values.
 
@@ -195,8 +195,8 @@ If you encounter issues:
 - Select "MCP Servers" from the dropdown
 - Look for error messages or connection status
 
-For more troubleshooting help, see the [Common Issues](../../README.md#common-issues) section in the main README.
+For more troubleshooting help, see the [Common Issues](../local-mcp-server.md#common-issues) section in the Local MCP Server guide.
 
 ## Proxy Configuration
 
-If you're behind a corporate proxy, see the [Proxy Configuration](../../README.md#proxy-configuration) section in the main README.
+If you're behind a corporate proxy, see the [Proxy Configuration](../local-mcp-server.md#proxy-configuration) section in the Local MCP Server guide.

--- a/docs/installation-guides/install-vscode.md
+++ b/docs/installation-guides/install-vscode.md
@@ -1,6 +1,8 @@
 # Installing Contrast MCP Server in VS Code (GitHub Copilot)
 
-This guide covers how to install and configure the Contrast MCP Server in VS Code with GitHub Copilot.
+This guide covers how to install and configure the Contrast Local MCP Server in VS Code with GitHub Copilot.
+
+> **This is a Local MCP Server guide.** It runs the open-source server as a local process using Contrast API and service keys. If you use Contrast SaaS, the [Hosted MCP Server](./install-hosted.md) is easier to set up and needs no local process or keys.
 
 > [!NOTE] Official VS Code Documentation Reference
 > VS Code's full documentation for MCP servers can be found here: https://code.visualstudio.com/docs/copilot/customization/mcp-servers

--- a/docs/local-mcp-server.md
+++ b/docs/local-mcp-server.md
@@ -1,0 +1,208 @@
+# Local MCP Server guide
+
+Reference material for the [Local MCP Server](../README.md#local-mcp-server). For installation, see the [README quick start](../README.md#quick-start) and the per-client [installation guides](installation-guides/).
+
+## Getting the JAR File
+
+If you're using JAR deployment (instead of Docker), you'll need the JAR file:
+
+### Download (Recommended)
+
+Download the latest pre-built JAR from [GitHub Releases](https://github.com/Contrast-Security-OSS/mcp-contrast/releases/latest).
+
+The JAR file will be named `mcp-contrast-X.X.X.jar`.
+
+### Verifying the Download
+
+Each release JAR is signed with a [GitHub build provenance attestation](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds), which proves the JAR was built by this repository's release workflow. Verify a downloaded JAR with the [GitHub CLI](https://cli.github.com/):
+
+```bash
+gh attestation verify mcp-contrast-X.X.X.jar --repo Contrast-Security-OSS/mcp-contrast
+```
+
+A successful check confirms the JAR was produced by the official release workflow and has not been altered. No key import or fingerprint comparison is required. The GitHub CLI validates the attestation against the public Sigstore transparency log.
+
+### Build from Source
+
+Alternatively, you can build from source if you need the latest development version. Requires Java 21+:
+
+```bash
+./gradlew :contrast-mcp-stdio-app:bootJar
+```
+
+The built JAR will be located at `contrast-mcp-stdio-app/build/libs/mcp-contrast-X.X.X-SNAPSHOT.jar`
+
+## Proxy Configuration
+
+If you're behind a corporate firewall or proxy, you'll need to configure proxy settings for the MCP server to reach your Contrast instance. The configuration differs depending on whether you're using Docker or JAR deployment.
+
+### Java Process (JAR Deployment)
+
+Choose ONE of the following based on how you're running the JAR:
+
+#### Direct Java Command
+
+Use this if you're running the JAR directly from the command line or a script.
+
+Add these two system properties to your `java` command:
+
+```
+-Dhttp_proxy_host=proxy.example.com
+-Dhttp_proxy_port=8080
+```
+
+**Complete example:**
+```bash
+java \
+  -Dhttp_proxy_host=proxy.example.com \
+  -Dhttp_proxy_port=8080 \
+  -jar /path/to/mcp-contrast-X.X.X.jar \
+  --CONTRAST_HOST_NAME=example.contrastsecurity.com \
+  --CONTRAST_API_KEY=example \
+  --CONTRAST_SERVICE_KEY=example \
+  --CONTRAST_USERNAME=example@example.com \
+  --CONTRAST_ORG_ID=example
+```
+
+#### MCP Configuration File
+
+Use this if you're running the JAR through an MCP host (IntelliJ, Claude Desktop, Cline, etc.).
+
+Add these two lines to the beginning of your `args` array:
+
+```json
+"-Dhttp_proxy_host=proxy.example.com",
+"-Dhttp_proxy_port=8080",
+```
+
+**Complete example using IntelliJ's `mcp.json`:**
+```json
+{
+  "servers": {
+    "contrast": {
+      "command": "java",
+      "args": [
+        "-Dhttp_proxy_host=proxy.example.com",
+        "-Dhttp_proxy_port=8080",
+        "-jar",
+        "/path/to/mcp-contrast-X.X.X.jar",
+        "--CONTRAST_HOST_NAME=example.contrastsecurity.com",
+        "--CONTRAST_API_KEY=example",
+        "--CONTRAST_SERVICE_KEY=example",
+        "--CONTRAST_USERNAME=example@example.com",
+        "--CONTRAST_ORG_ID=example"
+      ]
+    }
+  }
+}
+```
+
+### Docker (Docker Deployment)
+
+Choose ONE of the following based on how you're running Docker:
+
+#### Direct Docker Run Command
+
+Use this if you're running Docker directly from the command line.
+
+Add these two environment variables to your `docker run` command:
+
+```bash
+-e http_proxy_host="proxy.example.com" \
+-e http_proxy_port="8080" \
+```
+
+**Complete example:**
+```bash
+docker run \
+  -e http_proxy_host="proxy.example.com" \
+  -e http_proxy_port="8080" \
+  -e CONTRAST_HOST_NAME=example.contrastsecurity.com \
+  -e CONTRAST_API_KEY=example \
+  -e CONTRAST_SERVICE_KEY=example \
+  -e CONTRAST_USERNAME=example \
+  -e CONTRAST_ORG_ID=example \
+  -i --rm \
+  contrast/mcp-contrast:latest \
+  -t stdio
+```
+
+#### MCP Configuration File
+
+Use this if you're running Docker through an MCP host (IntelliJ, VS Code, Claude Desktop, Cline, etc.).
+
+Add these proxy settings:
+
+Add to the `args` array (after the Contrast credentials):
+```json
+"-e", "http_proxy_host",
+"-e", "http_proxy_port",
+```
+
+Add to the `env` object:
+```json
+"http_proxy_host": "proxy.example.com",
+"http_proxy_port": "8080"
+```
+
+**Complete example using IntelliJ's `mcp.json`:**
+```json
+{
+  "servers": {
+    "contrast": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-e", "CONTRAST_HOST_NAME",
+        "-e", "CONTRAST_API_KEY",
+        "-e", "CONTRAST_SERVICE_KEY",
+        "-e", "CONTRAST_USERNAME",
+        "-e", "CONTRAST_ORG_ID",
+        "-e", "http_proxy_host",
+        "-e", "http_proxy_port",
+        "-i", "--rm",
+        "contrast/mcp-contrast:latest",
+        "-t", "stdio"
+      ],
+      "env": {
+        "CONTRAST_HOST_NAME": "example.contrastsecurity.com",
+        "CONTRAST_API_KEY": "example",
+        "CONTRAST_SERVICE_KEY": "example",
+        "CONTRAST_USERNAME": "example@example.com",
+        "CONTRAST_ORG_ID": "example",
+        "http_proxy_host": "proxy.example.com",
+        "http_proxy_port": "8080"
+      }
+    }
+  }
+}
+```
+
+For VS Code with input variables, see the [VS Code Installation Guide](installation-guides/install-vscode.md).
+
+## Common Issues
+If you are experiencing issues with the MCP server, here are some common troubleshooting steps:
+### Review Log
+A log will be created, by default under `/tmp/mcp-contrast.log` either locally or within the Docker container. You can view this log to see if there are any errors or issues with the MCP server.
+
+### Enable Debug Logging
+To enable debug logging you can add the following flag to the command line arguments when running the MCP server:
+`--logging.level.root=DEBUG`
+This can be added at this part of the docker command
+```
+        "--rm",
+        "contrast/mcp-contrast:latest",
+        "-t",
+        "--logging.level.root=DEBUG",
+        "stdio"
+        ],
+```
+
+### Certificate Issues
+If the SSL Certificate for the Teamserver URL is not trusted, you may see the following error:
+```
+Failed to list applications: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
+```
+If this occurs you will need to add the certificate to the Java Truststore and then add the following to the command line arguments when running the MCP server:
+`-Djavax.net.ssl.trustStore=/location/to/mcp-truststore.jks, -Djavax.net.ssl.trustStorePassword=yourpassword`
+More details on how to do this can be found in the [Java documentation](https://docs.oracle.com/cd/E19509-01/820-3503/6nf1il6er/index.html). Or ask your LLM to help you with this.


### PR DESCRIPTION
**Jira:** [AIML-976](https://contrast.atlassian.net/browse/AIML-976)

## Summary
Restructure the public `mcp-contrast` README to lead with the Contrast Hosted MCP Server (the remote, OAuth, run-by-Contrast option) and present the existing Local MCP Server second, mirroring the Atlassian and `github-mcp-server` hosted-first pattern.

- Hosted server documented first as the recommended path, with connect steps, a supported-clients matrix, and a read-only tool list
- Existing local (stdio) setup retained and framed as the secondary path
- New per-client hosted install guide added, heavy local reference relocated to keep the README lean

## Why This Change Exists
Until now the repo only documented the local stdio server with per-developer API keys. A hosted server now exists and is the simplest path for Contrast SaaS, so the repo should point people there first while keeping the local option for on-premises and EOP. This satisfies AIML-976, whose acceptance criteria are to advertise the hosted option, retain self-host as the secondary path, and mirror the Atlassian hosted-first structure.

## Approach
The two servers needed names. The pair is **Hosted MCP Server** (the product brand) and **Local MCP Server**. "Remote" is woven into the hosted copy for search discoverability, since GitHub, Atlassian, Cloudflare, and Sentry all describe the vendor-run server as remote. We rejected "self-hosted" because the existing server is verified stdio-only and the MCP spec defines "local" as a process on the user's own machine, which is exactly what it is. We also kept "Hosted" as the brand rather than renaming it "remote". The decision and rejected alternatives are recorded as ADR-019 in the aiml-services repo.

Structure follows `github-mcp-server`. One lean README with prose steering instead of a comparison table, tool tables split per deployment, and details pushed into subdocs. The public repo cannot link to the internal Confluence User Guide, so the facts public readers need live in the repo itself.

## What Changed
### README
- `README.md` reorganized hosted-first. The new intro steers SaaS to Hosted and on-prem/EOP to Local, the shared LLM data warning is kept up top, hosted and local tool tables are separate, and the hosted set is marked read-only with NorthStar-gated issue tools.

### New docs
- `docs/installation-guides/install-hosted.md` (new) is the per-client hosted setup with a supported-clients matrix and troubleshooting.
- `docs/local-mcp-server.md` (new) holds the JAR download and verification, proxy configuration, and troubleshooting moved verbatim out of the README.

### Link repointing
- The per-client install guides now point at `docs/local-mcp-server.md` for the relocated sections instead of the old README anchors.

<details>
<summary>Mechanical / low-risk changes (7 files)</summary>

Inbound-link updates only, no content change. `docs/installation-guides/README.md`, `install-claude-code.md`, `install-claude-desktop.md`, `install-cline.md`, `install-intellij.md`, `install-oterm.md`, and `install-vscode.md` each had their `../../README.md#{build-from-source,common-issues,proxy-configuration,getting-the-jar-file}` links repointed to `../local-mcp-server.md`, and the "in the main README" wording corrected.

</details>

## Testing
No automated tests apply to docs. Verified by grep that every inbound link to a relocated section now resolves to `docs/local-mcp-server.md`, and that no stale `../../README.md#` anchors remain except the valid hosted-server link. The README contents anchors were checked against the headings they target. This repo has no automated link checking in CI, so a rendered-preview pass on GitHub before merge is worth doing.

## Risks / Rollout / Follow-ups
- **Public content.** The `app.contrastsecurity.com/mcp` URL, the "available now for Contrast SaaS" framing, and the supported-client list should pass product and marketing review before this leaves draft. It is kept as a draft for that reason.
- The Codex CLI, GitHub Copilot CLI, and opencode subsections use generic "add as an HTTP MCP server" wording rather than invented exact commands. Worth a follow-up once exact commands are confirmed.
- Minor internal doc drift. The Support Enablement Guide lists 26 hosted tools and the User Guide lists 27. The README groups by domain and avoids a hard count.


[AIML-976]: https://contrast.atlassian.net/browse/AIML-976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ