### PR TITLE
AIML-1158 Give vulnerability status a typed owner and render tool-param text from it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ the correct total, exercised, and discovered route counts and coverage percentag
 
 ### Improvements
 
+- search_vulnerabilities / search_app_vulnerabilities now advertise all 7 valid statuses (adds NotAProblem, AutoRemediated, previously accepted but undocumented); default-exclusion warning text updated. (AIML-1158)
+
 **New `search_servers` tool**: Search the EAC-visible server inventory by agent health,
 environment, application, tag, and Protect coverage with pagination and sorting.
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ValidationConstants.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ValidationConstants.java
@@ -15,9 +15,6 @@
  */
 package com.contrast.labs.ai.mcp.contrast.tool.validation;
 
-import java.util.List;
-import java.util.Set;
-
 /** Shared validation constants for MCP tools. */
 public final class ValidationConstants {
 
@@ -38,21 +35,6 @@ public final class ValidationConstants {
 
   /** Minimum page number (1-indexed). */
   public static final int MIN_PAGE = 1;
-
-  /** Valid vulnerability status values. */
-  public static final Set<String> VALID_VULN_STATUSES =
-      Set.of(
-          "Reported",
-          "Suspicious",
-          "Confirmed",
-          "NotAProblem",
-          "Remediated",
-          "Fixed",
-          "AutoRemediated");
-
-  /** Default vulnerability statuses (actionable only, excludes Fixed/Remediated). */
-  public static final List<String> DEFAULT_VULN_STATUSES =
-      List.of("Reported", "Suspicious", "Confirmed");
 
   private ValidationConstants() {}
 }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java
@@ -90,12 +90,7 @@ public class SearchAppVulnerabilitiesTool
               description = "Comma-separated severities: CRITICAL,HIGH,MEDIUM,LOW,NOTE",
               required = false)
           String severities,
-      @ToolParam(
-              description =
-                  "Comma-separated statuses: Reported,Suspicious,Confirmed,Remediated,Fixed."
-                      + " Default: Reported,Suspicious,Confirmed",
-              required = false)
-          String statuses,
+      @ToolParam(description = VulnStatus.PARAM_DESCRIPTION, required = false) String statuses,
       @ToolParam(
               description =
                   "Comma-separated vulnerability types. Use list_vulnerability_types for complete"

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesTool.java
@@ -86,13 +86,7 @@ public class SearchVulnerabilitiesTool extends PaginatedTool<VulnerabilityFilter
                       + " severities",
               required = false)
           String severities,
-      @ToolParam(
-              description =
-                  "Comma-separated statuses: Reported,Suspicious,Confirmed,Remediated,Fixed."
-                      + " Default: Reported,Suspicious,Confirmed (excludes Fixed and Remediated to"
-                      + " focus on actionable items)",
-              required = false)
-          String statuses,
+      @ToolParam(description = VulnStatus.PARAM_DESCRIPTION, required = false) String statuses,
       @ToolParam(
               description =
                   "Comma-separated vulnerability types (e.g., sql-injection,xss-reflected). Use"

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnStatus.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnStatus.java
@@ -15,7 +15,10 @@
  */
 package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 
+import com.contrast.labs.ai.mcp.contrast.tool.validation.ToolValidationContext;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -23,10 +26,11 @@ import java.util.stream.Collectors;
 /**
  * Single typed owner of the vulnerability status vocabulary.
  *
- * <p>This type owns three things that previously drifted apart across {@code ValidationConstants},
- * the {@code @ToolParam} description text, and the params javadoc: the valid status set, the
- * actionable default subset, and the model-facing description string. Owning them here keeps them
- * in lockstep (see {@code VulnStatusTest} for the anti-drift guard).
+ * <p>This type owns what previously drifted apart across {@code ValidationConstants}, the
+ * {@code @ToolParam} description text, and the params javadoc: the valid status set, the actionable
+ * default subset, the statuses excluded from that subset, the model-facing description string, and
+ * the default-applied warning reason. Owning them here keeps them in lockstep (see {@code
+ * VulnStatusTest} for the anti-drift guards).
  *
  * <p>Each constant carries its exact TeamServer trace-filter API value. Casing matters: {@link
  * com.contrast.labs.ai.mcp.contrast.tool.validation.StringListSpec} normalizes caller input against
@@ -51,14 +55,33 @@ public enum VulnStatus {
   /** Actionable default subset shown when the caller supplies no status filter. */
   private static final List<VulnStatus> DEFAULTS = List.of(REPORTED, SUSPICIOUS, CONFIRMED);
 
+  /** All status API values, computed once, in enum-declaration order for deterministic messages. */
+  private static final Set<String> VALID_API_VALUES =
+      Collections.unmodifiableSet(
+          Arrays.stream(values())
+              .map(VulnStatus::apiValue)
+              .collect(Collectors.<String, LinkedHashSet<String>>toCollection(LinkedHashSet::new)));
+
+  /** The actionable default status API values, computed once. */
+  private static final List<String> DEFAULT_API_VALUES =
+      DEFAULTS.stream().map(VulnStatus::apiValue).toList();
+
+  /** Statuses excluded from the default subset (valid minus default), in enum order. */
+  private static final List<String> NON_DEFAULT_API_VALUES =
+      Arrays.stream(values())
+          .map(VulnStatus::apiValue)
+          .filter(v -> !DEFAULT_API_VALUES.contains(v))
+          .toList();
+
   /**
    * Model-facing description for the {@code statuses} {@code @ToolParam}.
    *
    * <p>{@code @ToolParam(description = ...)} requires a compile-time constant, so this cannot be
    * computed from {@link #values()} at runtime. It is hand-written from string literals and kept
-   * honest by {@code VulnStatusTest}, which asserts the advertised set here equals {@link
-   * #validApiValues()} exactly. Keep the {@code "Comma-separated statuses: <csv>. Default:"} shape
-   * intact so that guard can parse it.
+   * honest by {@code VulnStatusTest}: one guard asserts the advertised CSV equals {@link
+   * #validApiValues()} exactly, another asserts the "excludes" clause equals {@link
+   * #nonDefaultApiValues()} exactly. Keep the {@code "Comma-separated statuses: <csv>. Default:"}
+   * shape and the {@code "excludes <csv>)"} tail intact so those guards can parse them.
    */
   public static final String PARAM_DESCRIPTION =
       "Comma-separated statuses: "
@@ -66,11 +89,14 @@ public enum VulnStatus {
           + "Default: Reported,Suspicious,Confirmed "
           + "(actionable only; excludes NotAProblem, Remediated, Fixed, AutoRemediated)";
 
-  /** Warning reason surfaced to the model when the actionable default subset is applied. */
+  /**
+   * Warning reason surfaced to the model when the actionable default subset is applied. Derived
+   * from {@link #nonDefaultApiValues()} so the excluded list cannot drift.
+   */
   public static final String DEFAULT_REASON =
-      "Showing actionable vulnerabilities only "
-          + "(excluding NotAProblem, Remediated, Fixed, AutoRemediated). "
-          + "To see all statuses, specify statuses parameter explicitly.";
+      "Showing actionable vulnerabilities only (excluding "
+          + String.join(", ", NON_DEFAULT_API_VALUES)
+          + "). To see all statuses, specify statuses parameter explicitly.";
 
   /** Exact TeamServer API value for this status. */
   public String apiValue() {
@@ -80,20 +106,42 @@ public enum VulnStatus {
   /**
    * All valid status API values, for use as {@code allowedValues} on the statuses filter.
    *
-   * @return an unmodifiable set of every status API value
+   * @return an unmodifiable, enum-ordered set of every status API value
    */
   public static Set<String> validApiValues() {
-    return Arrays.stream(values())
-        .map(VulnStatus::apiValue)
-        .collect(Collectors.toUnmodifiableSet());
+    return VALID_API_VALUES;
   }
 
   /**
    * The actionable default status API values, in a stable order.
    *
-   * @return {@code [Reported, Suspicious, Confirmed]}
+   * @return an unmodifiable list {@code [Reported, Suspicious, Confirmed]}
    */
   public static List<String> defaultApiValues() {
-    return DEFAULTS.stream().map(VulnStatus::apiValue).toList();
+    return DEFAULT_API_VALUES;
+  }
+
+  /**
+   * The statuses excluded from the actionable default subset (valid minus default).
+   *
+   * @return an unmodifiable list {@code [NotAProblem, Remediated, Fixed, AutoRemediated]}
+   */
+  public static List<String> nonDefaultApiValues() {
+    return NON_DEFAULT_API_VALUES;
+  }
+
+  /**
+   * Parse, validate, and default the statuses filter against this vocabulary. Centralizes the
+   * wiring both vulnerability params classes share.
+   *
+   * @param ctx the validation context collecting errors/warnings
+   * @param statusesParam raw comma-separated statuses (may be null/blank)
+   * @return the validated, normalized statuses, or the default subset when none supplied
+   */
+  public static List<String> resolveStatuses(ToolValidationContext ctx, String statusesParam) {
+    return ctx.stringListParam(statusesParam, "statuses")
+        .allowedValues(validApiValues())
+        .defaultTo(defaultApiValues(), DEFAULT_REASON)
+        .get();
   }
 }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnStatus.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnStatus.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Single typed owner of the vulnerability status vocabulary.
+ *
+ * <p>This type owns three things that previously drifted apart across {@code ValidationConstants},
+ * the {@code @ToolParam} description text, and the params javadoc: the valid status set, the
+ * actionable default subset, and the model-facing description string. Owning them here keeps them
+ * in lockstep (see {@code VulnStatusTest} for the anti-drift guard).
+ *
+ * <p>Each constant carries its exact TeamServer trace-filter API value. Casing matters: {@link
+ * com.contrast.labs.ai.mcp.contrast.tool.validation.StringListSpec} normalizes caller input against
+ * these strings. All seven values are confirmed accepted as filter inputs by the TeamServer {@code
+ * /orgtraces/filter} endpoint (see AIML-1158).
+ */
+public enum VulnStatus {
+  REPORTED("Reported"),
+  SUSPICIOUS("Suspicious"),
+  CONFIRMED("Confirmed"),
+  NOT_A_PROBLEM("NotAProblem"),
+  REMEDIATED("Remediated"),
+  FIXED("Fixed"),
+  AUTO_REMEDIATED("AutoRemediated");
+
+  private final String apiValue;
+
+  VulnStatus(String apiValue) {
+    this.apiValue = apiValue;
+  }
+
+  /** Actionable default subset shown when the caller supplies no status filter. */
+  private static final List<VulnStatus> DEFAULTS = List.of(REPORTED, SUSPICIOUS, CONFIRMED);
+
+  /**
+   * Model-facing description for the {@code statuses} {@code @ToolParam}.
+   *
+   * <p>{@code @ToolParam(description = ...)} requires a compile-time constant, so this cannot be
+   * computed from {@link #values()} at runtime. It is hand-written from string literals and kept
+   * honest by {@code VulnStatusTest}, which asserts the advertised set here equals {@link
+   * #validApiValues()} exactly. Keep the {@code "Comma-separated statuses: <csv>. Default:"} shape
+   * intact so that guard can parse it.
+   */
+  public static final String PARAM_DESCRIPTION =
+      "Comma-separated statuses: "
+          + "Reported,Suspicious,Confirmed,NotAProblem,Remediated,Fixed,AutoRemediated. "
+          + "Default: Reported,Suspicious,Confirmed "
+          + "(actionable only; excludes NotAProblem, Remediated, Fixed, AutoRemediated)";
+
+  /** Warning reason surfaced to the model when the actionable default subset is applied. */
+  public static final String DEFAULT_REASON =
+      "Showing actionable vulnerabilities only "
+          + "(excluding NotAProblem, Remediated, Fixed, AutoRemediated). "
+          + "To see all statuses, specify statuses parameter explicitly.";
+
+  /** Exact TeamServer API value for this status. */
+  public String apiValue() {
+    return apiValue;
+  }
+
+  /**
+   * All valid status API values, for use as {@code allowedValues} on the statuses filter.
+   *
+   * @return an unmodifiable set of every status API value
+   */
+  public static Set<String> validApiValues() {
+    return Arrays.stream(values())
+        .map(VulnStatus::apiValue)
+        .collect(Collectors.toUnmodifiableSet());
+  }
+
+  /**
+   * The actionable default status API values, in a stable order.
+   *
+   * @return {@code [Reported, Suspicious, Confirmed]}
+   */
+  public static List<String> defaultApiValues() {
+    return DEFAULTS.stream().map(VulnStatus::apiValue).toList();
+  }
+}

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParams.java
@@ -19,7 +19,7 @@ import com.contrast.labs.ai.mcp.contrast.sdkextension.ExtendedTraceFilterBody;
 import com.contrast.labs.ai.mcp.contrast.tool.base.BaseToolParams;
 import com.contrast.labs.ai.mcp.contrast.tool.validation.ToolValidationContext;
 import com.contrast.labs.ai.mcp.contrast.tool.validation.UnresolvedMetadataFilter;
-import com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants;
+import com.contrast.labs.ai.mcp.contrast.tool.vulnerability.VulnStatus;
 import com.contrastsecurity.http.RuleSeverity;
 import com.contrastsecurity.http.ServerEnvironment;
 import com.contrastsecurity.models.TraceTimestampField;
@@ -66,7 +66,8 @@ public class SearchAppVulnerabilitiesParams extends BaseToolParams {
    *
    * @param appIdParam Application ID (required)
    * @param severitiesParam Comma-separated severities (CRITICAL,HIGH,MEDIUM,LOW,NOTE)
-   * @param statusesParam Comma-separated statuses (Reported,Suspicious,Confirmed,Remediated,Fixed)
+   * @param statusesParam Comma-separated statuses; see {@link VulnStatus} for the valid set
+   *     (Reported,Suspicious,Confirmed,NotAProblem,Remediated,Fixed,AutoRemediated)
    * @param vulnTypesParam Comma-separated vulnerability types
    * @param environmentsParam Comma-separated environments (DEVELOPMENT,QA,PRODUCTION)
    * @param lastSeenAfterParam ISO date (YYYY-MM-DD) or epoch timestamp
@@ -101,11 +102,8 @@ public class SearchAppVulnerabilitiesParams extends BaseToolParams {
 
     params.statuses =
         ctx.stringListParam(statusesParam, "statuses")
-            .allowedValues(ValidationConstants.VALID_VULN_STATUSES)
-            .defaultTo(
-                ValidationConstants.DEFAULT_VULN_STATUSES,
-                "Showing actionable vulnerabilities only (excluding Fixed and Remediated). "
-                    + "To see all statuses, specify statuses parameter explicitly.")
+            .allowedValues(VulnStatus.validApiValues())
+            .defaultTo(VulnStatus.defaultApiValues(), VulnStatus.DEFAULT_REASON)
             .get();
 
     params.vulnTypes = ctx.stringListParam(vulnTypesParam, "vulnTypes").get();

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParams.java
@@ -67,7 +67,6 @@ public class SearchAppVulnerabilitiesParams extends BaseToolParams {
    * @param appIdParam Application ID (required)
    * @param severitiesParam Comma-separated severities (CRITICAL,HIGH,MEDIUM,LOW,NOTE)
    * @param statusesParam Comma-separated statuses; see {@link VulnStatus} for the valid set
-   *     (Reported,Suspicious,Confirmed,NotAProblem,Remediated,Fixed,AutoRemediated)
    * @param vulnTypesParam Comma-separated vulnerability types
    * @param environmentsParam Comma-separated environments (DEVELOPMENT,QA,PRODUCTION)
    * @param lastSeenAfterParam ISO date (YYYY-MM-DD) or epoch timestamp
@@ -100,11 +99,7 @@ public class SearchAppVulnerabilitiesParams extends BaseToolParams {
     // Parse filter parameters with fluent API
     params.severities = ctx.enumSetParam(severitiesParam, RuleSeverity.class, "severities").get();
 
-    params.statuses =
-        ctx.stringListParam(statusesParam, "statuses")
-            .allowedValues(VulnStatus.validApiValues())
-            .defaultTo(VulnStatus.defaultApiValues(), VulnStatus.DEFAULT_REASON)
-            .get();
+    params.statuses = VulnStatus.resolveStatuses(ctx, statusesParam);
 
     params.vulnTypes = ctx.stringListParam(vulnTypesParam, "vulnTypes").get();
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParams.java
@@ -18,7 +18,7 @@ package com.contrast.labs.ai.mcp.contrast.tool.vulnerability.params;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.ExtendedTraceFilterBody;
 import com.contrast.labs.ai.mcp.contrast.tool.base.BaseToolParams;
 import com.contrast.labs.ai.mcp.contrast.tool.validation.ToolValidationContext;
-import com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants;
+import com.contrast.labs.ai.mcp.contrast.tool.vulnerability.VulnStatus;
 import com.contrastsecurity.http.RuleSeverity;
 import com.contrastsecurity.http.ServerEnvironment;
 import com.contrastsecurity.models.TraceTimestampField;
@@ -59,7 +59,7 @@ public class VulnerabilityFilterParams extends BaseToolParams {
    * Parse and validate vulnerability filter parameters using fluent API.
    *
    * @param severitiesParam Comma-separated severities (CRITICAL,HIGH,MEDIUM,LOW,NOTE)
-   * @param statusesParam Comma-separated statuses
+   * @param statusesParam Comma-separated statuses; see {@link VulnStatus} for the valid set
    *     (Reported,Suspicious,Confirmed,NotAProblem,Remediated,Fixed,AutoRemediated)
    * @param vulnTypesParam Comma-separated vulnerability types
    * @param environmentsParam Comma-separated environments (DEVELOPMENT,QA,PRODUCTION)
@@ -85,11 +85,8 @@ public class VulnerabilityFilterParams extends BaseToolParams {
 
     params.statuses =
         ctx.stringListParam(statusesParam, "statuses")
-            .allowedValues(ValidationConstants.VALID_VULN_STATUSES)
-            .defaultTo(
-                ValidationConstants.DEFAULT_VULN_STATUSES,
-                "Showing actionable vulnerabilities only (excluding Fixed and Remediated). "
-                    + "To see all statuses, specify statuses parameter explicitly.")
+            .allowedValues(VulnStatus.validApiValues())
+            .defaultTo(VulnStatus.defaultApiValues(), VulnStatus.DEFAULT_REASON)
             .get();
 
     params.vulnTypes = ctx.stringListParam(vulnTypesParam, "vulnTypes").get();

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParams.java
@@ -60,7 +60,6 @@ public class VulnerabilityFilterParams extends BaseToolParams {
    *
    * @param severitiesParam Comma-separated severities (CRITICAL,HIGH,MEDIUM,LOW,NOTE)
    * @param statusesParam Comma-separated statuses; see {@link VulnStatus} for the valid set
-   *     (Reported,Suspicious,Confirmed,NotAProblem,Remediated,Fixed,AutoRemediated)
    * @param vulnTypesParam Comma-separated vulnerability types
    * @param environmentsParam Comma-separated environments (DEVELOPMENT,QA,PRODUCTION)
    * @param lastSeenAfterParam ISO date (YYYY-MM-DD) or epoch timestamp
@@ -83,11 +82,7 @@ public class VulnerabilityFilterParams extends BaseToolParams {
     // Parse with fluent API - validation state collected in ctx
     params.severities = ctx.enumSetParam(severitiesParam, RuleSeverity.class, "severities").get();
 
-    params.statuses =
-        ctx.stringListParam(statusesParam, "statuses")
-            .allowedValues(VulnStatus.validApiValues())
-            .defaultTo(VulnStatus.defaultApiValues(), VulnStatus.DEFAULT_REASON)
-            .get();
+    params.statuses = VulnStatus.resolveStatuses(ctx, statusesParam);
 
     params.vulnTypes = ctx.stringListParam(vulnTypesParam, "vulnTypes").get();
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ValidationConstantsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ValidationConstantsTest.java
@@ -28,37 +28,4 @@ class ValidationConstantsTest {
     assertThat(ValidationConstants.MAX_PAGE_SIZE).isEqualTo(100);
     assertThat(ValidationConstants.MIN_PAGE).isEqualTo(1);
   }
-
-  @Test
-  void valid_vuln_statuses_should_contain_expected_values() {
-    assertThat(ValidationConstants.VALID_VULN_STATUSES)
-        .containsExactlyInAnyOrder(
-            "Reported",
-            "Suspicious",
-            "Confirmed",
-            "NotAProblem",
-            "Remediated",
-            "Fixed",
-            "AutoRemediated");
-  }
-
-  @Test
-  void default_vuln_statuses_should_contain_actionable_only() {
-    assertThat(ValidationConstants.DEFAULT_VULN_STATUSES)
-        .containsExactly("Reported", "Suspicious", "Confirmed");
-
-    // Should not contain resolved statuses
-    assertThat(ValidationConstants.DEFAULT_VULN_STATUSES)
-        .doesNotContain("Fixed", "Remediated", "NotAProblem", "AutoRemediated");
-  }
-
-  @Test
-  void valid_vuln_statuses_should_be_immutable() {
-    assertThat(ValidationConstants.VALID_VULN_STATUSES).isUnmodifiable();
-  }
-
-  @Test
-  void default_vuln_statuses_should_be_immutable() {
-    assertThat(ValidationConstants.DEFAULT_VULN_STATUSES).isUnmodifiable();
-  }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnStatusTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnStatusTest.java
@@ -18,8 +18,7 @@ package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class VulnStatusTest {
@@ -49,6 +48,22 @@ class VulnStatusTest {
   }
 
   @Test
+  void defaultApiValues_should_be_unmodifiable() {
+    assertThat(VulnStatus.defaultApiValues()).isUnmodifiable();
+  }
+
+  @Test
+  void nonDefaultApiValues_should_be_valid_minus_default() {
+    assertThat(VulnStatus.nonDefaultApiValues())
+        .containsExactly("NotAProblem", "Remediated", "Fixed", "AutoRemediated");
+  }
+
+  @Test
+  void nonDefaultApiValues_should_be_unmodifiable() {
+    assertThat(VulnStatus.nonDefaultApiValues()).isUnmodifiable();
+  }
+
+  @Test
   void defaultApiValues_should_exclude_resolved_statuses() {
     assertThat(VulnStatus.defaultApiValues())
         .doesNotContain("NotAProblem", "Remediated", "Fixed", "AutoRemediated");
@@ -73,7 +88,7 @@ class VulnStatusTest {
    */
   @Test
   void paramDescription_should_advertise_exactly_the_valid_status_set() {
-    Set<String> advertised = advertisedStatuses(VulnStatus.PARAM_DESCRIPTION);
+    List<String> advertised = advertisedStatuses(VulnStatus.PARAM_DESCRIPTION);
 
     assertThat(advertised).containsExactlyInAnyOrderElementsOf(VulnStatus.validApiValues());
   }
@@ -85,12 +100,33 @@ class VulnStatusTest {
     assertThat(VulnStatus.PARAM_DESCRIPTION).contains(expectedDefault);
   }
 
+  // Anti-drift guard over the exclusion prose (M1): the "excludes ...)" clause in
+  // PARAM_DESCRIPTION must name exactly nonDefaultApiValues(), in order.
+  @Test
+  void paramDescription_excludes_clause_should_name_exactly_the_non_default_statuses() {
+    String marker = "excludes ";
+    int start = VulnStatus.PARAM_DESCRIPTION.indexOf(marker) + marker.length();
+    int end = VulnStatus.PARAM_DESCRIPTION.lastIndexOf(")");
+    List<String> excluded =
+        Arrays.stream(VulnStatus.PARAM_DESCRIPTION.substring(start, end).split(","))
+            .map(String::trim)
+            .toList();
+    assertThat(excluded).containsExactlyElementsOf(VulnStatus.nonDefaultApiValues());
+  }
+
+  // DEFAULT_REASON is derived; assert the full excluded list appears (M1).
+  @Test
+  void defaultReason_should_name_exactly_the_non_default_statuses() {
+    assertThat(VulnStatus.DEFAULT_REASON)
+        .contains("excluding " + String.join(", ", VulnStatus.nonDefaultApiValues()) + ")");
+  }
+
   /** Extract the advertised list from the "statuses: &lt;csv&gt;. Default:" segment. */
-  private static Set<String> advertisedStatuses(String description) {
+  private static List<String> advertisedStatuses(String description) {
     String marker = "statuses: ";
     int start = description.indexOf(marker) + marker.length();
     int end = description.indexOf(". Default:");
     String csv = description.substring(start, end);
-    return Arrays.stream(csv.split(",")).map(String::trim).collect(Collectors.toSet());
+    return Arrays.stream(csv.split(",")).map(String::trim).toList();
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnStatusTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnStatusTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class VulnStatusTest {
+
+  @Test
+  void validApiValues_should_contain_every_status_api_value() {
+    assertThat(VulnStatus.validApiValues())
+        .containsExactlyInAnyOrder(
+            "Reported",
+            "Suspicious",
+            "Confirmed",
+            "NotAProblem",
+            "Remediated",
+            "Fixed",
+            "AutoRemediated");
+  }
+
+  @Test
+  void validApiValues_should_be_unmodifiable() {
+    assertThat(VulnStatus.validApiValues()).isUnmodifiable();
+  }
+
+  @Test
+  void defaultApiValues_should_be_actionable_subset_in_order() {
+    assertThat(VulnStatus.defaultApiValues())
+        .containsExactly("Reported", "Suspicious", "Confirmed");
+  }
+
+  @Test
+  void defaultApiValues_should_exclude_resolved_statuses() {
+    assertThat(VulnStatus.defaultApiValues())
+        .doesNotContain("NotAProblem", "Remediated", "Fixed", "AutoRemediated");
+  }
+
+  @Test
+  void apiValue_should_match_teamserver_casing_for_every_constant() {
+    assertThat(VulnStatus.REPORTED.apiValue()).isEqualTo("Reported");
+    assertThat(VulnStatus.SUSPICIOUS.apiValue()).isEqualTo("Suspicious");
+    assertThat(VulnStatus.CONFIRMED.apiValue()).isEqualTo("Confirmed");
+    assertThat(VulnStatus.NOT_A_PROBLEM.apiValue()).isEqualTo("NotAProblem");
+    assertThat(VulnStatus.REMEDIATED.apiValue()).isEqualTo("Remediated");
+    assertThat(VulnStatus.FIXED.apiValue()).isEqualTo("Fixed");
+    assertThat(VulnStatus.AUTO_REMEDIATED.apiValue()).isEqualTo("AutoRemediated");
+  }
+
+  /**
+   * Anti-drift guard. The {@code @ToolParam} text is hand-written (the annotation requires a
+   * compile-time constant), so this asserts the statuses it advertises are exactly {@link
+   * VulnStatus#validApiValues()} — both directions. This is what closes the drift the bead reported
+   * (validation set advertised 7, tool text advertised 5).
+   */
+  @Test
+  void paramDescription_should_advertise_exactly_the_valid_status_set() {
+    Set<String> advertised = advertisedStatuses(VulnStatus.PARAM_DESCRIPTION);
+
+    assertThat(advertised).containsExactlyInAnyOrderElementsOf(VulnStatus.validApiValues());
+  }
+
+  @Test
+  void paramDescription_should_name_the_default_subset() {
+    String expectedDefault = "Default: " + String.join(",", VulnStatus.defaultApiValues());
+
+    assertThat(VulnStatus.PARAM_DESCRIPTION).contains(expectedDefault);
+  }
+
+  /** Extract the advertised list from the "statuses: &lt;csv&gt;. Default:" segment. */
+  private static Set<String> advertisedStatuses(String description) {
+    String marker = "statuses: ";
+    int start = description.indexOf(marker) + marker.length();
+    int end = description.indexOf(". Default:");
+    String csv = description.substring(start, end);
+    return Arrays.stream(csv.split(",")).map(String::trim).collect(Collectors.toSet());
+  }
+}

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParamsTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrast.labs.ai.mcp.contrast.sdkextension.ExtendedTraceFilterBody;
 import com.contrast.labs.ai.mcp.contrast.tool.validation.UnresolvedMetadataFilter;
+import com.contrast.labs.ai.mcp.contrast.tool.vulnerability.VulnStatus;
 import com.contrastsecurity.http.RuleSeverity;
 import com.contrastsecurity.http.ServerEnvironment;
 import com.contrastsecurity.models.TraceTimestampField;
@@ -103,9 +104,7 @@ class SearchAppVulnerabilitiesParamsTest {
 
     assertThat(params.isValid()).isTrue();
     assertThat(params.getStatuses()).containsExactly("Reported", "Suspicious", "Confirmed");
-    assertThat(params.warnings())
-        .anyMatch(
-            w -> w.contains("actionable") && w.contains("Fixed") && w.contains("AutoRemediated"));
+    assertThat(params.warnings()).contains(VulnStatus.DEFAULT_REASON);
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParamsTest.java
@@ -103,7 +103,9 @@ class SearchAppVulnerabilitiesParamsTest {
 
     assertThat(params.isValid()).isTrue();
     assertThat(params.getStatuses()).containsExactly("Reported", "Suspicious", "Confirmed");
-    assertThat(params.warnings()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+    assertThat(params.warnings())
+        .anyMatch(
+            w -> w.contains("actionable") && w.contains("Fixed") && w.contains("AutoRemediated"));
   }
 
   @Test
@@ -114,6 +116,29 @@ class SearchAppVulnerabilitiesParamsTest {
 
     assertThat(params.isValid()).isTrue();
     assertThat(params.getStatuses()).containsExactly("Reported", "Fixed");
+  }
+
+  @Test
+  void of_should_accept_widened_statuses_and_reach_filter_body() {
+    // NotAProblem and AutoRemediated were valid TeamServer filter values but previously
+    // undocumented in the tool contract (AIML-1158). Prove they validate and reach the body.
+    var params =
+        SearchAppVulnerabilitiesParams.of(
+            VALID_APP_ID,
+            null,
+            "NotAProblem,AutoRemediated",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    assertThat(params.isValid()).isTrue();
+    assertThat(params.getStatuses()).containsExactly("NotAProblem", "AutoRemediated");
+    assertThat(params.toTraceFilterBody().getStatus())
+        .containsExactlyInAnyOrder("NotAProblem", "AutoRemediated");
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParamsTest.java
@@ -79,7 +79,9 @@ class VulnerabilityFilterParamsTest {
 
     assertThat(params.isValid()).isTrue();
     assertThat(params.getStatuses()).containsExactly("Reported", "Suspicious", "Confirmed");
-    assertThat(params.warnings()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+    assertThat(params.warnings())
+        .anyMatch(
+            w -> w.contains("actionable") && w.contains("Fixed") && w.contains("AutoRemediated"));
   }
 
   @Test
@@ -91,6 +93,20 @@ class VulnerabilityFilterParamsTest {
     assertThat(params.isValid()).isTrue();
     // Should normalize to canonical form
     assertThat(params.getStatuses()).containsExactly("Reported", "Confirmed", "Fixed");
+  }
+
+  @Test
+  void of_should_accept_widened_statuses_and_reach_filter_body() {
+    // NotAProblem and AutoRemediated were valid TeamServer filter values but previously
+    // undocumented in the tool contract (AIML-1158). Prove they validate and reach the body.
+    var params =
+        VulnerabilityFilterParams.of(
+            null, "NotAProblem,AutoRemediated", null, null, null, null, null);
+
+    assertThat(params.isValid()).isTrue();
+    assertThat(params.getStatuses()).containsExactly("NotAProblem", "AutoRemediated");
+    assertThat(params.toTraceFilterBody().getStatus())
+        .containsExactlyInAnyOrder("NotAProblem", "AutoRemediated");
   }
 
   // -- Environment tests --

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParamsTest.java
@@ -18,6 +18,7 @@ package com.contrast.labs.ai.mcp.contrast.tool.vulnerability.params;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrast.labs.ai.mcp.contrast.sdkextension.ExtendedTraceFilterBody;
+import com.contrast.labs.ai.mcp.contrast.tool.vulnerability.VulnStatus;
 import com.contrastsecurity.http.RuleSeverity;
 import com.contrastsecurity.http.ServerEnvironment;
 import com.contrastsecurity.models.TraceTimestampField;
@@ -79,9 +80,7 @@ class VulnerabilityFilterParamsTest {
 
     assertThat(params.isValid()).isTrue();
     assertThat(params.getStatuses()).containsExactly("Reported", "Suspicious", "Confirmed");
-    assertThat(params.warnings())
-        .anyMatch(
-            w -> w.contains("actionable") && w.contains("Fixed") && w.contains("AutoRemediated"));
+    assertThat(params.warnings()).contains(VulnStatus.DEFAULT_REASON);
   }
 
   @Test

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesLocalParityTest.java
@@ -155,7 +155,8 @@ class SearchAppVulnerabilitiesLocalParityTest {
             APP_ID, 1, 10, null, null, null, null, null, null, null, null, null);
 
     assertThat(result.isSuccess()).isTrue();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+    assertThat(result.warnings())
+        .anyMatch(w -> w.contains("excluding NotAProblem, Remediated, Fixed, AutoRemediated"));
   }
 
   @Test
@@ -178,7 +179,8 @@ class SearchAppVulnerabilitiesLocalParityTest {
         .containsExactly(
             "Access denied or resource not found. Verify credentials and that the resource ID is"
                 + " correct.");
-    assertThat(result.warnings()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+    assertThat(result.warnings())
+        .anyMatch(w -> w.contains("excluding NotAProblem, Remediated, Fixed, AutoRemediated"));
   }
 
   @Test

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolIT.java
@@ -891,7 +891,7 @@ public class SearchAppVulnerabilitiesToolIT
     assertThat(response.errors()).as("default-filter query must not produce errors").isEmpty();
     assertThat(response.warnings())
         .as("must surface the default-status warning identifying which statuses were excluded")
-        .anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+        .anyMatch(w -> w.contains("excluding NotAProblem, Remediated, Fixed, AutoRemediated"));
 
     // Universal-quantifier check: any returned row must NOT have a terminal status. Vacuously
     // true on empty (when the seeded app has only Fixed/Remediated vulns), but the warning

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesLocalParityTest.java
@@ -121,7 +121,8 @@ class SearchVulnerabilitiesLocalParityTest {
     var result = tool.searchVulnerabilities(1, 10, null, null, null, null, null, null, null);
 
     assertThat(result.isSuccess()).isTrue();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+    assertThat(result.warnings())
+        .anyMatch(w -> w.contains("excluding NotAProblem, Remediated, Fixed, AutoRemediated"));
   }
 
   @Test

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolIT.java
@@ -439,7 +439,7 @@ public class SearchVulnerabilitiesToolIT
     assertThat(response.isSuccess()).as("default-filter query must succeed").isTrue();
     assertThat(response.warnings())
         .as("must surface the default-status warning")
-        .anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+        .anyMatch(w -> w.contains("excluding NotAProblem, Remediated, Fixed, AutoRemediated"));
 
     if (response.items().isEmpty()) {
       // With the default filter applied, an empty result set is plausible only on orgs

--- a/manual-tests/search-vulnerabilities-manual-test.md
+++ b/manual-tests/search-vulnerabilities-manual-test.md
@@ -10,7 +10,7 @@ The `search_vulnerabilities` tool is an **organization-level** search that queri
 **Supported parameters:**
 - `page`, `pageSize` - Pagination
 - `severities` - CRITICAL, HIGH, MEDIUM, LOW, NOTE
-- `statuses` - Reported, Suspicious, Confirmed, Remediated, Fixed
+- `statuses` - Reported, Suspicious, Confirmed, NotAProblem, Remediated, Fixed, AutoRemediated
 - `vulnTypes` - sql-injection, cmd-injection, path-traversal, etc.
 - `environments` - DEVELOPMENT, QA, PRODUCTION
 - `lastSeenAfter`, `lastSeenBefore` - Date filters
@@ -171,15 +171,15 @@ use contrast mcp to search for vulnerabilities across the organization with stat
 
 ---
 
-### Test 11: Include Fixed and Remediated statuses
-**Purpose:** Verify that Fixed and Remediated statuses can be explicitly included.
+### Test 11: Include all statuses
+**Purpose:** Verify that all non-default statuses can be explicitly included.
 
 **Prompt:**
 ```
-use contrast mcp to search for vulnerabilities across the organization with status Reported, Suspicious, Confirmed, Remediated, or Fixed
+use contrast mcp to search for vulnerabilities across the organization with status Reported, Suspicious, Confirmed, NotAProblem, Remediated, Fixed, or AutoRemediated
 ```
 
-**Expected Result:** All vulnerabilities regardless of status (no warning about excluding Fixed/Remediated)
+**Expected Result:** All vulnerabilities regardless of status (no warning about excluding NotAProblem, Remediated, Fixed, AutoRemediated)
 
 ---
 
@@ -543,7 +543,7 @@ use contrast mcp to search for vulnerabilities across the organization with seve
 use contrast mcp to search for all vulnerabilities across the organization
 ```
 
-**Expected Result:** Many vulnerabilities returned (~9947) with warning about excluding Fixed/Remediated
+**Expected Result:** Many vulnerabilities returned (~9947) with warning about excluding NotAProblem, Remediated, Fixed, AutoRemediated
 - Default statuses: Reported, Suspicious, Confirmed
 
 ---

--- a/test-plans/test-plan-search_app_vulnerabilities.md
+++ b/test-plans/test-plan-search_app_vulnerabilities.md
@@ -25,7 +25,7 @@ The new tool adds:
 | `page` | Integer | No | 1 | Page number (1-based) |
 | `pageSize` | Integer | No | 50 | Items per page (max 100) |
 | `severities` | String | No | null | Comma-separated: CRITICAL,HIGH,MEDIUM,LOW,NOTE |
-| `statuses` | String | No | smart defaults | Comma-separated: Reported,Suspicious,Confirmed,Remediated,Fixed |
+| `statuses` | String | No | smart defaults | Comma-separated: Reported,Suspicious,Confirmed,NotAProblem,Remediated,Fixed,AutoRemediated |
 | `vulnTypes` | String | No | null | Comma-separated vulnerability types |
 | `environments` | String | No | null | Comma-separated: DEVELOPMENT,QA,PRODUCTION |
 | `lastSeenAfter` | String | No | null | ISO date or epoch timestamp |
@@ -54,7 +54,7 @@ VulnLight {
     String type,                  // Vulnerability type
     String vulnID,                // Unique identifier (UUID)
     String severity,              // CRITICAL, HIGH, MEDIUM, LOW, NOTE
-    String status,                // Reported, Suspicious, Confirmed, Remediated, Fixed
+    String status,                // Reported, Suspicious, Confirmed, NotAProblem, Remediated, Fixed, AutoRemediated
     List<SessionMetadata> sessionMetadata,  // Session context
     String lastSeenAt,            // ISO-8601 timestamp
     String firstSeenAt,           // ISO-8601 timestamp (nullable)

--- a/test-plans/test-plan-search_vulnerabilities.md
+++ b/test-plans/test-plan-search_vulnerabilities.md
@@ -19,7 +19,7 @@ This test plan provides comprehensive testing guidance for the `search_vulnerabi
 | `page` | Integer | No | 1 | Page number (1-based) |
 | `pageSize` | Integer | No | 50 | Items per page (max 100) |
 | `severities` | String | No | null | Comma-separated: CRITICAL,HIGH,MEDIUM,LOW,NOTE |
-| `statuses` | String | No | smart defaults | Comma-separated: Reported,Suspicious,Confirmed,Remediated,Fixed |
+| `statuses` | String | No | smart defaults | Comma-separated: Reported,Suspicious,Confirmed,NotAProblem,Remediated,Fixed,AutoRemediated |
 | `vulnTypes` | String | No | null | Comma-separated vulnerability types (e.g., sql-injection,xss-reflected) |
 | `environments` | String | No | null | Comma-separated: DEVELOPMENT,QA,PRODUCTION |
 | `lastSeenAfter` | String | No | null | ISO date (YYYY-MM-DD) or epoch timestamp |
@@ -49,7 +49,7 @@ VulnLight {
     String appName,               // Application display name
     List<SessionMetadata> sessionMetadata,  // Session context
     String lastSeenAt,            // ISO-8601 timestamp
-    String status,                // Reported, Suspicious, Confirmed, Remediated, Fixed
+    String status,                // Reported, Suspicious, Confirmed, NotAProblem, Remediated, Fixed, AutoRemediated
     String firstSeenAt,           // ISO-8601 timestamp (nullable)
     String closedAt,              // ISO-8601 timestamp (nullable)
     List<String> environments,    // Historical environments (DEVELOPMENT, QA, PRODUCTION)
@@ -61,7 +61,7 @@ VulnLight {
 
 | Behavior | Description |
 |----------|-------------|
-| **Smart Defaults** | When `statuses` is omitted, uses Reported,Suspicious,Confirmed (excludes Fixed,Remediated) |
+| **Smart Defaults** | When `statuses` is omitted, uses Reported,Suspicious,Confirmed (excludes NotAProblem,Remediated,Fixed,AutoRemediated) |
 | **Date Filtering** | Filters on `lastTimeSeen`, NOT discovery date |
 | **Severity Validation** | Invalid severities cause HARD FAILURE (error, no results) |
 | **Status Validation** | Invalid statuses cause HARD FAILURE (error, no results) |
@@ -281,8 +281,10 @@ VulnLight {
 1. Call with `statuses="Reported"`
 2. Call with `statuses="Suspicious"`
 3. Call with `statuses="Confirmed"`
-4. Call with `statuses="Remediated"`
-5. Call with `statuses="Fixed"`
+4. Call with `statuses="NotAProblem"`
+5. Call with `statuses="Remediated"`
+6. Call with `statuses="Fixed"`
+7. Call with `statuses="AutoRemediated"`
 
 **Expected Results:**
 - Returns only vulnerabilities matching the specified status
@@ -316,8 +318,8 @@ VulnLight {
 
 **Expected Results:**
 - Uses smart defaults: Reported, Suspicious, Confirmed
-- **Excludes** Fixed and Remediated
-- Warning in `message`: "Showing actionable vulnerabilities only (excluding Fixed and Remediated)..."
+- **Excludes** NotAProblem, Remediated, Fixed, and AutoRemediated
+- Warning in `message`: "Showing actionable vulnerabilities only (excluding NotAProblem, Remediated, Fixed, AutoRemediated). To see all statuses, specify statuses parameter explicitly."
 - Only actionable vulnerabilities returned
 
 ---
@@ -339,19 +341,21 @@ VulnLight {
 
 ---
 
-### Test Case 3.5: Explicitly Include Fixed/Remediated
+### Test Case 3.5: Explicitly Include Non-Default Statuses
 
-**Objective:** Verify Fixed/Remediated can be explicitly included.
+**Objective:** Verify non-default statuses can be explicitly included.
 
 **Test Steps:**
-1. Call with `statuses="Remediated"`
-2. Call with `statuses="Fixed"`
-3. Call with `statuses="Reported,Suspicious,Confirmed,Remediated,Fixed"`
+1. Call with `statuses="NotAProblem"`
+2. Call with `statuses="Remediated"`
+3. Call with `statuses="Fixed"`
+4. Call with `statuses="AutoRemediated"`
+5. Call with `statuses="Reported,Suspicious,Confirmed,NotAProblem,Remediated,Fixed,AutoRemediated"`
 
 **Expected Results:**
 - Returns vulnerabilities in specified statuses
 - No smart defaults warning (explicit filter provided)
-- Fixed/Remediated vulnerabilities included
+- NotAProblem/Remediated/Fixed/AutoRemediated vulnerabilities included
 
 ---
 
@@ -869,7 +873,7 @@ VulnLight {
   - `severity`: one of CRITICAL, HIGH, MEDIUM, LOW, NOTE
   - `appID`: string (UUID format)
   - `appName`: string (application name)
-  - `status`: one of Reported, Suspicious, Confirmed, Remediated, Fixed
+  - `status`: one of Reported, Suspicious, Confirmed, NotAProblem, Remediated, Fixed, AutoRemediated
   - `sessionMetadata`: array (may be empty)
   - `lastSeenAt`: ISO timestamp
   - `firstSeenAt`: ISO timestamp or null


### PR DESCRIPTION
## What & why

The vulnerability **status** vocabulary was stringly-typed and split across three
places that had already drifted apart:

- `ValidationConstants.VALID_VULN_STATUSES` accepted **7** values (including
  `NotAProblem` and `AutoRemediated`)
- the `@ToolParam` the agent actually reads advertised only **5**
- the param javadoc listed **7**

An agent building a query from the advertised set silently **under-filtered** —
a live defect in the tool contract, which is the product's real compatibility
surface (AIML-1158).

## Change

Give the vocabulary a single typed owner: a new core-owned **`VulnStatus`** enum.
Each constant carries its exact TeamServer API value, and the type owns:

- `validApiValues()` — the allowed set for validation
- `defaultApiValues()` — the actionable default subset (`Reported, Suspicious, Confirmed`)
- `PARAM_DESCRIPTION` — the model-facing `@ToolParam` text
- `DEFAULT_REASON` — the warning surfaced when the default subset is applied

Both `SearchVulnerabilitiesTool` and `SearchAppVulnerabilitiesTool` now render
their status description from `VulnStatus.PARAM_DESCRIPTION`; both params classes
validate and default from `VulnStatus`. `ValidationConstants.VALID_VULN_STATUSES`
and `DEFAULT_VULN_STATUSES` are removed.

## Contract decision: widened to all 7 statuses

The design flagged one thing to confirm against the product: does the TeamServer
trace-filter API actually accept `NotAProblem` and `AutoRemediated` as filter
inputs? Confirmed yes:

- a live `search_vulnerabilities` call with `statuses=NotAProblem,AutoRemediated`
  returned `success` with results and no errors
- `platform-public-api` `V4VulnerabilityStatus` maps both values; Contrast PS
  scripts filter `/orgtraces/filter` on them

So the enum advertises the full 7-value set rather than narrowing.

## Tests

- **`VulnStatusTest`** — including an **anti-drift guard** asserting the statuses
  advertised in `PARAM_DESCRIPTION` equal `validApiValues()` exactly (both
  directions). This closes the loop that allowed the original 5-vs-7 drift.
- New param-level tests proving `NotAProblem`/`AutoRemediated` validate and reach
  the filter body's status set.
- Updated the affected default-warning assertions across the parity/IT tests to
  the accurate widened reason text.

## Verification

- `make check-test` — green (875 unit tests, static analysis clean)
- `make verify` — all unit tests and **all 4 vulnerability integration test
  classes pass** (Get/ListTypes/SearchApp/Search). Two unrelated IT failures are
  environmental and pre-existing, not regressions from this change:
  - `ListApplicationLibrariesToolIT` — transient **503 first byte timeout** from
    the Contrast API (library tool)
  - `SearchServersToolIT#searchServers_should_filter_by_tag` — missing seeded
    server-tag data in the test org (server tool)

## Out of scope

Severity and environment typing is deliberately deferred (it touches the SDK
request-body boundary and needs its own design decision). See the bead design
field for the follow-up outline.

Closes AIML-1158 · bead mcp-3rt4
