### PR TITLE
AIML-1057 Fix filtered route coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+
+**Session-filtered route coverage statistics were always zero**: Filtered route coverage now reports
+the correct total, exercised, and discovered route counts and coverage percentage.
+
 ## [2.0.0] - 2026-06-01
 
 ### Breaking Changes

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/routecoverage/RouteCoverageResponse.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/routecoverage/RouteCoverageResponse.java
@@ -30,7 +30,6 @@ public class RouteCoverageResponse {
   private List<String> messages;
   private List<Route> routes;
 
-  @SerializedName("count")
   private Integer count;
 
   @SerializedName("exercised_count")

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/routecoverage/RouteCoverageResponse.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/routecoverage/RouteCoverageResponse.java
@@ -15,6 +15,7 @@
  */
 package com.contrast.labs.ai.mcp.contrast.sdkextension.data.routecoverage;
 
+import com.google.gson.annotations.SerializedName;
 import java.util.List;
 import lombok.Data;
 
@@ -28,4 +29,13 @@ public class RouteCoverageResponse {
   private boolean success;
   private List<String> messages;
   private List<Route> routes;
+
+  @SerializedName("count")
+  private Integer count;
+
+  @SerializedName("exercised_count")
+  private Integer exercisedCount;
+
+  @SerializedName("discovered_count")
+  private Integer discoveredCount;
 }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageTool.java
@@ -50,14 +50,23 @@ public class GetRouteCoverageTool
           """
           Retrieves route coverage data for an application.
 
-          Routes can have two statuses:
+          Routes can have these statuses:
           - DISCOVERED: Found by Contrast Assess but has not received any HTTP requests
           - EXERCISED: Has received at least one HTTP request
+          - EXCLUDED: Excluded from route coverage tracking
 
           Response fields:
-          - routes: List of routes with coverage status and details
           - success: Whether the request completed successfully
-          - environments: Empty for session-filtered routes because the source omits this data
+          - messages: Informational messages returned by the service
+          - totalRoutes: Total number of routes
+          - exercisedCount: Number of routes with EXERCISED status
+          - discoveredCount: Number of routes with DISCOVERED status
+          - coveragePercent: Percentage of routes that are exercised
+          - totalVulnerabilities: Total vulnerabilities across the returned routes
+          - totalCriticalVulnerabilities: Critical vulnerabilities across the returned routes
+          - routes: List of routes with coverage status and details. Each route includes
+            environments; this list is empty for session-filtered routes because the source omits
+            that data.
 
           Filtering options (mutually exclusive):
           - No filter: Returns all routes across all sessions

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageTool.java
@@ -57,6 +57,7 @@ public class GetRouteCoverageTool
           Response fields:
           - routes: List of routes with coverage status and details
           - success: Whether the request completed successfully
+          - environments: Empty for session-filtered routes because the source omits this data
 
           Filtering options (mutually exclusive):
           - No filter: Returns all routes across all sessions

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/RouteMapper.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/RouteMapper.java
@@ -22,6 +22,7 @@ import com.contrast.labs.ai.mcp.contrast.sdkextension.data.routecoverage.RouteCo
 import java.util.Collections;
 import java.util.Optional;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 /**
  * Mapper for transforming Route objects into lightweight RouteLight representations. Eliminates
@@ -29,6 +30,9 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class RouteMapper {
+
+  private static final String STATUS_DISCOVERED = "DISCOVERED";
+  private static final String STATUS_EXERCISED = "EXERCISED";
 
   /**
    * Transform a Route object into a lightweight representation. Removes redundant app data, full
@@ -41,7 +45,7 @@ public class RouteMapper {
     return new RouteLight(
         route.getSignature(),
         Optional.ofNullable(route.getEnvironments()).orElse(Collections.emptyList()),
-        route.getStatus(),
+        statusFor(route),
         route.getRouteHash(),
         route.getVulnerabilities(),
         route.getCriticalVulnerabilities(),
@@ -71,16 +75,19 @@ public class RouteMapper {
     int totalCriticalVulnerabilities = 0;
 
     for (var route : routes) {
-      if ("EXERCISED".equalsIgnoreCase(route.getStatus())) {
+      var status = statusFor(route);
+      if (STATUS_EXERCISED.equalsIgnoreCase(status)) {
         exercisedCount++;
-      } else if ("DISCOVERED".equalsIgnoreCase(route.getStatus())) {
+      } else if (STATUS_DISCOVERED.equalsIgnoreCase(status)) {
         discoveredCount++;
       }
       totalVulnerabilities += route.getVulnerabilities();
       totalCriticalVulnerabilities += route.getCriticalVulnerabilities();
     }
 
-    int totalRoutes = routes.size();
+    int totalRoutes = Optional.ofNullable(response.getCount()).orElse(routes.size());
+    exercisedCount = Optional.ofNullable(response.getExercisedCount()).orElse(exercisedCount);
+    discoveredCount = Optional.ofNullable(response.getDiscoveredCount()).orElse(discoveredCount);
     double coveragePercent =
         totalRoutes > 0 ? Math.round((exercisedCount * 100.0) / totalRoutes * 100.0) / 100.0 : 0.0;
 
@@ -94,5 +101,12 @@ public class RouteMapper {
         totalVulnerabilities,
         totalCriticalVulnerabilities,
         lightRoutes);
+  }
+
+  private static String statusFor(Route route) {
+    if (StringUtils.hasText(route.getStatus())) {
+      return route.getStatus();
+    }
+    return route.getExercised() > 0 ? STATUS_EXERCISED : STATUS_DISCOVERED;
   }
 }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/RouteMapper.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/RouteMapper.java
@@ -85,6 +85,7 @@ public class RouteMapper {
       totalCriticalVulnerabilities += route.getCriticalVulnerabilities();
     }
 
+    // Filtered responses omit route status, so prefer their authoritative aggregate counts.
     int totalRoutes = Optional.ofNullable(response.getCount()).orElse(routes.size());
     exercisedCount = Optional.ofNullable(response.getExercisedCount()).orElse(exercisedCount);
     discoveredCount = Optional.ofNullable(response.getDiscoveredCount()).orElse(discoveredCount);

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolTest.java
@@ -34,6 +34,7 @@ import com.contrast.labs.ai.mcp.contrast.sdkextension.data.sessionmetadata.Agent
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.sessionmetadata.SessionMetadataResponse;
 import com.contrastsecurity.exceptions.HttpResponseException;
 import com.contrastsecurity.models.RouteCoverageBySessionIDAndMetadataRequest;
+import com.contrastsecurity.sdk.internal.GsonFactory;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
@@ -53,6 +54,27 @@ class GetRouteCoverageToolTest {
   private static final String SESSION_ID = "session-456";
   private static final String ROUTE_HASH = "route-hash-789";
   private static final String SECRET_BODY = "token=raw-token-value&apiKey=secret";
+  private static final String FILTERED_ROUTE_COVERAGE_RESPONSE =
+      """
+      {
+        "success": true,
+        "count": 48,
+        "exercised_count": 6,
+        "discovered_count": 42,
+        "routes": [
+          {
+            "signature": "GET /login",
+            "route_hash": "login-route",
+            "exercised": 1710000000000
+          },
+          {
+            "signature": "GET /health",
+            "route_hash": "health-route",
+            "exercised": 0
+          }
+        ]
+      }
+      """;
 
   private ContrastApiClient contrastApiClient;
   private GetRouteCoverageTool tool;
@@ -104,6 +126,43 @@ class GetRouteCoverageToolTest {
     assertThat(request.getValues()).hasSize(1);
     assertThat(request.getValues().get(0).getLabel()).isEqualTo(METADATA_NAME);
     assertThat(request.getValues().get(0).getValues()).containsExactly(METADATA_VALUE);
+  }
+
+  @Test
+  void getRouteCoverage_should_use_authoritative_counts_from_filtered_response() throws Exception {
+    var response =
+        GsonFactory.create()
+            .fromJson(FILTERED_ROUTE_COVERAGE_RESPONSE, RouteCoverageResponse.class);
+    when(contrastApiClient.getRouteCoverage(
+            eq(VALID_APP_ID), any(RouteCoverageBySessionIDAndMetadataRequest.class)))
+        .thenReturn(response);
+
+    var result = tool.getRouteCoverage(VALID_APP_ID, METADATA_NAME, METADATA_VALUE, false, null);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.data().totalRoutes()).isEqualTo(48);
+    assertThat(result.data().exercisedCount()).isEqualTo(6);
+    assertThat(result.data().discoveredCount()).isEqualTo(42);
+    assertThat(result.data().coveragePercent()).isEqualTo(12.5);
+  }
+
+  @Test
+  void getRouteCoverage_should_derive_missing_filtered_route_status_from_exercised_timestamp()
+      throws Exception {
+    var response =
+        GsonFactory.create()
+            .fromJson(FILTERED_ROUTE_COVERAGE_RESPONSE, RouteCoverageResponse.class);
+    when(contrastApiClient.getRouteCoverage(
+            eq(VALID_APP_ID), any(RouteCoverageBySessionIDAndMetadataRequest.class)))
+        .thenReturn(response);
+
+    var result = tool.getRouteCoverage(VALID_APP_ID, METADATA_NAME, METADATA_VALUE, false, null);
+
+    assertThat(result.data().routes())
+        .extracting(route -> route.status())
+        .containsExactly("EXERCISED", "DISCOVERED");
+    assertThat(result.data().routes())
+        .allSatisfy(route -> assertThat(route.environments()).isEmpty());
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/RouteMapperTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/RouteMapperTest.java
@@ -148,6 +148,25 @@ class RouteMapperTest {
   }
 
   @Test
+  void toResponseLight_should_derive_counts_from_exercised_when_status_and_counts_missing() {
+    var exercisedRoute = new Route();
+    exercisedRoute.setExercised(1L);
+
+    var discoveredRoute = new Route();
+    discoveredRoute.setExercised(0L);
+
+    var response = new RouteCoverageResponse();
+    response.setRoutes(List.of(exercisedRoute, discoveredRoute));
+
+    var result = mapper.toResponseLight(response);
+
+    assertThat(result.totalRoutes()).isEqualTo(2);
+    assertThat(result.exercisedCount()).isEqualTo(1);
+    assertThat(result.discoveredCount()).isEqualTo(1);
+    assertThat(result.coveragePercent()).isEqualTo(50.0);
+  }
+
+  @Test
   void toResponseLight_should_handle_null_routes() {
     var response = new RouteCoverageResponse();
     response.setSuccess(true);

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolIT.java
@@ -639,6 +639,9 @@ public class GetRouteCoverageToolIT
     assertThat(coverage.totalRoutes())
         .as("filtered totalRoutes must equal exercisedCount + discoveredCount")
         .isEqualTo(coverage.exercisedCount() + coverage.discoveredCount());
+    // totalRoutes == routes.size() holds because the MCP client's getRouteCoverage sends no
+    // limit/offset, so /route/filter returns the full result set in a single page. Validated
+    // against teamserver source, where the endpoint emits count alongside every matching route.
     assertThat(coverage.totalRoutes())
         .as("filtered totalRoutes must equal routes.size()")
         .isEqualTo(coverage.routes().size());

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolIT.java
@@ -18,6 +18,7 @@ package com.contrast.labs.ai.mcp.contrast.tool.coverage;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrast.labs.ai.mcp.contrast.config.IntegrationTestConfig;
+import com.contrast.labs.ai.mcp.contrast.result.RouteCoverageResponseLight;
 import com.contrast.labs.ai.mcp.contrast.util.AbstractIntegrationTest;
 import com.contrast.labs.ai.mcp.contrast.util.TestDataDiscoveryHelper;
 import com.contrast.labs.ai.mcp.contrast.util.TestDataDiscoveryHelper.RouteCoverageTestData;
@@ -356,6 +357,7 @@ public class GetRouteCoverageToolIT
               assertThat(route.signature()).as("route.signature").isNotBlank();
               assertThat(route.routeHash()).as("route.routeHash").isNotBlank();
             });
+    assertFilteredCoverageConsistent(response.data());
   }
 
   @Test
@@ -380,6 +382,7 @@ public class GetRouteCoverageToolIT
     assertThat(response.data().routes())
         .as("every latest-session route must populate signature")
         .allSatisfy(route -> assertThat(route.signature()).isNotBlank());
+    assertFilteredCoverageConsistent(response.data());
   }
 
   // ========== Empty string handling (MCP-OU8 bug fix) ==========
@@ -629,5 +632,21 @@ public class GetRouteCoverageToolIT
             "unfiltered (%d) must return at least as many routes as latest-session filter (%d)",
             unfilteredCount, latestSessionCount)
         .isGreaterThanOrEqualTo(latestSessionCount);
+  }
+
+  private static void assertFilteredCoverageConsistent(RouteCoverageResponseLight coverage) {
+    assertThat(coverage.routes()).as("filtered coverage must contain routes").isNotEmpty();
+    assertThat(coverage.totalRoutes())
+        .as("filtered totalRoutes must equal exercisedCount + discoveredCount")
+        .isEqualTo(coverage.exercisedCount() + coverage.discoveredCount());
+    assertThat(coverage.totalRoutes())
+        .as("filtered totalRoutes must equal routes.size()")
+        .isEqualTo(coverage.routes().size());
+    assertThat(coverage.routes())
+        .allSatisfy(
+            route -> {
+              assertThat(route.status()).isIn(KNOWN_ROUTE_STATUSES);
+              assertThat(route.environments()).isEmpty();
+            });
   }
 }

--- a/manual-tests/get-route-coverage-manual-test.md
+++ b/manual-tests/get-route-coverage-manual-test.md
@@ -340,7 +340,9 @@ use contrast mcp to get the route coverage statistics for the DemoRouteSession a
 
 **Expected Result:**
 - totalRoutes: 2
-- coveragePercent: 0.0 (session-scoped view doesn't aggregate overall status)
+- exercisedCount: 1
+- discoveredCount: 1
+- coveragePercent: 50.0
 
 ---
 
@@ -368,4 +370,4 @@ use contrast mcp to get the route coverage statistics for the DemoRouteSession a
 | 18 | Route Status | exercised routes | 1 |
 | 19 | Route Status | discovered routes | 2 |
 | 20 | Statistics | unfiltered stats | 3 total, 33.33% |
-| 21 | Statistics | filtered stats | 2 total |
+| 21 | Statistics | filtered stats | 2 total, 50% |


### PR DESCRIPTION
**Jira:** [AIML-1057](https://contrast.atlassian.net/browse/AIML-1057)

## Summary

Fix `get_route_coverage` so session-filtered and latest-session calls report accurate coverage counts and route status instead of false zeros.

- Filtered responses now use TeamServer's authoritative `count` / `exercised_count` / `discovered_count` totals.
- Routes missing a status get one derived from their `exercised` timestamp, so no filtered route reports `null`.
- Documents that filtered-route `environments` stays empty because the source omits it.

## Why This Change Exists

Calling `get_route_coverage` with `useLatestSession=true` (or any session-metadata filter) routes to a different TeamServer endpoint (`POST /route/filter`) than the unfiltered call. That filtered response returns correct top-level aggregate totals, but its per-route records omit `status`, `environments`, and `discovered`, carrying only an `exercised` epoch-millis timestamp.

The MCP downstream model discarded those top-level totals and recomputed `exercisedCount`/`discoveredCount` by string-matching each route's `status`. With every filtered route's status null, both counters stayed 0 and `coveragePercent` computed 0.0, even when routes were demonstrably exercised (non-zero `exercised` timestamps). The result was affirmatively wrong output — 0 exercised routes / 0% coverage — that misled agents and users assessing test or branch coverage for a session.

## Approach

Fixed entirely on the MCP side; the counts need no TeamServer change because the filtered response already carries them.

- Deserialize the authoritative top-level counts and prefer them when present, keeping the status-string recomputation only as a fallback for older responses that lack them.
- Derive missing per-route status from data already in hand: non-zero `exercised` → `EXERCISED`, otherwise `DISCOVERED`.
- `environments` cannot be safely invented, so it stays empty on the filtered path and the tool description documents the limitation.

## What Changed

### Response model
- `RouteCoverageResponse.java` — add nullable `count`, `exercisedCount`, `discoveredCount` fields with correct `@SerializedName` Gson mappings so the filtered totals are no longer discarded.

### Mapping
- `RouteMapper.java` — prefer the authoritative response counts over the recomputed ones; add `statusFor(route)` to derive status from the `exercised` timestamp when the source omits it; hoist the status strings to named constants.

### Tool description
- `GetRouteCoverageTool.java` — document that `environments` is empty for session-filtered routes.

## Testing

- `GetRouteCoverageToolTest` — two new unit tests over a fixture shaped like the real filtered response (null route statuses, non-zero `exercised` timestamps, top-level `exercised_count=6`/`discovered_count=42`): one asserts the authoritative counts and 12.5% coverage flow through, the other asserts status is derived (`EXERCISED`/`DISCOVERED`) and environments stay empty.
- `GetRouteCoverageToolIT` — new `assertFilteredCoverageConsistent` helper asserts, on the live filtered and latest-session paths, that `totalRoutes == exercisedCount + discoveredCount == routes.size()`, every status is a known value, and environments are empty.
- `make check-test` — 792 unit tests passed; Spotless and Checkstyle clean.
- `make verify` — route tests passed; six unrelated seeded-data failures in `GetVulnerabilityToolIT`/`SearchAttacksToolIT` reproduce on clean `origin/main`.

## Follow-ups

- Filtered-route `environments` stays empty because TeamServer's `/route/filter` generator omits it. Populating it would require a TeamServer-side change to that generator; left empty and documented as a known limitation for now.


[AIML-1057]: https://contrast.atlassian.net/browse/AIML-1057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ