### PR TITLE
AIML-1123 Upgrade mcp-contrast to Spring Boot 4.1.0 and Spring AI 1.1.7

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 .git
+.beads
 .gradle
+.gradle-sandbox
 .env*
 **/.gradle
 **/build

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ todos/
 
 # bv (beads viewer) local config and caches
 .bv/
+
+.orca/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ the correct total, exercised, and discovered route counts and coverage percentag
 
 **Richer CVE scoring details**: `list_applications_by_cve` responses now include nested `cvssv2` and `cvssv3` metrics plus a preferred `severity`. CVSS v3 scores remain available through `score`; v2-only CVEs omit `score` instead of reporting `0.0`. A null `score` is also omitted from `get_protect_rules` CVE output.
 
+### Security
+
+**Spring Boot 4.1.0 and Spring AI 1.1.7 baseline**: Upgraded the build and stdio
+runtime baseline from Spring Boot 3.5.7/Spring AI 1.1.4 to Spring Boot 4.1.0/Spring
+AI 1.1.7. This also moves the managed Spring Framework line to 7.0.8.
+
 ## [2.0.0] - 2026-06-01
 
 ### Breaking Changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ Required environment variables/arguments:
 
 ### Technology Stack
 
-- **Framework**: Spring Boot 3.* with Spring AI 1.*
+- **Framework**: Spring Boot 4.* with Spring AI 1.*
 - **MCP Integration**: Spring AI MCP Server starter
 - **Contrast Integration**: Contrast SDK Java 3.*
 - **Testing**: JUnit 5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Build Compatibility
 
 This repository builds and tests against Java 21 and the Spring Boot dependency-management
-version pinned by `springBootVersion` in `gradle.properties` (currently Spring Boot 3.5.7).
+version pinned by `springBootVersion` in `gradle.properties` (currently Spring Boot 4.1.0).
 
 The `contrast-mcp-core` module imports the Spring Boot BOM as a regular Gradle `platform()`
 so published-library consumers can keep control of their dependency graph. The deployable

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ subprojects {
         options.encoding = 'UTF-8'
         options.release = 21
         options.compilerArgs.add('-parameters')
+        options.compilerArgs.addAll(['-Xlint:deprecation', '-Xlint:removal'])
     }
 
     tasks.withType(Test).configureEach {

--- a/contrast-mcp-core/build.gradle
+++ b/contrast-mcp-core/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 
     implementation 'org.slf4j:slf4j-api'
 
-    testImplementation "org.mockito:mockito-inline:${mockitoInlineVersion}"
+    testImplementation 'org.mockito:mockito-core'
 }
 
 def publicMavenReleaseRepositoryName = 'contrastPublicRelease'

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/BuildCompatibilityTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/BuildCompatibilityTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 class BuildCompatibilityTest {
 
-  private static final Path ROOT_PROJECT = Path.of("..").toAbsolutePath().normalize();
+  private static final Path ROOT_PROJECT = findRootProject();
 
   @Test
   void build_should_pin_boot4_springAi117_and_gradle814() throws IOException {
@@ -35,32 +35,55 @@ class BuildCompatibilityTest {
 
     assertThat(gradleProperties)
         .containsEntry("springBootVersion", "4.1.0")
-        .containsEntry("springAiVersion", "1.1.7")
-        .doesNotContainKey("mockitoInlineVersion");
+        .containsEntry("springAiVersion", "1.1.7");
     assertThat(wrapperProperties)
         .containsEntry(
-            "distributionUrl", "https://services.gradle.org/distributions/gradle-8.14-bin.zip")
-        .containsEntry(
-            "distributionSha256Sum",
-            "61ad310d3c7d3e5da131b76bbf22b5a4c0786e9d892dae8c1658d4b484de3caa");
+            "distributionUrl", "https://services.gradle.org/distributions/gradle-8.14-bin.zip");
   }
 
   @Test
-  void build_should_use_bom_managed_mockito_core_not_discontinued_inline_artifact()
-      throws IOException {
-    assertThat(Files.readString(ROOT_PROJECT.resolve("contrast-mcp-core/build.gradle")))
-        .contains("testImplementation 'org.mockito:mockito-core'")
-        .doesNotContain("mockito-inline");
-    assertThat(Files.readString(ROOT_PROJECT.resolve("contrast-mcp-stdio-app/build.gradle")))
-        .contains("testImplementation 'org.mockito:mockito-core'")
-        .doesNotContain("mockito-inline");
+  void build_should_not_configure_discontinued_mockito_inline_artifact() throws IOException {
+    var gradleProperties = readProperties(ROOT_PROJECT.resolve("gradle.properties"));
+    var coreBuild = readString(ROOT_PROJECT.resolve("contrast-mcp-core/build.gradle"));
+    var stdioBuild = readString(ROOT_PROJECT.resolve("contrast-mcp-stdio-app/build.gradle"));
+
+    assertThat(gradleProperties).doesNotContainKey("mockitoInlineVersion");
+    assertThat(coreBuild).doesNotContain("mockito-inline");
+    assertThat(stdioBuild).doesNotContain("mockito-inline");
+  }
+
+  @Test
+  void stdio_app_should_keep_boot4_jackson2_compatibility_shim() throws IOException {
+    var coreBuild = readString(ROOT_PROJECT.resolve("contrast-mcp-core/build.gradle"));
+    var stdioBuild = readString(ROOT_PROJECT.resolve("contrast-mcp-stdio-app/build.gradle"));
+
+    assertThat(stdioBuild).contains("org.springframework.boot:spring-boot-jackson2");
+    assertThat(coreBuild).doesNotContain("org.springframework.boot:spring-boot-jackson2");
   }
 
   private static Properties readProperties(Path path) throws IOException {
+    assertThat(path).as("Expected %s to exist", path).isRegularFile();
     var properties = new Properties();
     try (var input = Files.newInputStream(path)) {
       properties.load(input);
     }
     return properties;
+  }
+
+  private static String readString(Path path) throws IOException {
+    assertThat(path).as("Expected %s to exist", path).isRegularFile();
+    return Files.readString(path);
+  }
+
+  private static Path findRootProject() {
+    var current = Path.of("").toAbsolutePath().normalize();
+    while (current != null) {
+      if (Files.isRegularFile(current.resolve("settings.gradle"))) {
+        return current;
+      }
+      current = current.getParent();
+    }
+    throw new IllegalStateException(
+        "Could not locate repository root by walking up from the current working directory.");
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/BuildCompatibilityTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/BuildCompatibilityTest.java
@@ -28,17 +28,18 @@ class BuildCompatibilityTest {
   private static final Path ROOT_PROJECT = findRootProject();
 
   @Test
-  void build_should_pin_boot4_springAi117_and_gradle814() throws IOException {
+  void build_should_use_boot4_springAi11_and_validated_gradle8_wrapper() throws IOException {
     var gradleProperties = readProperties(ROOT_PROJECT.resolve("gradle.properties"));
     var wrapperProperties =
         readProperties(ROOT_PROJECT.resolve("gradle/wrapper/gradle-wrapper.properties"));
 
-    assertThat(gradleProperties)
-        .containsEntry("springBootVersion", "4.1.0")
-        .containsEntry("springAiVersion", "1.1.7");
-    assertThat(wrapperProperties)
-        .containsEntry(
-            "distributionUrl", "https://services.gradle.org/distributions/gradle-8.14-bin.zip");
+    assertThat(gradleProperties.getProperty("springBootVersion")).startsWith("4.");
+    assertThat(gradleProperties.getProperty("springAiVersion")).startsWith("1.1.");
+    assertThat(wrapperProperties.getProperty("distributionUrl"))
+        .startsWith("https://services.gradle.org/distributions/gradle-8.")
+        .endsWith("-bin.zip");
+    assertThat(wrapperProperties.getProperty("distributionSha256Sum")).matches("[0-9a-f]{64}");
+    assertThat(wrapperProperties).containsEntry("validateDistributionUrl", "true");
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/BuildCompatibilityTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/BuildCompatibilityTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+class BuildCompatibilityTest {
+
+  private static final Path ROOT_PROJECT = Path.of("..").toAbsolutePath().normalize();
+
+  @Test
+  void build_should_pin_boot4_springAi117_and_gradle814() throws IOException {
+    var gradleProperties = readProperties(ROOT_PROJECT.resolve("gradle.properties"));
+    var wrapperProperties =
+        readProperties(ROOT_PROJECT.resolve("gradle/wrapper/gradle-wrapper.properties"));
+
+    assertThat(gradleProperties)
+        .containsEntry("springBootVersion", "4.1.0")
+        .containsEntry("springAiVersion", "1.1.7")
+        .doesNotContainKey("mockitoInlineVersion");
+    assertThat(wrapperProperties)
+        .containsEntry(
+            "distributionUrl", "https://services.gradle.org/distributions/gradle-8.14-bin.zip")
+        .containsEntry(
+            "distributionSha256Sum",
+            "61ad310d3c7d3e5da131b76bbf22b5a4c0786e9d892dae8c1658d4b484de3caa");
+  }
+
+  @Test
+  void build_should_use_bom_managed_mockito_core_not_discontinued_inline_artifact()
+      throws IOException {
+    assertThat(Files.readString(ROOT_PROJECT.resolve("contrast-mcp-core/build.gradle")))
+        .contains("testImplementation 'org.mockito:mockito-core'")
+        .doesNotContain("mockito-inline");
+    assertThat(Files.readString(ROOT_PROJECT.resolve("contrast-mcp-stdio-app/build.gradle")))
+        .contains("testImplementation 'org.mockito:mockito-core'")
+        .doesNotContain("mockito-inline");
+  }
+
+  private static Properties readProperties(Path path) throws IOException {
+    var properties = new Properties();
+    try (var input = Files.newInputStream(path)) {
+      properties.load(input);
+    }
+    return properties;
+  }
+}

--- a/contrast-mcp-stdio-app/build.gradle
+++ b/contrast-mcp-stdio-app/build.gradle
@@ -13,10 +13,11 @@ dependencies {
     implementation "com.google.guava:guava:${guavaVersion}"
     implementation "com.contrastsecurity:contrast-sdk-java:${contrastSdkVersion}"
     implementation "commons-validator:commons-validator:${commonsValidatorVersion}"
+    implementation 'org.springframework.boot:spring-boot-jackson2'
     implementation 'org.springframework.ai:spring-ai-starter-mcp-server'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation "org.mockito:mockito-inline:${mockitoInlineVersion}"
+    testImplementation 'org.mockito:mockito-core'
 }
 
 bootJar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,11 @@
-springBootVersion=3.5.7
-springAiVersion=1.1.4
+springBootVersion=4.1.0
+springAiVersion=1.1.7
 axionReleasePluginVersion=1.21.1
 spotlessGradlePluginVersion=7.0.4
 googleJavaFormatVersion=1.26.0
 guavaVersion=33.5.0-jre
 contrastSdkVersion=3.7.0
 commonsValidatorVersion=1.10.1
-mockitoInlineVersion=5.2.0
 assertjVersion=3.27.7
 checkstyleVersion=13.4.1
 lombokVersion=1.18.38

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
-distributionSha256Sum=20f1b1176237254a6fc204d8434196fa11a4cfb387567519c61556e8710aed78
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionSha256Sum=61ad310d3c7d3e5da131b76bbf22b5a4c0786e9d892dae8c1658d4b484de3caa
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
**Jira:** [AIML-1123](https://contrast.atlassian.net/browse/AIML-1123)

## Summary

Upgrades the build and stdio runtime baseline from Spring Boot 3.5.7 / Spring AI 1.1.4 to Spring Boot 4.1.0 / Spring AI 1.1.7, with Spring Framework 7.0.8 arriving transitively through the Boot 4.1 BOM. Published `contrast-mcp-core` metadata is deliberately left unchanged so library consumers keep control of their own dependency graph.

- Clears the Wiz EOL-Scan finding that flags the Spring Boot 3.5.x / Framework 6.2.x baseline as end of life.
- Shipped stdio app boots on Boot 4.1.0 / Framework 7.0.8 and registers all 13 MCP tools with no stray stdout.
- Published core coordinates and scopes are unchanged (`verifyCorePublicationMetadata` still green).

## Why This Change Exists

Wiz EOL-Scan flipped `main` from pass to fail with no accompanying code change, flagging Spring Boot 3.5.7 (EOL, fixed version 4.0.6) and Spring Framework 6.2.x (fixed version 7.0.8). This was an environment-wide Wiz policy-data change, not a repo regression. Targeting 4.1.0 clears the finding and exceeds Wiz's own fixed version.

The upgrade also unblocks PR #159 (release SBOMs), whose Wiz check was stuck on exactly these two EOL findings, and brings the repo to version parity with sibling repo `aiml-services`, which already runs Boot 4.1.0 / Spring AI 1.1.7.

## Approach

- **Spring AI 1.1.7, not 2.x.** Spring AI 2.0 is the line that officially targets Boot 4 and Jackson 3, but adopting it is separate future work. 1.1.7 is kept as a deliberate, documented bridge for parity with `aiml-services`. Because 1.1.x is built against Boot 3.5 / Framework 6.2, the enforced Boot 4 BOM force-upgrades the transitive Spring Framework to 7.0.8 at runtime. The app boots cleanly (all 13 tools register) with three benign `BeanPostProcessorChecker` auto-proxy warnings, so release is gated on the credentialed integration suite rather than on unit tests.
- **`spring-boot-jackson2` shim, stdio app only.** Boot 4 defaults JSON to Jackson 3, but the Contrast SDK and Spring AI 1.1.x still need Jackson 2. The shim is added to the deployable stdio app and deliberately kept out of published `contrast-mcp-core` (which exposes only shared `jackson-annotations`), so the published metadata contract stays stable. It is a stop-gap to remove at the Spring AI 2.0 upgrade.
- **`mockito-inline` dropped for BOM-managed `mockito-core`.** `mockito-inline` is discontinued and the inline mock maker is the default in Mockito 5, which the Boot 4 BOM manages. Existing `MockedStatic` tests continue to pass.
- **Deprecation/removal lint enabled** (`-Xlint:deprecation -Xlint:removal`, warnings only) to make Framework 7 migration warnings visible without failing the build.
- **JSpecify migration deferred.** `org.springframework.lang.@Nullable`/`@NonNull` is deprecated in Framework 7 across ~9 core files, but migrating it is intentionally left out of scope to avoid mid-PR scope creep.

## What Changed

### Version baseline
- `gradle.properties` — `springBootVersion` 3.5.7 → 4.1.0, `springAiVersion` 1.1.4 → 1.1.7, removed the now-unused `mockitoInlineVersion` pin.
- `gradle/wrapper/gradle-wrapper.properties` — Gradle 8.13 → 8.14 (a hard blocker for the Boot 4 Gradle plugin), `distributionUrl` and `distributionSha256Sum` bumped together so `wrapper-validation` stays green.

### Dependency surface
- `contrast-mcp-core/build.gradle`, `contrast-mcp-stdio-app/build.gradle` — swapped `mockito-inline` for `mockito-core`. The stdio app additionally pulls `spring-boot-jackson2`; core does not.
- `build.gradle` — added `-Xlint:deprecation -Xlint:removal` to the shared compiler args.

### Regression guard
- `BuildCompatibilityTest` (new) — locks the load-bearing build contract: Boot 4 / Spring AI 1.1.x versions, a validated Gradle 8.x wrapper, absence of `mockito-inline`, and the jackson2 shim living in the app but not core.

### Docs & build hygiene
- `CHANGELOG.md`, `CLAUDE.md` (Boot 3.* → 4.*), `CONTRIBUTING.md` (3.5.7 → 4.1.0), `.dockerignore` (exclude local `.beads` / `.gradle-sandbox` from build context).

## Testing

- `BuildCompatibilityTest` pins the version/wrapper/Mockito/jackson2 contract; its root resolution walks up to `settings.gradle` so it runs correctly regardless of test CWD.
- `make check-test` (801 unit tests), `spotlessCheck checkstyleMain checkstyleTest`, and `:contrast-mcp-core:publishToMavenLocal :contrast-mcp-core:verifyCorePublicationMetadata` all pass — the last confirms published core coordinates are unchanged.
- Built the stdio `bootJar` and Docker image, then ran real MCP stdio handshakes (both env-var and `--CONTRAST_*` CLI-arg paths): `initialize` + `tools/list` return all 13 tools with no non-JSON stdout. HTTPS-only startup rejection still exits nonzero on an `http://` host.
- Dependency resolution confirmed `spring-core:7.0.8`, `spring-boot-jackson2:4.1.0`, and BOM-managed `mockito-core:5.23.0`.
- **Gap:** unit tests never boot the Spring context (all `@SpringBootTest` cases are credential-gated integration tests), so context-wiring regressions on this off-baseline pairing are only caught by `make verify`. Run the full credentialed integration suite before release.

## Risks / Rollout / Follow-ups

- **Off-baseline pairing.** Spring AI 1.1.7 on Boot 4 / Framework 7.0.8 is not the officially aligned combination. It boots and lists tools, but deeper Spring AI wiring is only exercised by the integration suite — treat that suite as the pre-merge gate.
- **Published-core baseline shift.** Consumers of `contrast-mcp-core` now inherit a Boot 4.1 BOM import. Known consumer `aiml-services` is already aligned; decide at release time whether this warrants a core major-version bump.
- **Pre-existing IT failure.** Four `GetVulnerabilityToolIT` direct-retrieval assertions fail under `make verify`, reproduced on a clean `origin/main` worktree, so not introduced here. Tracked separately as bead `mcp-v4cg`.
- **Deferred follow-ups.** JSpecify nullability migration and the Spring AI 2.0 upgrade (which would let the jackson2 shim be removed) are intentionally out of scope.


[AIML-1123]: https://contrast.atlassian.net/browse/AIML-1123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ