### PR TITLE
AIML-1141 Add docker ecosystem and gradle grouping to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      dev-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        dependency-type: development
+      production-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        dependency-type: production
     cooldown:
       default-days: 7
 
@@ -28,3 +39,14 @@ updates:
           - '*'
       exclude:
           - react
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker-dependencies:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## What

- Add a `docker` ecosystem entry so base image updates in the root `Dockerfile` are proposed by Dependabot.
- Add a `groups` block to the `gradle` entry, splitting development and production dependencies so Gradle bumps arrive grouped instead of one PR each.

## Why

An audit of `.github/dependabot.yml` found docker was not covered even though a `Dockerfile` sits at the repo root, and the gradle entry had no grouping. Both entries already carried the correct weekly schedule and 7-day cooldown, so those are unchanged.

## Not in scope

Three orphaned Maven PRs (#113 spring-ai-bom, #114 guava, #117 checkstyle) that edited a deleted `pom.xml` were closed separately during the same triage pass. This repo builds with Gradle and has no `maven` ecosystem, so those PRs were permanently conflicting.

Jira AIML-1141