### PR TITLE
AIML-1164 Add on-demand harness-engineering review and improve commands

### DIFF
--- a/.claude/commands/harness-review.md
+++ b/.claude/commands/harness-review.md
@@ -1,0 +1,42 @@
+---
+description: Run the harness-engineering repository-review playbook against this repo, corpus kept read-only.
+argument-hint: [optional focus, e.g. "delivery and authority"]
+---
+
+# /harness-review
+
+Run Ryan Lopopolo's harness-engineering repository-review playbook against this
+repository. It is a broad, read-only diagnostic. It asks whether a capable coding
+agent can recover the real job, make a coherent change, prove the outcome, and
+operate safely here without using a person as a relay.
+
+An optional focus area may be passed as `$ARGUMENTS`.
+
+## Steps
+
+1. Locate the corpus by running the snippet in `docs/agents/harness.md`. That
+   resolves `CORPUS_DIR` to a read-only checkout pinned to a known commit.
+
+2. Read `$CORPUS_DIR/AGENTS.md`. Follow its Application routing and Working loop.
+   It routes a broad assessment to the repository-review playbook.
+
+3. Read `$CORPUS_DIR/playbooks/README.md`, then
+   `$CORPUS_DIR/playbooks/repository-review.md`. Treat the playbook as a scaffold
+   you can adapt, and record any omission with the local evidence that required it.
+
+4. Run the playbook with this repo as the target. Hold one model and
+   coding-agent configuration constant. Start from this repo's own instructions,
+   `CLAUDE.md` and `docs/agents/`, before pulling any corpus thesis. Pull a corpus
+   thesis only when local evidence leaves an owning decision unresolved. Keep the
+   corpus read-only, and adapt its ideas without copying its file layouts, version
+   pins, or fixtures.
+
+5. Deliver findings ordered by consequence, following the playbook's Findings
+   section. For each, name the invariant at risk, the concrete evidence and owning
+   boundary, why existing proof missed it, and the smallest owning correction.
+
+This command inspects only. It does not authorize changes to the repo. To act on
+one finding through a bounded change-and-verify loop, run `/improve-harness`.
+
+If `$ARGUMENTS` names a focus area, weight the review there while still answering
+the playbook's outcome questions.

--- a/.claude/commands/improve-harness.md
+++ b/.claude/commands/improve-harness.md
@@ -1,0 +1,45 @@
+---
+description: Run the harness-engineering improve-harness playbook for one bounded job in this repo.
+argument-hint: [the job to improve, e.g. "add a new MCP tool"]
+---
+
+# /improve-harness
+
+Run Ryan Lopopolo's harness-engineering improve-harness playbook against this
+repository. It closes one bounded operational loop, from baseline through the
+earliest failed handoff to the smallest owning intervention, native verification,
+and a fresh rerun.
+
+The job to improve is passed as `$ARGUMENTS`. If none is given, ask for one
+bounded, representative job before starting.
+
+## Steps
+
+1. Locate the corpus by running the snippet in `docs/agents/harness.md`. That
+   resolves `CORPUS_DIR` to a read-only checkout pinned to a known commit.
+
+2. Read `$CORPUS_DIR/AGENTS.md`. Follow its Application routing and Working loop,
+   and use its Context routing inside the gap-classification step.
+
+3. Read `$CORPUS_DIR/playbooks/README.md`, then
+   `$CORPUS_DIR/playbooks/improve-harness.md`. Treat the procedure as a scaffold
+   you can adapt or reject, and record what changed and why.
+
+4. Run the loop with this repo as the target. Record the job contract first, and
+   establish scope and authority before changing anything. Change this repo only
+   when the task and its authority contract grant that operation, otherwise stop
+   after recording the evidence, proposed owner, intervention, proof plan, and
+   expected effect.
+
+5. Implement the smallest reversible change at the earliest owner, then verify
+   both layers. Run this repo's native checks (`make check-test`, plus
+   `make verify` when credentials allow), and exercise the user or operational
+   journey that establishes the accepted outcome.
+
+6. Record the compact result where this repo keeps architecture or history, a
+   bead comment, an ADR under `docs/adr/`, or `CONTEXT.md`. Name the owner, the
+   evidence, and the retirement condition.
+
+Keep the corpus read-only, and adapt its ideas without copying its file layouts,
+version pins, or fixtures. Follow this repo's branching and PR workflow in
+CLAUDE.md for any change.

--- a/.claude/hooks/checkstyle.sh
+++ b/.claude/hooks/checkstyle.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# PostToolUse hook: run Checkstyle after Java files are created or edited
+
+f=$(jq -r '.tool_input.file_path // ""')
+
+# Only run for Java files
+if ! echo "$f" | grep -qE '\.java$'; then
+  exit 0
+fi
+
+# Navigate to project root (two levels up from .claude/hooks/)
+cd "$(dirname "$0")/../.." || exit 0
+
+output=$(./gradlew checkstyleMain checkstyleTest 2>&1)
+rc=$?
+
+[ $rc -eq 0 ] && exit 0
+
+# Feed violations back to Claude as additional context
+jq -n --arg ctx "Checkstyle violations after editing $f:
+
+$output" \
+  '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":$ctx}}'

--- a/.claude/hooks/trauma_guard.py
+++ b/.claude/hooks/trauma_guard.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+Dynamic Trauma Guard for Project Hot Stove.
+Reads from ~/.cass-memory/traumas.jsonl and .cass/traumas.jsonl to enforce safety.
+"""
+import json
+import sys
+import re
+import os
+from pathlib import Path
+
+GLOBAL_TRAUMA_FILE = Path.home() / ".cass-memory" / "traumas.jsonl"
+
+def find_repo_root():
+    """Find the root of the current git repository."""
+    curr = Path.cwd()
+    while curr != curr.parent:
+        if (curr / ".git").exists():
+            return curr
+        curr = curr.parent
+    return None
+
+def load_traumas():
+    """Load active traumas from global and project storage."""
+    traumas = []
+    
+    # Load Global
+    if GLOBAL_TRAUMA_FILE.exists():
+        try:
+            with open(GLOBAL_TRAUMA_FILE, "r", encoding="utf-8") as f:
+                for line in f:
+                    if line.strip():
+                        try:
+                            t = json.loads(line)
+                            if isinstance(t, dict) and t.get("status") == "active":
+                                traumas.append(t)
+                        except:
+                            pass
+        except Exception:
+            pass # Fail open on read error (don't block work if DB is corrupt)
+
+    # Load Project
+    repo_root = find_repo_root()
+    if repo_root:
+        repo_file = repo_root / ".cass" / "traumas.jsonl"
+        if repo_file.exists():
+            try:
+                with open(repo_file, "r", encoding="utf-8") as f:
+                    for line in f:
+                        if line.strip():
+                            try:
+                                t = json.loads(line)
+                                if isinstance(t, dict) and t.get("status") == "active":
+                                    traumas.append(t)
+                            except:
+                                pass
+            except Exception:
+                pass
+
+    return traumas
+
+def check_command(command, traumas):
+    """Check command against trauma patterns."""
+    for trauma in traumas:
+        if not isinstance(trauma, dict):
+            continue
+
+        pattern = trauma.get("pattern")
+        if not isinstance(pattern, str) or not pattern:
+            continue
+            
+        try:
+            # Case-insensitive match
+            if re.search(pattern, command, re.IGNORECASE):
+                return trauma
+        except re.error:
+            continue
+    return None
+
+def main():
+    # Read input from Claude/Generic Hook
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        # Not a JSON hook input, ignore
+        sys.exit(0)
+
+    if not isinstance(input_data, dict):
+        # Fail open if the hook input isn't the expected object shape
+        sys.exit(0)
+
+    # Extract command
+    # Claude Code format: {"tool_name": "Bash", "tool_input": {"command": "..."}}
+    tool_name = input_data.get("tool_name")
+    tool_input = input_data.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        sys.exit(0)
+    command = tool_input.get("command")
+
+    # Only check Bash commands
+    if tool_name != "Bash" or not isinstance(command, str) or not command:
+        sys.exit(0)
+
+    traumas = load_traumas()
+    match = check_command(command, traumas)
+
+    if match:
+        trigger = match.get("trigger_event")
+        if not isinstance(trigger, dict):
+            trigger = {}
+        msg = trigger.get("human_message") or "You previously caused a catastrophe with this command."
+        ref = trigger.get("session_path") or "unknown"
+        pattern = match.get("pattern") or "<unknown>"
+        trauma_id = match.get("id") or "<unknown>"
+
+        use_emoji = os.environ.get("CASS_MEMORY_NO_EMOJI") is None
+        banner = (
+            "\U0001f525 HOT STOVE: VISCERAL SAFETY INTERVENTION \U0001f525"
+            if use_emoji
+            else "[HOT STOVE] VISCERAL SAFETY INTERVENTION"
+        )
+        
+        # Deny the command
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": (
+                    f"{banner}\n\n"
+                    f"BLOCKED: This pattern matches a registered TRAUMA.\n"
+                    f"Pattern: {pattern}\n"
+                    f"Reason: {msg}\n"
+                    f"Reference: {ref}\n\n"
+                    f"If you MUST run this, heal it first with: cm trauma heal {trauma_id}"
+                )
+            }
+        }
+        print(json.dumps(output))
+        sys.exit(0)
+
+    # Allow
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,46 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__qmd__get",
+      "mcp__qmd__deep_search",
+      "mcp__qmd__search",
+      "Bash(make verify)",
+      "mcp__plugin_atlassian_atlassian__atlassianUserInfo",
+      "Bash(br show *)",
+      "Bash(br list *)",
+      "Bash(br ready)",
+      "Bash(make check-test)",
+      "Bash(make check *)",
+      "Bash(make test *)",
+      "Bash(cass search *)",
+      "Bash(cass timeline *)",
+      "mcp__plugin_atlassian_atlassian__getJiraIssue"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/checkstyle.sh",
+            "timeout": 60,
+            "statusMessage": "Running Checkstyle..."
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/trauma_guard.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,8 @@ test-plan-results/
 .mcp.json
 
 ### Claude Code ###
-.claude/
+.claude/settings.local.json
+.claude/worktrees/
 test-plans-archive/
 .tldr/
 .tldrignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -573,6 +573,10 @@ Canonical triage labels (`needs-triage`, `needs-info`, `ready-for-agent`, `ready
 
 Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root (created lazily). See `docs/agents/domain.md`.
 
+### Harness engineering
+
+Run the harness-engineering playbooks against this repo on demand via `/harness-review` (broad diagnostic) and `/improve-harness` (one bounded change-and-verify loop). The corpus is pinned and kept read-only. See `docs/agents/harness.md`.
+
 
 
 @SECURITY.md

--- a/docs/agents/harness.md
+++ b/docs/agents/harness.md
@@ -1,0 +1,62 @@
+# Harness engineering route
+
+The harness-engineering corpus is a read-only context bundle and set of playbooks
+by Ryan Lopopolo, meant to be pointed at a target repository. Two project commands
+run its playbooks against this repo just in time, so the corpus is never preloaded
+into CLAUDE.md.
+
+- `/harness-review` runs the repository-review playbook, a broad diagnostic of
+  whether a coding agent can recover the real job, make a coherent change, prove
+  the outcome, and operate safely here without a human relay.
+- `/improve-harness` runs the improve-harness playbook, one bounded loop from
+  baseline through the earliest failed handoff to the smallest owning
+  intervention, native verification, and a fresh rerun.
+
+Both commands read the corpus `AGENTS.md`, follow its routing to the named
+playbook, and keep the corpus read-only. This repo is always the target.
+
+## Locate the corpus
+
+The corpus is pinned to commit `226c8d35fb6ea3ed55467753dba6dea2b5fd5778` for
+reproducible runs. Any developer with git and network access resolves the same
+commit, no pre-existing local layout required. Run this to resolve `CORPUS_DIR`.
+
+```bash
+CORPUS_COMMIT=226c8d35fb6ea3ed55467753dba6dea2b5fd5778
+CORPUS_URL=https://github.com/lopopolo/harness-engineering.git
+CACHE_DIR=$HOME/.cache/harness-engineering/$CORPUS_COMMIT
+
+# Fast path, reuse a local checkout only when it already sits on the pin.
+# Never checkout inside a developer's own clone, the corpus stays read-only.
+if [ -n "$HARNESS_ENGINEERING_DIR" ] && \
+   [ "$(git -C "$HARNESS_ENGINEERING_DIR" rev-parse HEAD 2>/dev/null)" = "$CORPUS_COMMIT" ]; then
+  CORPUS_DIR=$HARNESS_ENGINEERING_DIR
+else
+  # Managed per-user cache, clone once and pin to the exact commit.
+  if [ ! -e "$CACHE_DIR/AGENTS.md" ]; then
+    git clone --quiet "$CORPUS_URL" "$CACHE_DIR"
+  fi
+  git -C "$CACHE_DIR" fetch --quiet origin "$CORPUS_COMMIT" 2>/dev/null || true
+  git -C "$CACHE_DIR" checkout --quiet "$CORPUS_COMMIT"
+  CORPUS_DIR=$CACHE_DIR
+fi
+echo "corpus $CORPUS_DIR at $(git -C "$CORPUS_DIR" rev-parse HEAD)"
+```
+
+Set `HARNESS_ENGINEERING_DIR` to an existing corpus checkout to skip the clone
+when it already sits on the pin. To bump the pin, change `CORPUS_COMMIT` here.
+This file owns the pin, so it lives in one place.
+
+## Read-only and non-goals
+
+Treat the corpus as read-only. The playbooks target this repo, so every change
+lands here through the normal branching and PR workflow. Do not embed the corpus
+in this repo, do not paste it into CLAUDE.md, and do not copy its file layouts,
+version pins, or fixtures. Adapt its ideas to this repo without importing its
+structure.
+
+## Reach
+
+These commands are scoped to this repo. Packaging the playbooks as a plugin in
+`Contrast-Security-Inc/claude-marketplace`, so every Contrast repo gets them from
+one source, is a possible follow-up tracked under AIML-1164.


### PR DESCRIPTION
## Why

This repo's AI harness, its CLAUDE.md, its docs/agents routes, commands, hooks, and checks, is what lets a coding agent do real work here. The harness-engineering corpus by Ryan Lopopolo (github.com/lopopolo/harness-engineering) is a read-only bundle of playbooks for improving exactly that, the environment around a fixed model and agent, so the agent can recover intent, operate the real system, prove outcomes, and leave the next run better equipped.

We already used that corpus by hand to run a repository review (AIML-1157 through AIML-1163) and one improve-harness loop, but there was no repo-native entry point, so the usage was ad hoc. This PR gives us a discoverable, just-in-time way to point those playbooks at this repo whenever we want to review or improve our own AI harness, without preloading the corpus into CLAUDE.md.

## What

Two project slash commands, following the corpus's own just-in-time principle.

- `/harness-review` runs the repository-review playbook, a broad read-only diagnostic of whether an agent can recover the job, make a coherent change, prove the outcome, and operate safely here.
- `/improve-harness` runs the improve-harness playbook, one bounded loop from baseline through the smallest owning intervention to a fresh rerun.

Each command locates the corpus, reads its AGENTS.md, follows its routing to the named playbook, and runs it against this repo with the corpus kept read-only.

## How the corpus is pinned

`docs/agents/harness.md` owns a single pinned commit (`226c8d3`) and the locate logic. A developer who already has the corpus checked out can point `HARNESS_ENGINEERING_DIR` at it (used only when it sits on the pin, and never checked out in place, so the corpus stays read-only). Everyone else clones the pinned commit into a per-user cache. Both paths resolve the identical commit, so runs are reproducible across the team. Both were tested end to end.

## Also in this PR

Standardizing the `.claude/` gitignore to the Claude Code convention. The repo previously ignored all of `.claude/`. It now ignores only the personal `settings.local.json` and the transient `worktrees/`, so the project `settings.json`, the two `hooks/` scripts, and the new `commands/` are shared with the team. The settings.json is a permission allowlist plus hook wiring, no secrets.

## Non-goals

The corpus is not embedded here and not pasted into CLAUDE.md. Its file layouts, version pins, and fixtures are not copied in. Packaging the commands as a marketplace plugin so every Contrast repo gets them is noted as a follow-up in docs/agents/harness.md.

## Testing

No application code changed, so there is nothing new to unit test. The only executable logic is the corpus-locate snippet in `docs/agents/harness.md`, verified on both the local-checkout and clone-on-demand paths, each resolving the pinned commit.

Jira ticket AIML-1164.
