### PR TITLE
chore: document 2.1.0 release and backfill 2.0.1 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 **Session-filtered route coverage statistics were always zero**: Filtered route coverage now reports
-the correct total, exercised, and discovered route counts and coverage percentage.
+the correct total, exercised, and discovered route counts and coverage percentage. Filtered routes
+that were missing a status now get one derived from their `exercised` timestamp instead of reporting
+`null`, and filtered-route `environments` is documented as empty because the source omits it.
+
+**VS Code one-click install button was broken**: The "Install contrast-mcp" button in the README and
+the VS Code guide referenced five input variables that were never defined, so it installed an
+unauthenticated, non-working server configuration. It now defines those inputs and prompts for all
+five Contrast credentials.
 
 ### Improvements
 
@@ -32,6 +39,14 @@ environment, application, tag, and Protect coverage with pagination and sorting.
 **Spring Boot 4.1.0 and Spring AI 1.1.7 baseline**: Upgraded the build and stdio
 runtime baseline from Spring Boot 3.5.7/Spring AI 1.1.4 to Spring Boot 4.1.0/Spring
 AI 1.1.7. This also moves the managed Spring Framework line to 7.0.8.
+
+### Documentation
+
+**README leads with the Hosted MCP Server**: The README now presents the Contrast Hosted MCP
+Server (remote, OAuth, run by Contrast) as the recommended path, with connect steps, a
+supported-clients matrix, and a new per-client hosted install guide. Local stdio setup is
+retained as the secondary path, with the detailed local reference moved to
+`docs/local-mcp-server.md`.
 
 ## [2.0.1] - 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-07-20
+
 ### Breaking Changes
 
 **CVE score accessors now use `Double`**: The published `contrast-mcp-core` `Cve` model changed `getScore()` and `setScore()` from primitive `double` to nullable `Double` so unavailable scores can be represented accurately. Consumers compiled against the previous signature must recompile.
@@ -30,6 +32,27 @@ environment, application, tag, and Protect coverage with pagination and sorting.
 **Spring Boot 4.1.0 and Spring AI 1.1.7 baseline**: Upgraded the build and stdio
 runtime baseline from Spring Boot 3.5.7/Spring AI 1.1.4 to Spring Boot 4.1.0/Spring
 AI 1.1.7. This also moves the managed Spring Framework line to 7.0.8.
+
+## [2.0.1] - 2026-06-05
+
+### Bug Fixes
+
+**Duplicate servers in `list_applications_by_cve`**: The `servers` array could list
+the same server more than once because of a TeamServer API bug (TS-42992). Servers are
+now deduplicated by ID before the response is built.
+
+**`search_attacks` sort syntax was inconsistent**: The sort parameter now uses the same
+`property,DIRECTION` convention as every other tool, replacing the one-off `-property`
+descending syntax. Invalid sort input returns a clear error listing the expected format.
+
+### Improvements
+
+**CVE ID input is normalized**: `list_applications_by_cve` now trims whitespace and
+uppercases the CVE ID, so values such as `cve-2021-44228` are accepted.
+
+**Timestamp parameter validation**: The core validation framework now validates ISO
+timestamp and epoch-millisecond inputs and rejects reversed time ranges before they
+reach downstream APIs.
 
 ## [2.0.0] - 2026-06-01
 


### PR DESCRIPTION
## Summary

Update the changelog for the just-cut `v2.1.0` release, then close gaps found in a completeness audit of the release ranges.

**2.1.0**
- Stamp the accumulated `[Unreleased]` section as `[2.1.0] - 2026-07-20` and add a fresh empty `[Unreleased]`.
- Added entries missed on the first pass: the broken VS Code one-click install button fix (AIML-1072) and a Documentation entry for the Hosted-MCP-Server-first README (AIML-976).
- Expanded the filtered route coverage fix (AIML-1057) to also cover the null-status fix and the empty `environments` note.

**2.0.1** (backfill — was never recorded)
- `list_applications_by_cve` duplicate-server fix (TS-42992 workaround), `search_attacks` sort-syntax alignment, CVE ID input normalization, and the new timestamp parameter validation.

No code changes — documentation only.

## Completeness check

Two independent read-only subagents audited `v2.0.0..v2.0.1` and `v2.0.1..v2.1.0` PR-by-PR. Internal-only changes were confirmed excluded on purpose: dependabot config (AIML-1141), the GitHub Actions dependency-group bump, the Wiz scan policy update (ENTSEC-1), test-only fixes (AIML-1134), and release plumbing (AIML-822, PRODSEC gradle pin).

## Notes

- The `Cve` `getScore()`/`setScore()` change (`double` -> nullable `Double`) is recorded under `[2.1.0]` as a Breaking Change. The release shipped as a minor bump, so this documents what was released, not a new decision.