### PR TITLE
AIML-573 Generate and attach release SBOMs

### DIFF
--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -160,13 +160,15 @@ jobs:
           ./gradlew clean :contrast-mcp-stdio-app:bootJar -x test --no-daemon
           test -f "contrast-mcp-stdio-app/build/libs/mcp-contrast-${{ steps.versions.outputs.release }}.jar"
 
-      # Pin the Syft version explicitly. The download action SHA-verifies the
-      # downloaded binary against anchore's signed checksums. Bump respecting
-      # the ENTSEC-1742 7-day dependency soak window.
+      # Syft version is intentionally left unset. The download action is
+      # SHA-pinned above, so its baked-in default Syft version is already
+      # deterministic, and the action SHA-verifies the downloaded binary
+      # against anchore's signed checksums. Bumping the pinned action (via
+      # Dependabot) carries the Syft version forward with it; an explicit
+      # syft-version input is not tracked by Dependabot and could silently
+      # go stale.
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-        with:
-          syft-version: v1.46.0
 
       # Scan the packaged JAR here in both formats for ecosystem interoperability.
       - name: Generate release jar SBOMs

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -176,6 +176,10 @@ jobs:
             test -s "$sbom"
             jq empty "$sbom"
           done
+          jq -e '(.components // []) | length > 0' \
+            "$SBOM_DIR/mcp-contrast-${{ steps.versions.outputs.release }}.sbom.cdx.json"
+          jq -e '(.packages // []) | length > 1' \
+            "$SBOM_DIR/mcp-contrast-${{ steps.versions.outputs.release }}.sbom.spdx.json"
 
       - name: Verify tracked worktree is clean before publishing
         run: |
@@ -296,6 +300,10 @@ jobs:
             test -s "$sbom"
             jq empty "$sbom"
           done
+          jq -e '(.components // []) | length > 0' \
+            "$SBOM_DIR/mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.cdx.json"
+          jq -e '(.packages // []) | length > 1' \
+            "$SBOM_DIR/mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.spdx.json"
 
       - name: Push and sign Docker image with DCT
         env:

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -169,6 +169,12 @@ jobs:
           syft scan file:contrast-mcp-stdio-app/build/libs/mcp-contrast-${{ steps.versions.outputs.release }}.jar \
             -o "cyclonedx-json=$SBOM_DIR/mcp-contrast-${{ steps.versions.outputs.release }}.sbom.cdx.json" \
             -o "spdx-json=$SBOM_DIR/mcp-contrast-${{ steps.versions.outputs.release }}.sbom.spdx.json"
+          for sbom in \
+            "$SBOM_DIR/mcp-contrast-${{ steps.versions.outputs.release }}.sbom.cdx.json" \
+            "$SBOM_DIR/mcp-contrast-${{ steps.versions.outputs.release }}.sbom.spdx.json"; do
+            test -s "$sbom"
+            jq empty "$sbom"
+          done
 
       - name: Verify tracked worktree is clean before publishing
         run: |
@@ -276,6 +282,12 @@ jobs:
           syft scan docker:contrast/mcp-contrast:${{ steps.versions.outputs.release }} \
             -o "cyclonedx-json=$SBOM_DIR/mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.cdx.json" \
             -o "spdx-json=$SBOM_DIR/mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.spdx.json"
+          for sbom in \
+            "$SBOM_DIR/mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.cdx.json" \
+            "$SBOM_DIR/mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.spdx.json"; do
+            test -s "$sbom"
+            jq empty "$sbom"
+          done
 
       - name: Push and sign Docker image with DCT
         env:

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -19,6 +19,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      SBOM_DIR: build/release-sboms
     permissions:
       contents: write
       id-token: write
@@ -163,9 +165,10 @@ jobs:
 
       - name: Generate release jar SBOMs
         run: |
+          mkdir -p "$SBOM_DIR"
           syft scan file:contrast-mcp-stdio-app/build/libs/mcp-contrast-${{ steps.versions.outputs.release }}.jar \
-            -o cyclonedx-json=mcp-contrast-${{ steps.versions.outputs.release }}.sbom.cdx.json \
-            -o spdx-json=mcp-contrast-${{ steps.versions.outputs.release }}.sbom.spdx.json
+            -o "cyclonedx-json=$SBOM_DIR/mcp-contrast-${{ steps.versions.outputs.release }}.sbom.cdx.json" \
+            -o "spdx-json=$SBOM_DIR/mcp-contrast-${{ steps.versions.outputs.release }}.sbom.spdx.json"
 
       - name: Verify tracked worktree is clean before publishing
         run: |
@@ -209,7 +212,7 @@ jobs:
         uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
         with:
           subject-path: contrast-mcp-stdio-app/build/libs/mcp-contrast-${{ steps.versions.outputs.release }}.jar
-          sbom-path: mcp-contrast-${{ steps.versions.outputs.release }}.sbom.cdx.json
+          sbom-path: ${{ env.SBOM_DIR }}/mcp-contrast-${{ steps.versions.outputs.release }}.sbom.cdx.json
 
       - name: Create the trust keys folder
         shell: sh
@@ -271,8 +274,8 @@ jobs:
       - name: Generate release Docker image SBOMs
         run: |
           syft scan docker:contrast/mcp-contrast:${{ steps.versions.outputs.release }} \
-            -o cyclonedx-json=mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.cdx.json \
-            -o spdx-json=mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.spdx.json
+            -o "cyclonedx-json=$SBOM_DIR/mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.cdx.json" \
+            -o "spdx-json=$SBOM_DIR/mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.spdx.json"
 
       - name: Push and sign Docker image with DCT
         env:
@@ -295,10 +298,10 @@ jobs:
           fail_on_unmatched_files: true
           files: |
             contrast-mcp-stdio-app/build/libs/mcp-contrast-${{ steps.versions.outputs.release }}.jar
-            mcp-contrast-${{ steps.versions.outputs.release }}.sbom.cdx.json
-            mcp-contrast-${{ steps.versions.outputs.release }}.sbom.spdx.json
-            mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.cdx.json
-            mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.spdx.json
+            ${{ env.SBOM_DIR }}/mcp-contrast-${{ steps.versions.outputs.release }}.sbom.cdx.json
+            ${{ env.SBOM_DIR }}/mcp-contrast-${{ steps.versions.outputs.release }}.sbom.spdx.json
+            ${{ env.SBOM_DIR }}/mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.cdx.json
+            ${{ env.SBOM_DIR }}/mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.spdx.json
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -163,6 +163,7 @@ jobs:
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
+      # Scan the packaged JAR here in both formats for ecosystem interoperability.
       - name: Generate release jar SBOMs
         run: |
           mkdir -p "$SBOM_DIR"
@@ -282,6 +283,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # Scan the loaded image here so both formats describe the exact image that will be pushed.
       # A separate repository produces the registry-bound image SBOM; these copies are release assets only.
       - name: Generate release Docker image SBOMs
         run: |

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -158,6 +158,15 @@ jobs:
           ./gradlew clean :contrast-mcp-stdio-app:bootJar -x test --no-daemon
           test -f "contrast-mcp-stdio-app/build/libs/mcp-contrast-${{ steps.versions.outputs.release }}.jar"
 
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+      - name: Generate release jar SBOMs
+        run: |
+          syft scan file:contrast-mcp-stdio-app/build/libs/mcp-contrast-${{ steps.versions.outputs.release }}.jar \
+            -o cyclonedx-json=mcp-contrast-${{ steps.versions.outputs.release }}.sbom.cdx.json \
+            -o spdx-json=mcp-contrast-${{ steps.versions.outputs.release }}.sbom.spdx.json
+
       - name: Verify tracked worktree is clean before publishing
         run: |
           git diff --quiet
@@ -195,6 +204,12 @@ jobs:
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: contrast-mcp-stdio-app/build/libs/mcp-contrast-${{ steps.versions.outputs.release }}.jar
+
+      - name: Attest release jar SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: contrast-mcp-stdio-app/build/libs/mcp-contrast-${{ steps.versions.outputs.release }}.jar
+          sbom-path: mcp-contrast-${{ steps.versions.outputs.release }}.sbom.cdx.json
 
       - name: Create the trust keys folder
         shell: sh
@@ -252,6 +267,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Generate release Docker image SBOMs
+        run: |
+          syft scan docker:contrast/mcp-contrast:${{ steps.versions.outputs.release }} \
+            -o cyclonedx-json=mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.cdx.json \
+            -o spdx-json=mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.spdx.json
+
       - name: Push and sign Docker image with DCT
         env:
           DOCKER_CONTENT_TRUST: 1
@@ -270,7 +291,12 @@ jobs:
           name: Release ${{ steps.versions.outputs.tag }}
           draft: false
           prerelease: false
-          files: contrast-mcp-stdio-app/build/libs/mcp-contrast-${{ steps.versions.outputs.release }}.jar
+          files: |
+            contrast-mcp-stdio-app/build/libs/mcp-contrast-${{ steps.versions.outputs.release }}.jar
+            mcp-contrast-${{ steps.versions.outputs.release }}.sbom.cdx.json
+            mcp-contrast-${{ steps.versions.outputs.release }}.sbom.spdx.json
+            mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.cdx.json
+            mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.spdx.json
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -287,11 +287,13 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # This relies on the single-platform load above; inspect keeps the scan bound to the local image.
       # Scan the loaded image here so both formats describe the exact image that will be pushed.
       # A separate repository produces the registry-bound image SBOM; these copies are release assets only.
       - name: Generate release Docker image SBOMs
         run: |
           mkdir -p "$SBOM_DIR"
+          docker image inspect "contrast/mcp-contrast:${{ steps.versions.outputs.release }}" >/dev/null
           syft scan docker:contrast/mcp-contrast:${{ steps.versions.outputs.release }} \
             -o "cyclonedx-json=$SBOM_DIR/mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.cdx.json" \
             -o "spdx-json=$SBOM_DIR/mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.spdx.json"

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -292,6 +292,7 @@ jobs:
           name: Release ${{ steps.versions.outputs.tag }}
           draft: false
           prerelease: false
+          fail_on_unmatched_files: true
           files: |
             contrast-mcp-stdio-app/build/libs/mcp-contrast-${{ steps.versions.outputs.release }}.jar
             mcp-contrast-${{ steps.versions.outputs.release }}.sbom.cdx.json

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -214,11 +214,17 @@ jobs:
         with:
           subject-path: contrast-mcp-stdio-app/build/libs/mcp-contrast-${{ steps.versions.outputs.release }}.jar
 
-      - name: Attest release jar SBOM
+      - name: Attest release jar CycloneDX SBOM
         uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
         with:
           subject-path: contrast-mcp-stdio-app/build/libs/mcp-contrast-${{ steps.versions.outputs.release }}.jar
           sbom-path: ${{ env.SBOM_DIR }}/mcp-contrast-${{ steps.versions.outputs.release }}.sbom.cdx.json
+
+      - name: Attest release jar SPDX SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: contrast-mcp-stdio-app/build/libs/mcp-contrast-${{ steps.versions.outputs.release }}.jar
+          sbom-path: ${{ env.SBOM_DIR }}/mcp-contrast-${{ steps.versions.outputs.release }}.sbom.spdx.json
 
       - name: Create the trust keys folder
         shell: sh

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -291,6 +291,7 @@ jobs:
       # A separate repository produces the registry-bound image SBOM; these copies are release assets only.
       - name: Generate release Docker image SBOMs
         run: |
+          mkdir -p "$SBOM_DIR"
           syft scan docker:contrast/mcp-contrast:${{ steps.versions.outputs.release }} \
             -o "cyclonedx-json=$SBOM_DIR/mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.cdx.json" \
             -o "spdx-json=$SBOM_DIR/mcp-contrast-docker-${{ steps.versions.outputs.release }}.sbom.spdx.json"

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -267,6 +267,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # A separate repository produces the registry-bound image SBOM; these copies are release assets only.
       - name: Generate release Docker image SBOMs
         run: |
           syft scan docker:contrast/mcp-contrast:${{ steps.versions.outputs.release }} \

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -160,8 +160,13 @@ jobs:
           ./gradlew clean :contrast-mcp-stdio-app:bootJar -x test --no-daemon
           test -f "contrast-mcp-stdio-app/build/libs/mcp-contrast-${{ steps.versions.outputs.release }}.jar"
 
+      # Pin the Syft version explicitly. The download action SHA-verifies the
+      # downloaded binary against anchore's signed checksums. Bump respecting
+      # the ENTSEC-1742 7-day dependency soak window.
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          syft-version: v1.46.0
 
       # Scan the packaged JAR here in both formats for ecosystem interoperability.
       - name: Generate release jar SBOMs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ environment, application, tag, and Protect coverage with pagination and sorting.
 
 **Richer CVE scoring details**: `list_applications_by_cve` responses now include nested `cvssv2` and `cvssv3` metrics plus a preferred `severity`. CVSS v3 scores remain available through `score`; v2-only CVEs omit `score` instead of reporting `0.0`. A null `score` is also omitted from `get_protect_rules` CVE output.
 
+### Security
+
 **Release SBOMs added**: GitHub releases now include CycloneDX and SPDX JSON SBOMs for both the release JAR and Docker image. Both JAR SBOM formats are bound to the JAR with GitHub attestations.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ environment, application, tag, and Protect coverage with pagination and sorting.
 
 **Richer CVE scoring details**: `list_applications_by_cve` responses now include nested `cvssv2` and `cvssv3` metrics plus a preferred `severity`. CVSS v3 scores remain available through `score`; v2-only CVEs omit `score` instead of reporting `0.0`. A null `score` is also omitted from `get_protect_rules` CVE output.
 
+**Release SBOMs added**: GitHub releases now include CycloneDX and SPDX JSON SBOMs for both the release JAR and Docker image. Both JAR SBOM formats are bound to the JAR with GitHub attestations.
+
 ### Security
 
 **Spring Boot 4.1.0 and Spring AI 1.1.7 baseline**: Upgraded the build and stdio

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,6 @@ environment, application, tag, and Protect coverage with pagination and sorting.
 
 **Release SBOMs added**: GitHub releases now include CycloneDX and SPDX JSON SBOMs for both the release JAR and Docker image. Both JAR SBOM formats are bound to the JAR with GitHub attestations.
 
-### Security
-
 **Spring Boot 4.1.0 and Spring AI 1.1.7 baseline**: Upgraded the build and stdio
 runtime baseline from Spring Boot 3.5.7/Spring AI 1.1.4 to Spring Boot 4.1.0/Spring
 AI 1.1.7. This also moves the managed Spring Framework line to 7.0.8.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,11 @@ This is an MCP (Model Context Protocol) server for Contrast Security that enable
 
 Branch naming: `AIML-<ticket-id>-<short-description>` (e.g., `AIML-391-add-medium-low-note-counts`)
 
+## PR Requirements
+
+PR Titles should be in the form: `<Jira Issue Id> <Title>` 
+For example: `AIML-573 Generate and attach release SBOMs`
+
 ## Required Plugins
 
 The workflows below use the **pr-tools** plugin (`/pr-tools:*` commands). If those skills aren't available, ask permission, then have the user run:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,12 +33,15 @@ The first Axion-managed release must be run with `release_version=2.0.0`. After 
 5. Checks out the release tag.
 6. Verifies that `./gradlew -q printVersion` matches the tag version.
 7. Builds `contrast-mcp-stdio-app/build/libs/mcp-contrast-{version}.jar` from the tag.
-8. Publishes `contrast-mcp-core` to Artifactory (signed with PGP).
-9. Attests build provenance for the release JAR.
-10. Builds the Docker image, signs it with Docker Content Trust, and publishes with the release and `latest` tags.
-11. Creates the GitHub release and attaches the JAR.
+8. Generates CycloneDX and SPDX JSON SBOMs for the release JAR.
+9. Publishes `contrast-mcp-core` to Artifactory (signed with PGP).
+10. Attests build provenance and both SBOM formats for the release JAR.
+11. Builds the Docker image and generates CycloneDX and SPDX JSON SBOM release assets from the loaded image.
+12. Signs the Docker image with Docker Content Trust and publishes the release and `latest` tags.
+13. Creates the GitHub release and attaches the JAR plus all four JAR and Docker image SBOM files.
 
 The workflow does not commit release-version or next-snapshot changes to `main`.
+The release-attached Docker image SBOMs are convenience artifacts; a separate repository generates the registry-bound image SBOM.
 
 ## Versioning
 
@@ -84,7 +87,8 @@ Then create a GitHub release for the tag and attach `contrast-mcp-stdio-app/buil
 
 ## Verify the Release
 
-- GitHub release exists with the expected tag and attached JAR.
+- GitHub release exists with the expected tag, attached JAR, and CycloneDX and SPDX JSON SBOMs for both the JAR and Docker image.
+- All four downloaded SBOM files are non-empty and pass `jq empty <file>`.
 - `gh attestation verify mcp-contrast-X.Y.Z.jar --repo Contrast-Security-OSS/mcp-contrast` succeeds.
 - DockerHub has the version tag and updated `latest` tag (signed with DCT).
 - `contrast-mcp-core` artifact is available in Artifactory at the release version.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -83,9 +83,11 @@ git checkout vX.Y.Z
 test -f contrast-mcp-stdio-app/build/libs/mcp-contrast-X.Y.Z.jar
 ```
 
-Then create a GitHub release for the tag and attach `contrast-mcp-stdio-app/build/libs/mcp-contrast-X.Y.Z.jar`. Note that a manual release will not publish to Artifactory or sign the Docker image. Use the workflow whenever possible.
+Then create a GitHub release for the tag and attach `contrast-mcp-stdio-app/build/libs/mcp-contrast-X.Y.Z.jar`. Note that these manual instructions do not publish to Artifactory, sign the Docker image, generate SBOMs, or create attestations. Use the workflow whenever possible.
 
 ## Verify the Release
+
+This checklist describes an automated workflow release. For a manual recovery release, verify only the outputs you explicitly reproduced and document any omitted publication, SBOM, or attestation assets in the release notes.
 
 - GitHub release exists with the expected tag, attached JAR, and CycloneDX and SPDX JSON SBOMs for both the JAR and Docker image.
 - All four downloaded SBOM files are non-empty and pass `jq empty <file>`.
@@ -119,8 +121,9 @@ DockerHub credentials and signing keys are only available in the main repository
 2. Enable GitHub Actions and read/write workflow permissions in the fork.
 3. Push the branch containing `.github/workflows/gradle-release.yml` to the fork's `main` branch.
 4. Run **Gradle Release** from the Actions tab.
-5. Verify the release tag and attached JAR.
-6. Delete the test release and tag when done.
+5. Verify the release tag, JAR build, and JAR CycloneDX and SPDX SBOM generation.
+6. Without equivalent Artifactory, DockerHub, and signing configuration, expect the workflow to stop before Docker SBOM generation and the GitHub release. If the fork is fully configured, verify the attached JAR and all four SBOM files.
+7. Delete any test release and tag created by the run when done.
 
 ## Support
 


### PR DESCRIPTION
**Jira:** [AIML-573](https://contrast.atlassian.net/browse/AIML-573)

> [!WARNING]
>  This PR has a failing build due to new requirements for the Wiz Scan. To fix the build I need to update the version of Spring Boot to 4.x. I am doing this now. You can review this PR and I will merge only AFTER that change is merged. Its ticket it AIML-1123.

## Summary
Extends the release workflow to generate Software Bills of Materials for the released jar and Docker image, cryptographically attest the jar SBOM, and attach all SBOMs to the GitHub Release — improving supply-chain transparency for every published version.

- Generates CycloneDX and SPDX SBOMs for both the release jar and the Docker image via Syft
- Adds a GitHub build attestation binding the jar to its CycloneDX SBOM
- Publishes all four SBOM files as GitHub Release assets alongside the jar

## Why This Change Exists
Contrast is committing to supply-chain transparency across its products, and the MCP server had no machine-readable dependency manifest for its releases. Consumers had no way to inspect or verify what shipped inside a given version. Generating SBOMs on release and attaching them to the published artifacts closes that gap and lays the groundwork for the broader public-SBOM initiative.

## What Changed
### `.github/workflows/gradle-release.yml`
- **Install Syft** — pins `anchore/sbom-action/download-syft` by commit SHA (v0.24.0) to install the SBOM scanner.
- **Generate release jar SBOMs** — scans the built jar and emits CycloneDX JSON and SPDX JSON, immediately after the artifact is built.
- **Attest release jar SBOM** — uses `actions/attest-sbom` (v4.1.0) to bind the jar to its CycloneDX SBOM, alongside the existing build-provenance attestation.
- **Generate release Docker image SBOMs** — scans the loaded image (after build, before push) and emits CycloneDX JSON and SPDX JSON.
- **Create GitHub Release** — attaches all four SBOM files to the release in addition to the jar.

## Testing
No automated coverage — this is a release-only CI workflow that cannot run outside a tag push. The action refs are pinned to known-good SHAs, and the SBOM output paths reuse the same `steps.versions.outputs.release` interpolation already proven elsewhere in the job. First real validation happens on the next release run.

## Risks / Rollout / Follow-ups
- **Publishing to `contrastsecurity.dev/sbom-public/` is not yet implemented.** This PR satisfies the "generate," "attest," and "attach to release" parts of AIML-573; pushing the SBOM to the public SBOM site (AC #2) remains a follow-up pending coordination with the SBOM-site owner on the publishing mechanism.
- SBOM generation runs inline in the release job, so a Syft failure will fail the release. This is intentional — a release should not ship without its SBOM.


[AIML-573]: https://contrast.atlassian.net/browse/AIML-573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ