### PR TITLE
AIML-1056 Fix CVE CVSS mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Breaking Changes
+
+**CVE score accessors now use `Double`**: The published `contrast-mcp-core` `Cve` model changed `getScore()` and `setScore()` from primitive `double` to nullable `Double` so unavailable scores can be represented accurately. Consumers compiled against the previous signature must recompile.
+
+### Improvements
+
+**Richer CVE scoring details**: `list_applications_by_cve` responses now include nested `cvssv2` and `cvssv3` metrics plus a preferred `severity`. CVSS v3 scores remain available through `score`; v2-only CVEs omit `score` instead of reporting `0.0`. A null `score` is also omitted from `get_protect_rules` CVE output.
+
 ## [2.0.0] - 2026-06-01
 
 ### Breaking Changes

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/Cve.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/Cve.java
@@ -30,10 +30,19 @@ public class Cve {
   private String cwe;
   private Double epssScore;
   private Double epssPercentile;
+
+  /** Whether the CVE appears in CISA's Known Exploited Vulnerabilities catalog. */
   private Boolean cisa;
+
   private String cvssScoreSource;
+
+  /** NVD publication time as Unix epoch milliseconds. */
   private Long nvdPublished;
+
+  /** NVD modification time as Unix epoch milliseconds. */
   private Long nvdModified;
+
+  /** First-seen time as Unix epoch milliseconds. */
   private Long firstSeen;
 
   // Legacy flat CVSS fields retained for the get_protect_rules contract.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/Cve.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/Cve.java
@@ -24,9 +24,7 @@ import lombok.Data;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Cve {
   private Long id;
-  private String availabilityImpact;
   private String name;
-  private String uuid;
   private String description;
   private String status;
   private String cwe;
@@ -37,14 +35,21 @@ public class Cve {
   private Long nvdPublished;
   private Long nvdModified;
   private Long firstSeen;
-  private String severity;
+
+  // Legacy flat CVSS fields retained for the get_protect_rules contract.
+  private String uuid;
   private String accessVector;
   private String accessComplexity;
   private String authentication;
   private String confidentialityImpact;
   private String integrityImpact;
-  private Double score;
+  private String availabilityImpact;
   private List<String> references;
+
   private CvssV2 cvssv2;
   private CvssV3 cvssv3;
+
+  // Preferred summary derived from the nested CVSS data.
+  private Double score;
+  private String severity;
 }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/CvssV2.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/CvssV2.java
@@ -15,10 +15,12 @@
  */
 package com.contrast.labs.ai.mcp.contrast.sdkextension.data;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 
 /** Class representing CVSS v2 scoring details for a CVE. */
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CvssV2 {
 
   private String accessVector;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/CvssV2.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/CvssV2.java
@@ -15,36 +15,25 @@
  */
 package com.contrast.labs.ai.mcp.contrast.sdkextension.data;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import java.util.List;
 import lombok.Data;
 
-/** Class representing CVE vulnerability information. */
+/** Class representing CVSS v2 scoring details for a CVE. */
 @Data
-@JsonInclude(JsonInclude.Include.NON_NULL)
-public class Cve {
-  private Long id;
-  private String availabilityImpact;
-  private String name;
-  private String uuid;
-  private String description;
-  private String status;
-  private String cwe;
-  private Double epssScore;
-  private Double epssPercentile;
-  private Boolean cisa;
-  private String cvssScoreSource;
-  private Long nvdPublished;
-  private Long nvdModified;
-  private Long firstSeen;
-  private String severity;
+public class CvssV2 {
+
   private String accessVector;
   private String accessComplexity;
   private String authentication;
   private String confidentialityImpact;
   private String integrityImpact;
-  private Double score;
-  private List<String> references;
-  private CvssV2 cvssv2;
-  private CvssV3 cvssv3;
+  private String availabilityImpact;
+  private String exploitability;
+  private String remediationLevel;
+  private String reportConfidence;
+  private String collateralDamagePotential;
+  private String targetDistribution;
+  private String confidentialityRequirement;
+  private String integrityRequirement;
+  private String availabilityRequirement;
+  private String severity;
 }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/CvssV3.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/CvssV3.java
@@ -15,10 +15,12 @@
  */
 package com.contrast.labs.ai.mcp.contrast.sdkextension.data;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 
 /** Class representing CVSS v3 scoring details for a CVE. */
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CvssV3 {
 
   private String attackVector;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
@@ -143,6 +143,7 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
       cve.setScore(cve.getCvssv3().getBaseScore());
       cve.setSeverity(cve.getCvssv3().getSeverity());
     } else if (cve.getCvssv2() != null) {
+      cve.setScore(null);
       cve.setSeverity(cve.getCvssv2().getSeverity());
     }
   }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
@@ -136,10 +136,13 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
   }
 
   private static void applyPreferredCvssSummary(Cve cve) {
-    if (cve != null && cve.getCvssv3() != null) {
+    if (cve == null) {
+      return;
+    }
+    if (cve.getCvssv3() != null) {
       cve.setScore(cve.getCvssv3().getBaseScore());
       cve.setSeverity(cve.getCvssv3().getSeverity());
-    } else if (cve != null && cve.getCvssv2() != null) {
+    } else if (cve.getCvssv2() != null) {
       cve.setSeverity(cve.getCvssv2().getSeverity());
     }
   }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
@@ -17,6 +17,7 @@ package com.contrast.labs.ai.mcp.contrast.tool.library;
 
 import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.App;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.data.Cve;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.CveData;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.Library;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.LibraryExtended;
@@ -60,7 +61,7 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
           Takes a CVE ID (e.g., CVE-2021-44228) and returns:
           - apps: List of applications containing vulnerable libraries
           - libraries: The vulnerable library versions
-          - cve: CVE details including severity and description
+          - cve: CVE details including preferred CVSS score/severity and nested v2/v3 metrics
 
           For each application, class usage data is populated:
           - classCount: Total classes in the vulnerable library
@@ -69,6 +70,9 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
           Important: If classUsage is 0, the vulnerable library code is likely NOT
           being executed, significantly reducing exploitability risk. Prioritize
           remediation for applications where classUsage > 0.
+
+          score is absent for v2-only CVEs because TeamServer does not provide a numeric v2
+          base score; use severity and cvssv2 metrics in that case.
 
           Related tools:
           - list_application_libraries: Get all libraries for a specific application
@@ -94,6 +98,7 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
     if (cveData == null) {
       return null; // SingleTool converts this to notFound response
     }
+    applyPreferredCvssSummary(cveData.getCve());
     dedupeServersById(cveData);
 
     var vulnerableLibs =
@@ -128,6 +133,15 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
         apps.size());
 
     return cveData;
+  }
+
+  private static void applyPreferredCvssSummary(Cve cve) {
+    if (cve != null && cve.getCvssv3() != null) {
+      cve.setScore(cve.getCvssv3().getBaseScore());
+      cve.setSeverity(cve.getCvssv3().getSeverity());
+    } else if (cve != null && cve.getCvssv2() != null) {
+      cve.setSeverity(cve.getCvssv2().getSeverity());
+    }
   }
 
   private void enrichAppsWithClassUsage(

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/CveTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/CveTest.java
@@ -42,7 +42,14 @@ class CveTest {
         .contains(
             "\"name\":\"CVE-2015-4000\"", "\"severity\":\"High\"", "\"severity\":\"Critical\"")
         .doesNotContain(
-            "\"score\"", "\"uuid\"", "\"references\"", "\"exploitability\"", "\"attackVector\"");
+            "\"score\"",
+            "\"uuid\"",
+            "\"references\"",
+            "\"id\"",
+            "\"epssScore\"",
+            "\"cisa\"",
+            "\"exploitability\"",
+            "\"attackVector\"");
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/CveTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/CveTest.java
@@ -32,12 +32,17 @@ class CveTest {
     var cvssv2 = new CvssV2();
     cvssv2.setSeverity("High");
     cve.setCvssv2(cvssv2);
+    var cvssv3 = new CvssV3();
+    cvssv3.setSeverity("Critical");
+    cve.setCvssv3(cvssv3);
 
     var json = objectMapper.writeValueAsString(cve);
 
     assertThat(json)
-        .contains("\"name\":\"CVE-2015-4000\"", "\"severity\":\"High\"")
-        .doesNotContain("\"score\"", "\"uuid\"", "\"references\"");
+        .contains(
+            "\"name\":\"CVE-2015-4000\"", "\"severity\":\"High\"", "\"severity\":\"Critical\"")
+        .doesNotContain(
+            "\"score\"", "\"uuid\"", "\"references\"", "\"exploitability\"", "\"attackVector\"");
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/CveTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/CveTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.sdkextension.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.contrastsecurity.sdk.internal.GsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class CveTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  void jackson_should_omit_unavailable_cve_fields() throws Exception {
+    var cve = new Cve();
+    cve.setName("CVE-2015-4000");
+    var cvssv2 = new CvssV2();
+    cvssv2.setSeverity("High");
+    cve.setCvssv2(cvssv2);
+
+    var json = objectMapper.writeValueAsString(cve);
+
+    assertThat(json)
+        .contains("\"name\":\"CVE-2015-4000\"", "\"severity\":\"High\"")
+        .doesNotContain("\"score\"", "\"uuid\"", "\"references\"");
+  }
+
+  @Test
+  void gson_should_preserve_legacy_flat_cve_fields_used_by_protect_rules() {
+    var protectData =
+        GsonFactory.create()
+            .fromJson(
+                """
+                {
+                  "success": true,
+                  "rules": [{
+                    "name": "Log4Shell",
+                    "type": "CVE",
+                    "cves": [{
+                      "name": "CVE-2021-44228",
+                      "uuid": "cve-2021-44228",
+                      "score": 9.3,
+                      "accessVector": "NETWORK",
+                      "accessComplexity": "LOW",
+                      "authentication": "NONE",
+                      "confidentialityImpact": "COMPLETE",
+                      "integrityImpact": "COMPLETE",
+                      "availabilityImpact": "COMPLETE",
+                      "references": [123]
+                    }]
+                  }]
+                }
+                """,
+                ProtectData.class);
+
+    assertThat(protectData.getRules())
+        .singleElement()
+        .satisfies(
+            rule ->
+                assertThat(rule.getCves())
+                    .singleElement()
+                    .satisfies(
+                        cve -> {
+                          assertThat(cve.getUuid()).isEqualTo("cve-2021-44228");
+                          assertThat(cve.getScore()).isEqualTo(9.3);
+                          assertThat(cve.getAccessVector()).isEqualTo("NETWORK");
+                          assertThat(cve.getReferences()).containsExactly("123");
+                        }));
+  }
+}

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
@@ -172,6 +172,7 @@ class ListApplicationsByCveToolTest {
   void listApplicationsByCve_should_fallback_to_cvss_v2_severity_when_cvss_v3_is_absent()
       throws Exception {
     var cveData = GsonFactory.create().fromJson(CVSS_V2_CVE_RESPONSE, CveData.class);
+    cveData.getCve().setScore(9.9);
     when(contrastApiClient.getApplicationsByCve(eq("CVE-2015-4000"))).thenReturn(cveData);
 
     var result = tool.listApplicationsByCve("CVE-2015-4000", null);

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
@@ -23,7 +23,9 @@ import static org.mockito.Mockito.when;
 
 import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.App;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.data.Cve;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.CveData;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.data.CvssV3;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.Library;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.LibraryExtended;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.Server;
@@ -186,6 +188,39 @@ class ListApplicationsByCveToolTest {
             cvss -> cvss.getIntegrityImpact(),
             cvss -> cvss.getAvailabilityImpact())
         .containsExactly("NETWORK", "MEDIUM", "NONE", "PARTIAL", "NONE", "NONE");
+  }
+
+  @Test
+  void listApplicationsByCve_should_leave_summary_absent_when_cve_has_no_cvss_data()
+      throws Exception {
+    var cve = new Cve();
+    var cveData = cveData(cve);
+    when(contrastApiClient.getApplicationsByCve(eq(CVE_ID))).thenReturn(cveData);
+
+    var result = tool.listApplicationsByCve(CVE_ID, null);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.data().getCve()).isSameAs(cve);
+    assertThat(result.data().getCve())
+        .extracting(Cve::getScore, Cve::getSeverity)
+        .containsExactly(null, null);
+  }
+
+  @Test
+  void listApplicationsByCve_should_leave_severity_absent_when_cvss_v3_severity_is_absent()
+      throws Exception {
+    var cvssv3 = new CvssV3();
+    cvssv3.setBaseScore(7.5);
+    var cve = new Cve();
+    cve.setCvssv3(cvssv3);
+    var cveData = cveData(cve);
+    when(contrastApiClient.getApplicationsByCve(eq(CVE_ID))).thenReturn(cveData);
+
+    var result = tool.listApplicationsByCve(CVE_ID, null);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.data().getCve().getScore()).isEqualTo(7.5);
+    assertThat(result.data().getCve().getSeverity()).isNull();
   }
 
   @Test
@@ -383,6 +418,14 @@ class ListApplicationsByCveToolTest {
     var cveData = new CveData();
     cveData.setApps(List.of(app));
     cveData.setLibraries(List.of(library));
+    return cveData;
+  }
+
+  private static CveData cveData(Cve cve) {
+    var cveData = new CveData();
+    cveData.setCve(cve);
+    cveData.setApps(List.of());
+    cveData.setLibraries(List.of());
     return cveData;
   }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
@@ -148,6 +148,8 @@ class ListApplicationsByCveToolTest {
     assertThat(result.data().getCve())
         .extracting(
             cve -> cve.getId(),
+            cve -> cve.getDescription(),
+            cve -> cve.getStatus(),
             cve -> cve.getCwe(),
             cve -> cve.getEpssScore(),
             cve -> cve.getEpssPercentile(),
@@ -158,6 +160,8 @@ class ListApplicationsByCveToolTest {
             cve -> cve.getFirstSeen())
         .containsExactly(
             12345L,
+            "Apache Log4j remote code execution",
+            "unseen",
             "CWE-502",
             0.97565,
             0.99996,

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
@@ -29,6 +29,7 @@ import com.contrast.labs.ai.mcp.contrast.sdkextension.data.LibraryExtended;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.Server;
 import com.contrastsecurity.exceptions.HttpResponseException;
 import com.contrastsecurity.exceptions.ResourceNotFoundException;
+import com.contrastsecurity.sdk.internal.GsonFactory;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.List;
@@ -45,6 +46,58 @@ class ListApplicationsByCveToolTest {
   private static final String CVE_ID = "CVE-2021-44228";
   private static final String LIBRARY_HASH = "hash-123";
   private static final String SECRET_BODY = "token=raw-token-value&apiKey=secret";
+  private static final String CVSS_V3_CVE_RESPONSE =
+      """
+      {
+        "cve": {
+          "id": 12345,
+          "name": "CVE-2021-44228",
+          "description": "Apache Log4j remote code execution",
+          "status": "unseen",
+          "cwe": "CWE-502",
+          "epssScore": 0.97565,
+          "epssPercentile": 0.99996,
+          "cisa": true,
+          "cvssScoreSource": "NVD",
+          "nvdPublished": 1639008000000,
+          "nvdModified": 1716336000000,
+          "firstSeen": 1640995200000,
+          "cvssv2": {
+            "severity": "High"
+          },
+          "cvssv3": {
+            "baseScore": 9.3,
+            "severity": "Critical"
+          }
+        },
+        "apps": [],
+        "libraries": [],
+        "servers": []
+      }
+      """;
+  private static final String CVSS_V2_CVE_RESPONSE =
+      """
+      {
+        "cve": {
+          "id": 2,
+          "name": "CVE-2015-4000",
+          "description": "TLS weak Diffie-Hellman key exchange",
+          "status": "seen",
+          "cvssv2": {
+            "accessVector": "NETWORK",
+            "accessComplexity": "MEDIUM",
+            "authentication": "NONE",
+            "confidentialityImpact": "PARTIAL",
+            "integrityImpact": "NONE",
+            "availabilityImpact": "NONE",
+            "severity": "High"
+          }
+        },
+        "apps": [],
+        "libraries": [],
+        "servers": []
+      }
+      """;
 
   private ContrastApiClient contrastApiClient;
   private ListApplicationsByCveTool tool;
@@ -77,6 +130,62 @@ class ListApplicationsByCveToolTest {
               assertThat(enriched.getClassCount()).isEqualTo(42);
               assertThat(enriched.getClassUsage()).isEqualTo(7);
             });
+  }
+
+  @Test
+  void listApplicationsByCve_should_return_cvss_v3_score_when_teamserver_nests_cvss_data()
+      throws Exception {
+    var cveData = GsonFactory.create().fromJson(CVSS_V3_CVE_RESPONSE, CveData.class);
+    when(contrastApiClient.getApplicationsByCve(eq(CVE_ID))).thenReturn(cveData);
+
+    var result = tool.listApplicationsByCve(CVE_ID, null);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.data().getCve().getScore()).isEqualTo(9.3);
+    assertThat(result.data().getCve().getSeverity()).isEqualTo("Critical");
+    assertThat(result.data().getCve())
+        .extracting(
+            cve -> cve.getId(),
+            cve -> cve.getCwe(),
+            cve -> cve.getEpssScore(),
+            cve -> cve.getEpssPercentile(),
+            cve -> cve.getCisa(),
+            cve -> cve.getCvssScoreSource(),
+            cve -> cve.getNvdPublished(),
+            cve -> cve.getNvdModified(),
+            cve -> cve.getFirstSeen())
+        .containsExactly(
+            12345L,
+            "CWE-502",
+            0.97565,
+            0.99996,
+            true,
+            "NVD",
+            1639008000000L,
+            1716336000000L,
+            1640995200000L);
+  }
+
+  @Test
+  void listApplicationsByCve_should_fallback_to_cvss_v2_severity_when_cvss_v3_is_absent()
+      throws Exception {
+    var cveData = GsonFactory.create().fromJson(CVSS_V2_CVE_RESPONSE, CveData.class);
+    when(contrastApiClient.getApplicationsByCve(eq("CVE-2015-4000"))).thenReturn(cveData);
+
+    var result = tool.listApplicationsByCve("CVE-2015-4000", null);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.data().getCve().getSeverity()).isEqualTo("High");
+    assertThat(result.data().getCve().getScore()).isNull();
+    assertThat(result.data().getCve().getCvssv2())
+        .extracting(
+            cvss -> cvss.getAccessVector(),
+            cvss -> cvss.getAccessComplexity(),
+            cvss -> cvss.getAuthentication(),
+            cvss -> cvss.getConfidentialityImpact(),
+            cvss -> cvss.getIntegrityImpact(),
+            cvss -> cvss.getAvailabilityImpact())
+        .containsExactly("NETWORK", "MEDIUM", "NONE", "PARTIAL", "NONE", "NONE");
   }
 
   @Test

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolIT.java
@@ -43,10 +43,6 @@ class ListApplicationsByCveToolIT
 
   @Autowired private ListApplicationsByCveTool tool;
 
-  // CVSS v3 scores range from 0.0 to 10.0 inclusive.
-  private static final double MIN_CVSS_SCORE = 0.0;
-  private static final double MAX_CVSS_SCORE = 10.0;
-
   // Percentage fields in ImpactStats are reported on a 0–100 scale.
   private static final double MIN_PERCENTAGE = 0.0;
   private static final double MAX_PERCENTAGE = 100.0;
@@ -181,9 +177,13 @@ class ListApplicationsByCveToolIT
     assertThat(cve.getDescription())
         .as("cve.description must be populated for a known CVE")
         .isNotBlank();
+    assertThat(cve.getCvssv3() != null || cve.getCvssv2() != null)
+        .as("cve must expose at least one nested CVSS version")
+        .isTrue();
+    assertThat(cve.getSeverity()).as("cve.severity must be derived from CVSS data").isNotBlank();
     assertThat(cve.getScore())
-        .as("cve.score must be within CVSS range [%s, %s]", MIN_CVSS_SCORE, MAX_CVSS_SCORE)
-        .isBetween(MIN_CVSS_SCORE, MAX_CVSS_SCORE);
+        .as("cve.score must match cvssv3.baseScore when CVSS v3 is available")
+        .isEqualTo(cve.getCvssv3() == null ? null : cve.getCvssv3().getBaseScore());
   }
 
   @Test

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolIT.java
@@ -181,9 +181,12 @@ class ListApplicationsByCveToolIT
     assertThat(cve.getDescription())
         .as("cve.description must be populated for a known CVE")
         .isNotBlank();
-    assertThat(cve.getCvssv3() != null || cve.getCvssv2() != null)
-        .as("cve must expose at least one nested CVSS version")
-        .isTrue();
+    assertThat(cve)
+        .satisfiesAnyOf(
+            candidate ->
+                assertThat(candidate.getCvssv3()).as("cve.cvssv3 must be populated").isNotNull(),
+            candidate ->
+                assertThat(candidate.getCvssv2()).as("cve.cvssv2 must be populated").isNotNull());
     assertThat(cve.getSeverity()).as("cve.severity must be derived from CVSS data").isNotBlank();
     if (cve.getCvssv3() != null) {
       assertThat(cve.getScore())

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolIT.java
@@ -43,6 +43,10 @@ class ListApplicationsByCveToolIT
 
   @Autowired private ListApplicationsByCveTool tool;
 
+  // CVSS v3 scores range from 0.0 to 10.0 inclusive.
+  private static final double MIN_CVSS_SCORE = 0.0;
+  private static final double MAX_CVSS_SCORE = 10.0;
+
   // Percentage fields in ImpactStats are reported on a 0–100 scale.
   private static final double MIN_PERCENTAGE = 0.0;
   private static final double MAX_PERCENTAGE = 100.0;
@@ -181,9 +185,12 @@ class ListApplicationsByCveToolIT
         .as("cve must expose at least one nested CVSS version")
         .isTrue();
     assertThat(cve.getSeverity()).as("cve.severity must be derived from CVSS data").isNotBlank();
-    assertThat(cve.getScore())
-        .as("cve.score must match cvssv3.baseScore when CVSS v3 is available")
-        .isEqualTo(cve.getCvssv3() == null ? null : cve.getCvssv3().getBaseScore());
+    if (cve.getCvssv3() != null) {
+      assertThat(cve.getScore())
+          .as("cve.score must be within CVSS range [%s, %s]", MIN_CVSS_SCORE, MAX_CVSS_SCORE)
+          .isNotNull()
+          .isBetween(MIN_CVSS_SCORE, MAX_CVSS_SCORE);
+    }
   }
 
   @Test

--- a/manual-tests/list-applications-by-cve-manual-test.md
+++ b/manual-tests/list-applications-by-cve-manual-test.md
@@ -3,7 +3,7 @@
 ## Overview
 
 The `list_applications_by_cve` tool finds applications and libraries affected by a specific CVE. Given a CVE ID, it returns:
-- **cve**: CVE details including name, description, and severity
+- **cve**: CVE details including name, description, preferred severity, preferred CVSS v3 `score` (omitted for v2-only CVEs), and nested `cvssv2`/`cvssv3` metrics
 - **apps**: List of applications containing vulnerable libraries with class usage data
 - **libraries**: The vulnerable library versions
 - **impactStats**: Statistics about affected applications and servers

--- a/test-plans/test-plan-list_applications_by_cve.md
+++ b/test-plans/test-plan-list_applications_by_cve.md
@@ -41,7 +41,7 @@ SingleToolResponse {
 
 // CveData structure:
 CveData {
-    Cve cve,                    // CVE details (name, score, description)
+    Cve cve,                    // CVE details plus preferred and nested CVSS data
     ImpactStats impactStats,    // Impact statistics
     List<Library> libraries,    // Vulnerable library versions
     List<App> apps,             // Affected applications
@@ -108,9 +108,10 @@ App {
 **cve object contains:**
 - `name`: CVE ID string (matches request)
 - `description`: Text description of vulnerability
-- `score`: CVSS score (0.0-10.0)
-- `availabilityImpact`, `confidentialityImpact`, `integrityImpact`: Impact ratings
-- `accessVector`, `accessComplexity`: Access information
+- `severity`: Preferred CVSS v3 severity, falling back to CVSS v2 severity
+- `score`: Preferred CVSS v3 score (0.0-10.0); absent for v2-only CVEs
+- `cvssv2`: Nested CVSS v2 metrics, including access and impact ratings
+- `cvssv3`: Nested CVSS v3 metrics, including attack, impact, vector, and score details
 - `references`: List of reference URLs
 
 **impactStats object contains:**


### PR DESCRIPTION
**Jira:** [AIML-1056](https://contrast.atlassian.net/browse/AIML-1056)

## Summary

Fix `list_applications_by_cve` so it returns a truthful CVSS score and severity. The tool previously reported `score: 0.0` and blank severity for **every** CVE (Log4Shell included), because the `Cve` model no longer matched TeamServer's CVE-detail response. This restores the severity/score signal agents rely on to prioritize CVE remediation, across both the hosted and stdio servers.

- Nested `cvssv2`/`cvssv3` data now deserializes and is exposed on the `cve` object.
- A single preferred `score`/`severity` is derived (CVSS v3, falling back to v2 severity).
- v2-only CVEs report an absent `score` instead of a misleading `0.0`.
- The legacy flat CVE contract consumed by `get_protect_rules` is preserved.

## Why This Change Exists

TeamServer's `GET /ng/organizations/{orgId}/cves/{cveId}` response nests CVSS metrics under `cvssv2`/`cvssv3` sub-objects and identifies the CVE by a numeric `id`, with no top-level `score` or `references`. Our `Cve` model still declared the old flat, NVD-style shape: a primitive `double score` and top-level CVSS vector strings.

Gson matches field names exactly with no naming policy and no `@SerializedName` remap, so only `name`, `description`, and `status` lined up. The nested `cvssv2`/`cvssv3` objects were silently dropped, and because `score` was a primitive `double`, the missing property defaulted to `0.0`. The net effect: every `list_applications_by_cve` call returned blank severity and a `0.0` score in both the hosted server (`BearerTokenApiClient`) and the stdio app (`SDKExtension`), which share `contrast-mcp-core`. A `0.0` score is worse than missing data — it reads as "no severity." (`status: "unseen"` is unrelated passthrough and does not gate scoring.)

## Approach

- **Reshape `Cve` to the real `CveDetail` shape.** Wire in the already-present-but-unused `CvssV3` model and add `CvssV2`, plus the CVE-intelligence metadata TeamServer actually sends (`id`, `cwe`, `epssScore`, `epssPercentile`, `cisa`, `cvssScoreSource`, `nvdPublished`, `nvdModified`, `firstSeen`).
- **Normalize at the tool seam, not in the model.** `applyPreferredCvssSummary` sets `score`/`severity` from `cvssv3` when present, else `severity` from `cvssv2`. Keeps the model a plain DTO and the preference policy in one place.
- **Represent "no numeric score" as absent.** TeamServer gives no numeric v2 base score, so for v2-only CVEs `score` stays `null` rather than manufacturing `0.0`. `score` was changed from `double` to `Double` to allow this.
- **Nullable wrappers for all new fields** so legacy Protect CVEs (which lack this metadata) don't acquire misleading zeros/`false`.
- **`@JsonInclude(NON_NULL)`** on `Cve` so fields that don't apply to the current response (`score` on v2-only CVEs, and the legacy `uuid`/`references`) are omitted from the agent-facing JSON rather than emitted as `null`.
- The legacy flat CVE fields are retained on the model because `get_protect_rules` still deserializes that shape via Gson.

## What Changed

### CVE model (`contrast-mcp-core/.../sdkextension/data/`)
- `Cve.java` — added nested `cvssv2`/`cvssv3`, numeric `id`, and CVE-intelligence metadata; `score` is now `Double`; `@JsonInclude(NON_NULL)` added. Legacy flat fields retained for the Protect contract.
- `CvssV2.java` (new) — CVSS v2 metric block (vector fields + `severity`), mirroring the existing `CvssV3`.

### Tool response (`.../tool/library/ListApplicationsByCveTool.java`)
- Added `applyPreferredCvssSummary` to derive the preferred `score`/`severity`, called before dedupe.
- Updated the tool description to document the nested v2/v3 metrics and the v2-only absent-`score` caveat.

## Testing

- `CveTest` (new) — asserts Jackson omits unavailable fields (`score`/`uuid`/`references`) for a v2-only CVE, and that Gson still deserializes the **legacy flat** Protect CVE JSON (`uuid`, `score`, `accessVector`, `references`) so `get_protect_rules` is not regressed.
- `ListApplicationsByCveToolTest` (new cases) — parses TeamServer-shaped payloads through the public tool: a v3 CVE yields `score 9.3` / severity `Critical` with all intelligence metadata mapped, and a v2-only CVE falls back to severity `High` with `score` null and v2 vector fields populated.
- `ListApplicationsByCveToolIT` — the live assertion now requires at least one nested CVSS version, a non-blank derived `severity`, and `score` equal to `cvssv3.baseScore` (null when v3 is absent), replacing the old range-only check.
- `make check-test` passed (Spotless + Checkstyle + unit tests).

## Risks / Follow-ups

- `uuid` and `references` are not present in the current CVE-detail response and are now omitted from that path; they remain on the model and continue to populate for the legacy Protect flat shape.
- `make verify` surfaced six pre-existing seeded-data failures in `GetVulnerabilityToolIT` and `SearchAttacksToolIT` that reproduce on clean `origin/main` — unrelated to this change.


[AIML-1056]: https://contrast.atlassian.net/browse/AIML-1056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ