### PR TITLE
AIML-1163 Correct stale base-class and tool names in CLAUDE.md and MCP_STANDARDS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ tool/
 ├── library/        # Library tools (list_application_libraries, list_applications_by_cve)
 ├── attack/         # Attack tools (search_attacks, get_protect_rules)
 ├── server/         # Server tools (search_servers)
-├── sast/           # SAST tools (get_sast_project, get_scan_results)
+├── sast/           # SAST tools (get_scan_project, get_scan_results)
 └── coverage/       # Coverage tools (get_route_coverage)
 ```
 
@@ -158,7 +158,7 @@ EOF
 
 ### Development Patterns
 
-1. **Tool-per-Class**: Each MCP tool is a standalone `@Service` class with `@Tool` annotation, extending `BaseMcpTool` or `BaseGetTool`
+1. **Tool-per-Class**: Each MCP tool is a standalone `@Service` class with `@Tool` annotation, extending `PaginatedTool`, `SingleTool`, or `CursorPaginatedTool`
 2. **@Tool Annotation**: Methods annotated with `@Tool(name = "snake_case_name")` are exposed to AI agents
 3. **Params Pattern**: Each tool has an associated `*Params` class extending `ToolValidationContext` for validation
 4. **Template Method**: Base classes enforce consistent pipeline (validation → execution → response building)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ EOF
 
 1. **Tool-per-Class**: Each MCP tool is a standalone `@Service` class with `@Tool` annotation, extending `PaginatedTool`, `SingleTool`, or `CursorPaginatedTool`
 2. **@Tool Annotation**: Methods annotated with `@Tool(name = "snake_case_name")` are exposed to AI agents
-3. **Params Pattern**: Each tool has an associated `*Params` class extending `ToolValidationContext` for validation
+3. **Params Pattern**: Each tool has an associated `*Params` class extending `BaseToolParams` for validation
 4. **Template Method**: Base classes enforce consistent pipeline (validation → execution → response building)
 5. **SDK Extension Pattern**: Enhanced data models extend base SDK classes with AI-friendly representations
 6. **Hint Generation**: Rule-based system provides contextual security guidance

--- a/MCP_STANDARDS.md
+++ b/MCP_STANDARDS.md
@@ -175,7 +175,7 @@ com.contrast.labs.ai.mcp.contrast.tool/
 
 ### Parameter Classes (Params Pattern)
 
-Each tool has an associated `*Params` class extending `ToolValidationContext`:
+Each tool has an associated `*Params` class extending `BaseToolParams` and validating input through a `ToolValidationContext` used by composition:
 - Validates and parses input parameters
 - Collects errors and warnings via fluent API
 - Converts to SDK filter objects (e.g., `toTraceFilterForm()`)
@@ -187,11 +187,13 @@ return executePipeline(page, pageSize,
     () -> VulnerabilityFilterParams.of(severities, statuses, ...));
 
 // Params class
-public class VulnerabilityFilterParams extends ToolValidationContext {
+public class VulnerabilityFilterParams extends BaseToolParams {
   public static VulnerabilityFilterParams of(String severities, ...) {
     var params = new VulnerabilityFilterParams();
-    params.severities = params.enumSetParam(severities, RuleSeverity.class, "severities").get();
-    // ... more fluent validation
+    var ctx = new ToolValidationContext(); // composition, not inheritance
+    params.severities = ctx.enumSetParam(severities, RuleSeverity.class, "severities").get();
+    // ... more fluent validation on ctx
+    params.setValidationResult(ctx); // transfer errors/warnings
     return params;
   }
 }

--- a/MCP_STANDARDS.md
+++ b/MCP_STANDARDS.md
@@ -209,7 +209,7 @@ Each tool requires corresponding test classes:
 
 1. Create tool class in appropriate domain package (e.g., `tool/vulnerability/`)
 2. Extend `PaginatedTool`, `CursorPaginatedTool`, or `SingleTool` with appropriate type parameters
-3. Create corresponding `*Params` class extending `ToolValidationContext`
+3. Create corresponding `*Params` class extending `BaseToolParams`
 4. Implement `doExecute()` with tool-specific logic
 5. Add `@Tool` annotation with snake_case name following naming standards
 6. **Register the tool explicitly in the appropriate application** (see Tool Registration below)


### PR DESCRIPTION
## What and why

The agent guidance named base classes and a tool that do not exist, and misdescribed the params base class. An agent following `CLAUDE.md` or `MCP_STANDARDS.md` searched for symbols and a tool name absent from the tree, and would model the params pattern with the wrong superclass.

Three stale claims, all now corrected against the code.

- **Base classes.** `CLAUDE.md` said tools extend `BaseMcpTool` or `BaseGetTool`. Neither exists. The real bases are `PaginatedTool`, `SingleTool`, and `CursorPaginatedTool`.
- **Tool name.** `CLAUDE.md` listed `get_sast_project`. The real `@Tool` name is `get_scan_project` (`GetSastProjectTool.java` line 43).
- **Params base.** `CLAUDE.md` and `MCP_STANDARDS.md` said `*Params` extend `ToolValidationContext`. Every `*Params` class extends `BaseToolParams`, and `ToolValidationContext` is a fluent-validation helper used by composition. This one was surfaced by the improve-harness verification rerun.

## Changes

- `CLAUDE.md`. Development Patterns now names `PaginatedTool`, `SingleTool`, `CursorPaginatedTool`, and `BaseToolParams`. The architecture tree now reads `get_scan_project`.
- `MCP_STANDARDS.md`. The params-pattern prose, the worked example, and the Adding a New Tool steps now show `extends BaseToolParams` with a `ToolValidationContext` used by composition (`new ToolValidationContext()`, `ctx.enumSetParam(...)`, `params.setValidationResult(ctx)`).

## Verification

- Every class and tool name written exists in the tree. `SingleTool` and `PaginatedTool` under `contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/`, `get_scan_project` in `GetSastProjectTool.java` line 43, and the corrected example mirrors the real `VulnerabilityFilterParams` and the `BaseToolParams` javadoc.
- A cold-context agent, following only the corrected guidance, reached `SingleTool`, `PaginatedTool`, and `get_scan_project` with guidance and code in agreement. That rerun also surfaced the params-base error, which this PR then fixed.
- A repo-wide sweep confirms no `extends`/`extending ToolValidationContext` reference remains in any tracked doc.
- Docs-only change with no code or test impact.

## Source

Raised from a harness-engineering repository review at commit 8b73c14 and tracked as AIML-1163.
