### PR TITLE
AIML-1134 Fix GetVulnerabilityToolIT staging discovery failures

### DIFF
--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.util.StringUtils;
 
 /**
  * Integration tests for {@link GetVulnerabilityTool} verifying the contract across the SDK/Assess
@@ -75,10 +76,12 @@ public class GetVulnerabilityToolIT
    * <p>Carries two samples:
    *
    * <ul>
-   *   <li><b>primary</b> — first vulnerability returned by the org-wide search; backs the main
-   *       retrieval, validation-error, and not-found tests.
-   *   <li><b>env-populated</b> — first vulnerability with non-empty {@code environments}; backs the
-   *       {@code _should_populate_environments_*} test. May coincide with the primary sample.
+   *   <li><b>primary</b> — first vulnerability returned by the org-wide search whose {@code
+   *       (vulnId, appId)} pair resolves through the detail endpoint; backs the main retrieval,
+   *       validation-error, and not-found tests.
+   *   <li><b>env-populated</b> — first retrievable vulnerability with non-empty {@code
+   *       environments}; backs the {@code _should_populate_environments_*} test. May coincide with
+   *       the primary sample.
    * </ul>
    */
   static class TestData {
@@ -131,12 +134,13 @@ public class GetVulnerabilityToolIT
    * Captures two vulnerability samples from the first page of org-wide search results:
    *
    * <ul>
-   *   <li><b>Primary sample</b> — the first vuln carrying a non-blank {@code vulnID}, plus its
-   *       {@code appID}, {@code appName}, title, type, severity, and status. Drives the happy-path
-   *       retrieval test plus every field-shape assertion in {@code testDiscoveredTestDataExists}.
-   *   <li><b>Environment sample</b> — the first vuln whose {@code environments} list is populated.
-   *       The {@code _populate_environments_} test asserts {@code isNotEmpty} on the returned
-   *       environments list, so it cannot use the primary sample if that sample has no
+   *   <li><b>Primary sample</b> — the first vuln carrying non-blank {@code vulnID} and {@code
+   *       appID} values whose pair resolves through {@link GetVulnerabilityTool}. Its search fields
+   *       drive the happy-path retrieval test plus every field-shape assertion in {@code
+   *       testDiscoveredTestDataExists}.
+   *   <li><b>Environment sample</b> — the first retrievable vuln whose {@code environments} list is
+   *       populated. The {@code _populate_environments_} test asserts {@code isNotEmpty} on the
+   *       returned environments list, so it cannot use the primary sample if that sample has no
    *       environments. Reused if the primary sample already carries them.
    * </ul>
    *
@@ -161,36 +165,68 @@ public class GetVulnerabilityToolIT
 
     var data = new TestData();
 
-    // Primary sample — first vuln carrying a non-blank vulnID.
+    // Search and detail endpoints do not guarantee that every search-derived (vulnID, appID) pair
+    // is resolvable. Only commit a candidate after the detail endpoint proves the pair is valid.
     for (var vuln : response.items()) {
-      if (vuln.vulnID() == null || vuln.vulnID().isBlank()) {
+      if (!StringUtils.hasText(vuln.vulnID()) || !StringUtils.hasText(vuln.appID())) {
         continue;
       }
-      data.vulnId = vuln.vulnID();
-      data.appId = vuln.appID();
-      data.appName = vuln.appName();
-      data.vulnTitle = vuln.title();
-      data.vulnType = vuln.type();
-      data.severity = vuln.severity();
-      data.status = vuln.status();
-      break;
+
+      String firstEnvironment = null;
+      if (vuln.environments() != null) {
+        for (var environment : vuln.environments()) {
+          if (StringUtils.hasText(environment)) {
+            firstEnvironment = environment;
+            break;
+          }
+        }
+      }
+
+      var needsPrimarySample = data.vulnId == null;
+      var needsEnvironmentSample = data.envSampleVulnId == null && firstEnvironment != null;
+      if (!needsPrimarySample && !needsEnvironmentSample) {
+        continue;
+      }
+
+      var detailResponse = getVulnerabilityTool.getVulnerability(vuln.vulnID(), vuln.appID());
+      if (!detailResponse.isSuccess()) {
+        continue;
+      }
+
+      if (needsPrimarySample) {
+        data.vulnId = vuln.vulnID();
+        data.appId = vuln.appID();
+        data.appName = vuln.appName();
+        data.vulnTitle = vuln.title();
+        data.vulnType = vuln.type();
+        data.severity = vuln.severity();
+        data.status = vuln.status();
+      }
+
+      if (needsEnvironmentSample) {
+        data.envSampleVulnId = vuln.vulnID();
+        data.envSampleAppId = vuln.appID();
+        data.envSampleEnvironment = firstEnvironment;
+      }
+
+      if (data.vulnId != null && data.envSampleVulnId != null) {
+        break;
+      }
     }
 
-    // Environment-populated sample — first vuln with non-empty environments. Used by the
-    // populate-environments test, which must assert isNotEmpty rather than isNotNull. If the
-    // primary sample already has environments, reuse it; otherwise scan further into the page.
-    for (var vuln : response.items()) {
-      if (vuln.environments() == null || vuln.environments().isEmpty()) {
-        continue;
-      }
-      var firstEnv = vuln.environments().get(0);
-      if (firstEnv == null || firstEnv.isBlank()) {
-        continue;
-      }
-      data.envSampleVulnId = vuln.vulnID();
-      data.envSampleAppId = vuln.appID();
-      data.envSampleEnvironment = firstEnv;
-      break;
+    if (data.vulnId == null) {
+      throw new NoTestDataException(
+          "GetVulnerabilityToolIT could not find a retrievable (vulnId, appId) pair in the first "
+              + DISCOVERY_PAGE_SIZE
+              + " search results — verify the test user can access the vulnerability detail"
+              + " endpoint and that staging contains active traces");
+    }
+    if (data.envSampleVulnId == null) {
+      throw new NoTestDataException(
+          "GetVulnerabilityToolIT could not find a retrievable vulnerability with populated"
+              + " environments in the first "
+              + DISCOVERY_PAGE_SIZE
+              + " search results — verify staging seed data includes deployment environments");
     }
 
     return data;

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java
@@ -49,6 +49,10 @@ public class GetVulnerabilityToolIT
   // (required for the populate-environments test) without pulling the entire org corpus.
   private static final int DISCOVERY_PAGE_SIZE = 100;
 
+  // Bumped when discovery began validating (vulnId, appId) pairs against the detail endpoint
+  // (found() gate, AIML-1134). Invalidates disk-cache entries written by the earlier discovery.
+  private static final int DISCOVERY_VERSION = 2;
+
   // Exact validation messages produced by ToolValidationContext#require for each parameter.
   // Asserting the full shape (not just a parameter-name substring) prevents a false-positive match
   // against any unrelated message that happens to mention the parameter name.
@@ -124,6 +128,11 @@ public class GetVulnerabilityToolIT
   @Override
   protected Class<TestData> testDataType() {
     return TestData.class;
+  }
+
+  @Override
+  protected int discoveryVersion() {
+    return DISCOVERY_VERSION;
   }
 
   @Override

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java
@@ -80,8 +80,9 @@ public class GetVulnerabilityToolIT
    *       (vulnId, appId)} pair resolves through the detail endpoint; backs the main retrieval,
    *       validation-error, and not-found tests.
    *   <li><b>env-populated</b> — first retrievable vulnerability with non-empty {@code
-   *       environments}; backs the {@code _should_populate_environments_*} test. May coincide with
-   *       the primary sample.
+   *       environments}, if present; backs the {@code _should_populate_environments_*} test. May
+   *       coincide with the primary sample. Absence remains visible to that test's precondition
+   *       without preventing the environment-independent tests from running.
    * </ul>
    */
   static class TestData {
@@ -139,9 +140,10 @@ public class GetVulnerabilityToolIT
    *       drive the happy-path retrieval test plus every field-shape assertion in {@code
    *       testDiscoveredTestDataExists}.
    *   <li><b>Environment sample</b> — the first retrievable vuln whose {@code environments} list is
-   *       populated. The {@code _populate_environments_} test asserts {@code isNotEmpty} on the
-   *       returned environments list, so it cannot use the primary sample if that sample has no
-   *       environments. Reused if the primary sample already carries them.
+   *       populated, if present. The {@code _populate_environments_} test asserts {@code
+   *       isNotEmpty} on the returned environments list, so it cannot use the primary sample if
+   *       that sample has no environments. Reused if the primary sample already carries them; left
+   *       null so that test's precondition fails locally if no suitable seed data exists.
    * </ul>
    *
    * Both samples come from the default-status search (not {@code ALL_STATUSES}) — the populated
@@ -149,18 +151,27 @@ public class GetVulnerabilityToolIT
    */
   @Override
   protected TestData performDiscovery() throws IOException {
+    int examinedCandidates = 0;
+    int skippedMissingIdentifiers = 0;
+    int skippedUnresolvedCandidates = 0;
+
     var response =
         searchVulnerabilitiesTool.searchVulnerabilities(
             1, DISCOVERY_PAGE_SIZE, null, null, null, null, null, null, null);
 
     if (!response.isSuccess()) {
       throw new NoTestDataException(
-          "GetVulnerabilityToolIT discovery failed — errors: " + response.errors());
+          "GetVulnerabilityToolIT discovery failed — errors: "
+              + response.errors()
+              + formatDiscoveryCounts(
+                  examinedCandidates, skippedMissingIdentifiers, skippedUnresolvedCandidates));
     }
     if (response.items().isEmpty()) {
       throw new NoTestDataException(
           "GetVulnerabilityToolIT requires at least one vulnerability in the organization — "
-              + "see INTEGRATION_TESTS.md");
+              + "see INTEGRATION_TESTS.md"
+              + formatDiscoveryCounts(
+                  examinedCandidates, skippedMissingIdentifiers, skippedUnresolvedCandidates));
     }
 
     var data = new TestData();
@@ -168,7 +179,9 @@ public class GetVulnerabilityToolIT
     // Search and detail endpoints do not guarantee that every search-derived (vulnID, appID) pair
     // is resolvable. Only commit a candidate after the detail endpoint proves the pair is valid.
     for (var vuln : response.items()) {
+      examinedCandidates++;
       if (!StringUtils.hasText(vuln.vulnID()) || !StringUtils.hasText(vuln.appID())) {
+        skippedMissingIdentifiers++;
         continue;
       }
 
@@ -189,7 +202,8 @@ public class GetVulnerabilityToolIT
       }
 
       var detailResponse = getVulnerabilityTool.getVulnerability(vuln.vulnID(), vuln.appID());
-      if (!detailResponse.isSuccess()) {
+      if (!detailResponse.found()) {
+        skippedUnresolvedCandidates++;
         continue;
       }
 
@@ -219,17 +233,32 @@ public class GetVulnerabilityToolIT
           "GetVulnerabilityToolIT could not find a retrievable (vulnId, appId) pair in the first "
               + DISCOVERY_PAGE_SIZE
               + " search results — verify the test user can access the vulnerability detail"
-              + " endpoint and that staging contains active traces");
-    }
-    if (data.envSampleVulnId == null) {
-      throw new NoTestDataException(
-          "GetVulnerabilityToolIT could not find a retrievable vulnerability with populated"
-              + " environments in the first "
-              + DISCOVERY_PAGE_SIZE
-              + " search results — verify staging seed data includes deployment environments");
+              + " endpoint and that staging contains active traces"
+              + formatDiscoveryCounts(
+                  examinedCandidates, skippedMissingIdentifiers, skippedUnresolvedCandidates));
     }
 
+    var summaryLog =
+        skippedMissingIdentifiers > 0 || skippedUnresolvedCandidates > 0
+            ? log.atWarn()
+            : log.atInfo();
+    summaryLog
+        .setMessage("GetVulnerabilityToolIT discovery summary")
+        .addKeyValue("examined", examinedCandidates)
+        .addKeyValue("skippedMissingIdentifiers", skippedMissingIdentifiers)
+        .addKeyValue("skippedUnresolved", skippedUnresolvedCandidates)
+        .addKeyValue("primarySampleFound", true)
+        .addKeyValue("environmentSampleFound", data.envSampleVulnId != null)
+        .log();
+
     return data;
+  }
+
+  private static String formatDiscoveryCounts(
+      int examinedCandidates, int skippedMissingIdentifiers, int skippedUnresolvedCandidates) {
+    return String.format(
+        " (examined=%d, skippedMissingIdentifiers=%d, skippedUnresolved=%d)",
+        examinedCandidates, skippedMissingIdentifiers, skippedUnresolvedCandidates);
   }
 
   // ---------- Discovery precondition ----------

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/util/AbstractIntegrationTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/util/AbstractIntegrationTest.java
@@ -66,6 +66,15 @@ public abstract class AbstractIntegrationTest<T> {
    */
   protected abstract T performDiscovery() throws Exception;
 
+  /**
+   * Version of this test's {@link #performDiscovery()} logic/invariants. Bump in a subclass
+   * whenever discovery changes in a way that must invalidate disk-cached TestData written by an
+   * earlier version, so a warm pre-change cache entry cannot defeat the new discovery invariants.
+   */
+  protected int discoveryVersion() {
+    return 1;
+  }
+
   /** Logs important details about the discovered test data. */
   protected abstract void logTestDataDetails(T data);
 
@@ -174,7 +183,7 @@ public abstract class AbstractIntegrationTest<T> {
   }
 
   private String cacheKey() {
-    return testDisplayName().replaceAll("\\s+", "");
+    return testDisplayName().replaceAll("\\s+", "") + "-v" + discoveryVersion();
   }
 
   /**


### PR DESCRIPTION
**Jira:** [AIML-1134](https://contrast.atlassian.net/browse/AIML-1134)

## Summary
Fix four `GetVulnerabilityToolIT` integration tests that failed against staging because test-data discovery trusted a search-derived `(vulnID, appID)` pair the detail endpoint could not retrieve. Discovery now selects only pairs that actually resolve, and the IT disk cache is versioned so a tightened discovery can't be defeated by a stale cached sample.

- Discovery validates each candidate against the detail endpoint and commits only resolvable primary / environment samples, failing loudly when none exist.
- No production code or test assertions were changed — the fix is confined to integration-test discovery plus its shared base class.
- Full IT suite green against staging with the disk cache disabled (194 run, 0 failures).

## Why This Change Exists
`GetVulnerabilityToolIT` failed four direct-retrieval assertions against staging even on a clean `origin/main`, so the failures predate the AIML-1123 Spring Boot 4 / Spring AI upgrade (they were found during it and tracked separately). Root cause: `performDiscovery()` took the first vulnerability from an org-wide search and paired its `vulnID` with its `appID`, but staging no longer guarantees that pairing resolves on the detail endpoint (`GET /traces/{org}/{appId}/{traceId}`). When it did not, `getVulnerability(...)` returned a not-found response and every test that depends on a successful retrieval failed at its `isSuccess()`/`found()` assertion. The tests were correct; the test data they were handed was not.

## What Changed
### Discovery robustness — `GetVulnerabilityToolIT`
- `performDiscovery()` now calls `getVulnerability(vulnID, appID)` for each candidate and commits a sample only when the detail response actually resolves. The guard checks `found()`, not merely `isSuccess()`: a not-found response carries empty errors, so `isSuccess()==true` while `found()==false` and `data()==null` — only `found()` guarantees a real, non-null retrieval. Applies to both the primary and the environment-populated sample.
- Throws `NoTestDataException` only when no resolvable **primary** sample exists in the first page. A missing environment sample no longer fails the whole class — it is owned by the environment test's own `isNotBlank()` precondition, so environment-independent tests (validation, not-found, warnings) still run.
- Counts examined / skipped candidates (fluent SLF4J) and embeds the counts in the failure message, so a slow decline in staging retrievability is visible rather than silent.

### Cache versioning — `AbstractIntegrationTest`
- Adds an overridable `discoveryVersion()` (default `1`) folded into the disk-cache key; `GetVulnerabilityToolIT` bumps it (`DISCOVERY_VERSION = 2`). Without this, a `TestData` entry written by the pre-fix discovery could be replayed from the 12h disk cache and defeat the new `found()` gate. TTL, org fingerprint, and serialized cache format are untouched; the version lives only in the filename, so the change is a one-time, self-healing cache-key bump for every IT.

## Testing
- Focused IT (cache disabled): `GetVulnerabilityToolIT` — 13 tests, 0 failures.
- Full integration suite (cache disabled, staging): 194 tests, 0 failures, 0 errors, 8 skipped (pre-existing `GetSastResultsToolIT` conditional gating, unrelated to this change).
- `make check-test`: static analysis clean; 802 unit tests, 0 failures.
- No assertion was weakened, deleted, or skipped. The pre-fix cache files left in the git-ignored `test-cache/` are harmless and clear with `CONTRAST_TEST_CACHE_CLEAR=true`.


[AIML-1134]: https://contrast.atlassian.net/browse/AIML-1134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
