### PR TITLE
AIML-501 Add JaCoCo code coverage with enforced floors and CI gating

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,5 +29,21 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
         cache: gradle
-    - name: Run checks, tests, and build
-      run: ./gradlew spotlessCheck checkstyleMain checkstyleTest test :contrast-mcp-stdio-app:bootJar --no-daemon
+    - name: Run checks, tests, coverage, and build
+      run: ./gradlew spotlessCheck checkstyleMain checkstyleTest test jacocoTestCoverageVerification :contrast-mcp-stdio-app:bootJar --no-daemon
+
+    # Runs even when the coverage floor fails, since that is exactly when the
+    # numbers and the HTML report are needed to diagnose the failure.
+    - name: Publish coverage summary
+      if: always()
+      run: ./gradlew --quiet coverageSummary --no-daemon >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Upload coverage reports
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: jacoco-coverage-reports
+        path: |
+          **/build/reports/jacoco/test/html/**
+          **/build/reports/jacoco/test/jacocoTestReport.xml
+        if-no-files-found: warn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,9 @@ jobs:
       run: ./gradlew spotlessCheck checkstyleMain checkstyleTest test jacocoTestCoverageVerification :contrast-mcp-stdio-app:bootJar --no-daemon
 
     # Runs even when the coverage floor fails, since that is exactly when the
-    # numbers and the HTML report are needed to diagnose the failure.
+    # numbers and the HTML report are needed to diagnose the failure. coverageSummary
+    # only reads the reports the step above wrote, so this does not re-run the tests;
+    # if that step failed before producing them, the table says so per module.
     - name: Publish coverage summary
       if: always()
       run: ./gradlew --quiet coverageSummary --no-daemon >> "$GITHUB_STEP_SUMMARY"
@@ -47,3 +49,5 @@ jobs:
           **/build/reports/jacoco/test/html/**
           **/build/reports/jacoco/test/jacocoTestReport.xml
         if-no-files-found: warn
+        # Diagnostic output for a failed run, not a durable artifact.
+        retention-days: 7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,11 +70,15 @@ This repository uses the Gradle wrapper and Java 21. Do not use Maven commands o
 **Common commands:**
 ```bash
 ./gradlew spotlessCheck checkstyleMain checkstyleTest test
+./gradlew jacocoTestCoverageVerification coverageSummary
 ./gradlew :contrast-mcp-stdio-app:bootJar
 ./gradlew :contrast-mcp-core:publishToMavenLocal :contrast-mcp-core:verifyCorePublicationMetadata
+make coverage
 make check-test
 make verify
 ```
+
+**Coverage floors:** JaCoCo measures coverage on every `test` run. Per-module floors live in `ext.coverageMinimums` in the root `build.gradle` and are enforced by `jacocoTestCoverageVerification`, which `check` and `make check-test` both run, so a coverage regression fails the build. Raise a floor as coverage improves. Never lower one to make a build pass, and treat additions to `coverageExcludedClassFiles` like a checkstyle suppression.
 
 **Module split:**
 - `contrast-mcp-core` is the transport-neutral shared library published as `com.contrast.labs.ai.mcp:contrast-mcp-core`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,8 @@ Use these make targets for all checks and tests:
 ```bash
 make check       # Auto-format then run static analysis (no need to run make format first)
 make test        # Run unit tests (quiet output)
-make check-test  # Run static analysis and unit tests
+make coverage    # Verify JaCoCo coverage floors and print the summary
+make check-test  # Run static analysis, unit tests, and coverage
 make verify      # Run all tests including integration
 make format      # Auto-format code with Spotless (also runs automatically via make check)
 make build       # Build the project
@@ -54,11 +55,14 @@ make check VERBOSE=1
 - **Test (unit)**: `./gradlew test`
 - **Test (all)**: `source .env.integration-test && ./gradlew test :contrast-mcp-stdio-app:integrationTest`
 - **Static analysis**: `./gradlew spotlessCheck checkstyleMain checkstyleTest`
+- **Coverage**: `./gradlew jacocoTestCoverageVerification coverageSummary`
 - **Core publication metadata**: `./gradlew :contrast-mcp-core:verifyCorePublicationMetadata`
 - **Format code**: `./gradlew spotlessApply`
 - **Run locally**: `java -jar contrast-mcp-stdio-app/build/libs/mcp-contrast-*.jar --CONTRAST_HOST_NAME=<host> --CONTRAST_API_KEY=<key> --CONTRAST_SERVICE_KEY=<key> --CONTRAST_USERNAME=<user> --CONTRAST_ORG_ID=<org>`
 
-**Note:** `make check` auto-formats before checking — no separate `make format` step needed. `make check-test` is the standard local verification command for static analysis and unit tests.
+**Note:** `make check` auto-formats before checking — no separate `make format` step needed. `make check-test` is the standard local verification command for static analysis, unit tests, and coverage.
+
+**Coverage floors:** Per-module minimums live in `ext.coverageMinimums` in the root `build.gradle` and are enforced by `jacocoTestCoverageVerification`, which `check` depends on. Raise a floor as coverage improves; never lower one to make a build pass. `McpContrastApplication` is the only class excluded.
 
 **Integration Tests:** Require Contrast credentials in `.env.integration-test` (copy from `.env.integration-test.template`). See INTEGRATION_TESTS.md for details. Integration tests are intentionally skipped when credentials are not available (e.g., in CI forks or local builds without `.env.integration-test`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ make clean       # Clean build artifacts
 # Verbose output when debugging failures
 make test VERBOSE=1
 make check VERBOSE=1
+make coverage VERBOSE=1
 ```
 
 **After a compilation failure**, stale `.class` files may remain and cause confusing follow-up failures. Always run `make clean && make test` to recover before continuing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,12 @@ make verify
 
 Checkstyle rules and suppressions are the same rules used before the Gradle split. Gradle binds `checkstyle.xml` and `checkstyle-suppressions.xml` to each module, and rules remain `error` severity.
 
+## Test Coverage
+
+JaCoCo measures coverage on every `test` run and writes HTML and XML reports to `<module>/build/reports/jacoco/test/`. `make coverage` verifies the floors and prints a summary, and `make check-test` includes it.
+
+Per-module floors live in `ext.coverageMinimums` in the root `build.gradle` and are enforced by `jacocoTestCoverageVerification`, which `check` depends on. They are set just below the measured baseline so they block regression rather than blocking adoption. Raise a floor as coverage improves. Never lower one to make a build pass. CI runs the same verification and uploads the reports as a build artifact.
+
 ## Consuming `contrast-mcp-core` Locally
 
 Downstream projects can validate unpublished shared-code changes by using a Gradle composite build that substitutes the published `contrast-mcp-core` artifact with a local checkout:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GRADLE ?= ./gradlew
 
-.PHONY: help build test test-verbose check check-verbose check-test format clean verify verify-verbose
+.PHONY: help build test test-verbose check check-verbose check-test coverage format clean verify verify-verbose
 
 help: ## Display available make targets
 	@awk 'BEGIN {FS=":.*##"; printf "\nUsage: make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_\-]+:.*##/ {printf "  %-12s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -63,11 +63,19 @@ verify-quiet:
 verify-verbose: ## Run all tests with verbose output
 	@VERBOSE=1 $(MAKE) verify
 
+## Coverage targets
+
+coverage: ## Verify coverage floors and print the summary
+	@. ./hack/run_silent.sh && print_main_header "Checking Coverage"
+	@. ./hack/run_silent.sh && run_with_quiet "Coverage floors met" "$(GRADLE) jacocoTestCoverageVerification"
+	@$(GRADLE) --quiet coverageSummary
+
 ## Combined targets
 
-check-test: ## Run all checks and tests
+check-test: ## Run all checks, tests, and coverage
 	@$(MAKE) check
 	@$(MAKE) test
+	@$(MAKE) coverage
 
 ## Other targets
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GRADLE ?= ./gradlew
 
-.PHONY: help build test test-verbose check check-verbose check-test coverage format clean verify verify-verbose
+.PHONY: help build test test-verbose check check-verbose check-test coverage coverage-verbose format clean verify verify-verbose
 
 help: ## Display available make targets
 	@awk 'BEGIN {FS=":.*##"; printf "\nUsage: make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_\-]+:.*##/ {printf "  %-12s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -66,9 +66,25 @@ verify-verbose: ## Run all tests with verbose output
 ## Coverage targets
 
 coverage: ## Verify coverage floors and print the summary
+	@if [ -n "$$VERBOSE" ]; then \
+		$(GRADLE) --continue jacocoTestCoverageVerification coverageSummary; \
+	else \
+		$(MAKE) coverage-quiet; \
+	fi
+
+# The summary runs after verification and regardless of its result, because a breached
+# floor is exactly when the numbers are wanted. The verification exit code is held and
+# re-raised at the end so a failure still fails the target.
+coverage-quiet:
 	@. ./hack/run_silent.sh && print_main_header "Checking Coverage"
-	@. ./hack/run_silent.sh && run_with_quiet "Coverage floors met" "$(GRADLE) jacocoTestCoverageVerification"
-	@$(GRADLE) --quiet coverageSummary
+	@. ./hack/run_silent.sh && print_header "mcp-contrast" "Coverage floors"
+	@status=0; \
+	. ./hack/run_silent.sh && run_with_quiet "Coverage floors met" "$(GRADLE) jacocoTestCoverageVerification" || status=$$?; \
+	$(GRADLE) --quiet coverageSummary; \
+	exit $$status
+
+coverage-verbose: ## Run coverage with verbose output
+	@VERBOSE=1 $(MAKE) coverage
 
 ## Combined targets
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -85,6 +85,8 @@ test -f contrast-mcp-stdio-app/build/libs/mcp-contrast-X.Y.Z.jar
 
 Then create a GitHub release for the tag and attach `contrast-mcp-stdio-app/build/libs/mcp-contrast-X.Y.Z.jar`. Note that these manual instructions do not publish to Artifactory, sign the Docker image, generate SBOMs, or create attestations. Use the workflow whenever possible.
 
+**Coverage gate:** `check` runs `jacocoTestCoverageVerification`, so a release aborts if either module falls below its floor in `ext.coverageMinimums`. Because releases only run from `main`, and the same task and floors already gated the commit in `build.yml`, this should not fire in practice. If it does, run `make coverage` locally for the per-module numbers, or read the `jacoco-coverage-reports` artifact from that commit's build run.
+
 ## Verify the Release
 
 This checklist describes an automated workflow release. For a manual recovery release, verify only the outputs you explicitly reproduced and document any omitted publication, SBOM, or attestation assets in the release notes.

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,22 @@ allprojects {
     version = rootProject.version
 }
 
+// Enforced per-module coverage floors, set just below the measured baseline so they
+// block regression without failing on adoption. Raise them as coverage improves;
+// never lower one to make a build pass. Baseline measured 2026-07-26 under AIML-501:
+// core LINE 92.2% BRANCH 82.5%, stdio-app LINE 75.3% BRANCH 69.2% (post-exclusion).
+ext.coverageMinimums = [
+    'contrast-mcp-core'     : [line: 0.90, branch: 0.80],
+    'contrast-mcp-stdio-app': [line: 0.72, branch: 0.65],
+]
+
+// Spring Boot bootstrap: main() plus bean wiring, exercised at runtime rather than
+// by unit tests. Excluded from both the report and the enforced floor so it does not
+// distort them. Keep this list minimal — everything else stays measured.
+ext.coverageExcludedClassFiles = [
+    'com/contrast/labs/ai/mcp/contrast/McpContrastApplication.class',
+]
+
 ext.positiveIntProperty = { String propertyName, int defaultValue ->
     def rawValue = providers.gradleProperty(propertyName).orElse(defaultValue.toString()).get()
     try {
@@ -39,6 +55,7 @@ subprojects {
     apply plugin: 'java-library'
     apply plugin: 'checkstyle'
     apply plugin: 'com.diffplug.spotless'
+    apply plugin: 'jacoco'
 
     java {
         toolchain {
@@ -61,6 +78,61 @@ subprojects {
         systemProperty 'junit.jupiter.execution.parallel.mode.classes.default', 'concurrent'
         systemProperty 'junit.jupiter.execution.parallel.config.strategy', 'dynamic'
         systemProperty 'junit.jupiter.execution.parallel.config.dynamic.factor', '1'
+    }
+
+    jacoco {
+        toolVersion = jacocoVersion
+    }
+
+    tasks.named('test') {
+        finalizedBy tasks.named('jacocoTestReport')
+    }
+
+    // Applied to the report and the enforced floor alike so both describe the same
+    // set of classes. A BUNDLE-level violation rule measures whatever is in
+    // classDirectories, so filtering here is what actually drops the exclusions.
+    def coverageClassDirs = sourceSets.main.output.classesDirs.asFileTree.matching {
+        exclude rootProject.ext.coverageExcludedClassFiles
+    }
+
+    tasks.named('jacocoTestReport') {
+        dependsOn tasks.named('test')
+        reports {
+            // Gradle enables HTML but not XML. XML is what CI and any external
+            // coverage tooling reads, so both are required here.
+            xml.required = true
+            html.required = true
+        }
+        classDirectories.setFrom(coverageClassDirs)
+    }
+
+    tasks.named('jacocoTestCoverageVerification') {
+        dependsOn tasks.named('jacocoTestReport')
+        def minimums = rootProject.ext.coverageMinimums[project.name]
+        if (minimums == null) {
+            throw new GradleException(
+                "No coverage minimums declared for ${project.name}. Add an entry to coverageMinimums in the root build.gradle.")
+        }
+        classDirectories.setFrom(coverageClassDirs)
+        violationRules {
+            rule {
+                element = 'BUNDLE'
+                limit {
+                    counter = 'LINE'
+                    value = 'COVEREDRATIO'
+                    minimum = minimums.line
+                }
+                limit {
+                    counter = 'BRANCH'
+                    value = 'COVEREDRATIO'
+                    minimum = minimums.branch
+                }
+            }
+        }
+    }
+
+    tasks.named('check') {
+        dependsOn tasks.named('jacocoTestCoverageVerification')
     }
 
     spotless {
@@ -102,6 +174,65 @@ subprojects {
         testImplementation 'org.junit.jupiter:junit-jupiter'
         testImplementation "org.assertj:assertj-core:${assertjVersion}"
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    }
+}
+
+tasks.register('coverageSummary') {
+    group = 'verification'
+    description = 'Prints per-module JaCoCo coverage against the enforced floors.'
+    dependsOn subprojects.collect { ":${it.name}:jacocoTestReport" }
+
+    def reports = subprojects.collectEntries {
+        [(it.name): it.layout.buildDirectory.file('reports/jacoco/test/jacocoTestReport.xml')]
+    }
+    def minimums = rootProject.ext.coverageMinimums
+
+    doLast {
+        // JaCoCo's XML declares a DOCTYPE, which XmlSlurper rejects by default. Allow the
+        // declaration but keep every entity and DTD fetch switched off, so the parser never
+        // resolves anything external. Input here is our own build output, not user data.
+        def parser = new XmlSlurper()
+        parser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false)
+        parser.setFeature('http://apache.org/xml/features/nonvalidating/load-external-dtd', false)
+        parser.setFeature('http://xml.org/sax/features/external-general-entities', false)
+        parser.setFeature('http://xml.org/sax/features/external-parameter-entities', false)
+        parser.setFeature('http://xml.org/sax/features/validation', false)
+
+        // Emitted as a Markdown table so the same output is readable in a terminal and
+        // renders as a table when CI appends it to GITHUB_STEP_SUMMARY.
+        println ''
+        println '### Coverage'
+        println ''
+        println '| module | line | branch |'
+        println '| --- | --- | --- |'
+
+        reports.each { moduleName, reportFile ->
+            def file = reportFile.get().asFile
+            if (!file.exists()) {
+                println "| ${moduleName} | no report found | no report found |"
+                return
+            }
+            def root = parser.parse(file)
+            def ratio = { String counter ->
+                def node = root.counter.find { it.@type == counter }
+                if (!node || node.isEmpty()) {
+                    return null
+                }
+                def missed = node.@missed.toInteger()
+                def covered = node.@covered.toInteger()
+                (missed + covered) == 0 ? null : covered / (missed + covered)
+            }
+            def cell = { BigDecimal actual, BigDecimal floor ->
+                actual == null
+                    ? 'n/a'
+                    : String.format('%.1f%% (floor %.0f%%)', actual * 100, floor * 100)
+            }
+            def floors = minimums[moduleName]
+            println "| ${moduleName} " +
+                "| ${cell(ratio('LINE') as BigDecimal, floors.line as BigDecimal)} " +
+                "| ${cell(ratio('BRANCH') as BigDecimal, floors.branch as BigDecimal)} |"
+        }
+        println ''
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,11 +31,18 @@ ext.coverageMinimums = [
     'contrast-mcp-stdio-app': [line: 0.72, branch: 0.65],
 ]
 
-// Spring Boot bootstrap: main() plus bean wiring, exercised at runtime rather than
-// by unit tests. Excluded from both the report and the enforced floor so it does not
-// distort them. Keep this list minimal — everything else stays measured.
+// Spring Boot bootstrap: main() plus bean wiring, whose behaviour belongs to container
+// startup rather than to unit tests. Excluded from both the report and the enforced floor
+// so it does not distort them. The class is partially covered today by
+// McpContrastApplicationToolRegistrationTest, so this is a statement about what the floor
+// should hold us to, not a claim that unit tests never reach it.
+// Excluding a class lowers the effective gate, so treat additions here like a checkstyle
+// suppression and get them reviewed. Keep this list minimal — everything else stays measured.
 ext.coverageExcludedClassFiles = [
     'com/contrast/labs/ai/mcp/contrast/McpContrastApplication.class',
+    // Inner and anonymous classes compile to their own class files. Without this they
+    // would stay measured while the outer class is excluded. No such classes exist today.
+    'com/contrast/labs/ai/mcp/contrast/McpContrastApplication$*.class',
 ]
 
 ext.positiveIntProperty = { String propertyName, int defaultValue ->
@@ -114,6 +121,25 @@ subprojects {
                 "No coverage minimums declared for ${project.name}. Add an entry to coverageMinimums in the root build.gradle.")
         }
         classDirectories.setFrom(coverageClassDirs)
+
+        // Gradle's JacocoReportBase registers onlyIf("Any of the execution data files
+        // exists"), so a module with no .exec file SKIPs verification and the build still
+        // goes green. JaCoCo's Limit.check separately returns no violation when a counter
+        // total is zero, because the ratio is NaN. Either state means the floor below
+        // enforced nothing. Override the skip and assert both preconditions instead, so a
+        // module that declares floors can never pass without actually measuring something.
+        setOnlyIf { true }
+        doFirst {
+            if (executionData.files.every { !it.exists() }) {
+                throw new GradleException(
+                    "No JaCoCo execution data for ${project.name}; coverage was not measured. Run the test task before verifying.")
+            }
+            if (classDirectories.asFileTree.empty) {
+                throw new GradleException(
+                    "No class files to measure for ${project.name}; check coverageExcludedClassFiles in the root build.gradle.")
+            }
+        }
+
         violationRules {
             rule {
                 element = 'BUNDLE'
@@ -180,7 +206,15 @@ subprojects {
 tasks.register('coverageSummary') {
     group = 'verification'
     description = 'Prints per-module JaCoCo coverage against the enforced floors.'
-    dependsOn subprojects.collect { ":${it.name}:jacocoTestReport" }
+
+    // Ordering only, deliberately not dependsOn. As a dependency this drags `test` back
+    // into the graph, and :contrast-mcp-stdio-app:bootBuildInfo rewrites
+    // build-info.properties on every invocation, so the app's test task is never
+    // UP-TO-DATE and the whole suite re-runs just to print a table. This task reads
+    // reports that a previous task or invocation already wrote; when nothing has written
+    // one it says so per module rather than generating it.
+    mustRunAfter subprojects.collect { ":${it.name}:jacocoTestReport" }
+    mustRunAfter subprojects.collect { ":${it.name}:jacocoTestCoverageVerification" }
 
     def reports = subprojects.collectEntries {
         [(it.name): it.layout.buildDirectory.file('reports/jacoco/test/jacocoTestReport.xml')]
@@ -197,6 +231,10 @@ tasks.register('coverageSummary') {
         parser.setFeature('http://xml.org/sax/features/external-general-entities', false)
         parser.setFeature('http://xml.org/sax/features/external-parameter-entities', false)
         parser.setFeature('http://xml.org/sax/features/validation', false)
+        // Permitting the DOCTYPE leaves internal entity expansion in play, so restore the
+        // JAXP limits that bound it. Defence in depth: the input is regenerated build
+        // output, not anything an attacker supplies.
+        parser.setFeature('http://javax.xml.XMLConstants/feature/secure-processing', true)
 
         // Emitted as a Markdown table so the same output is readable in a terminal and
         // renders as a table when CI appends it to GITHUB_STEP_SUMMARY.
@@ -209,7 +247,7 @@ tasks.register('coverageSummary') {
         reports.each { moduleName, reportFile ->
             def file = reportFile.get().asFile
             if (!file.exists()) {
-                println "| ${moduleName} | no report found | no report found |"
+                println "| ${moduleName} | no report — run jacocoTestReport | no report — run jacocoTestReport |"
                 return
             }
             def root = parser.parse(file)
@@ -225,9 +263,16 @@ tasks.register('coverageSummary') {
             def cell = { BigDecimal actual, BigDecimal floor ->
                 actual == null
                     ? 'n/a'
-                    : String.format('%.1f%% (floor %.0f%%)', actual * 100, floor * 100)
+                    : String.format('%.1f%% (floor %.1f%%)', actual * 100, floor * 100)
             }
+            // jacocoTestCoverageVerification throws for an undeclared module, but this task
+            // does not depend on it, so a new subproject reaches here first. Fail with the
+            // same actionable message rather than an NPE on floors.line.
             def floors = minimums[moduleName]
+            if (floors == null) {
+                throw new GradleException(
+                    "No coverage minimums declared for ${moduleName}. Add an entry to coverageMinimums in the root build.gradle.")
+            }
             println "| ${moduleName} " +
                 "| ${cell(ratio('LINE') as BigDecimal, floors.line as BigDecimal)} " +
                 "| ${cell(ratio('BRANCH') as BigDecimal, floors.branch as BigDecimal)} |"

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,5 @@ contrastSdkVersion=3.7.0
 commonsValidatorVersion=1.10.1
 assertjVersion=3.27.7
 checkstyleVersion=13.4.1
+jacocoVersion=0.8.15
 lombokVersion=1.18.38


### PR DESCRIPTION
**Jira:** [AIML-501](https://contrast.atlassian.net/browse/AIML-501)

## Summary
Adds JaCoCo coverage measurement to the Gradle build with per-module floors that are actually enforced, wired into `check`, `make check-test`, and CI.

- The repo measured no coverage at all before this. There was no JaCoCo plugin, no coverage tasks, and nothing in CI.
- Floors are enforced in-repo by `jacocoTestCoverageVerification`, which `check` now depends on, so they cannot be skipped.
- CI gates on coverage, publishes a summary table to the job summary, and uploads the HTML and XML reports as an artifact.

## Why This Change Exists
AIML-501 was filed in February and sat in Backlog. It was written against Maven, naming `pom.xml`, the `prepare-agent` and `report` goal bindings, and `target/site/jacoco`. None of that applies now that the repo is Gradle, so the ticket and its bead were rewritten for Gradle before the work started.

The gap this closes is that nothing measured coverage. A test could be deleted and no build step would notice.

The sibling repo `aiml-services` has coverage, but its in-repo JaCoCo minimum is set to `0.0` and the real 85 percent lives only in an external `@master`-pinned action plus a skippable pre-push hook. AIML-1170 tracks that as a bug. This PR deliberately avoids repeating it.

## Approach
Floors are set per module, just below the measured baseline, so they block regression without failing on adoption.

| module | line | branch | line floor | branch floor |
| --- | --- | --- | --- | --- |
| contrast-mcp-core | 92.2% | 82.5% | 90% | 80% |
| contrast-mcp-stdio-app | 75.3% | 69.2% | 72% | 65% |

Three alternatives were rejected.

A single combined gate at 85 percent was rejected because combined line coverage is already 88.6 percent, so it would pass on day one and enforce nothing, and core's high coverage would mask rot in stdio-app.

The `aiml-services` shared action `Contrast-Security-Inc/common-github-actions/test-coverage@master` cannot be reused. That repo is private under Contrast-Security-Inc and this one is public under Contrast-Security-OSS, so the default `GITHUB_TOKEN` cannot resolve it and fork PRs never could. Enforcement therefore lives in Gradle, which runs everywhere including forks, and the reporting is done with a SHA-pinned `upload-artifact` rather than an unpinned reference.

The `org.barfuin.gradle.jacocolog` plugin that `aiml-services` uses for its console summary was rejected in favour of a 40-line native `coverageSummary` task, to avoid adding a third-party build dependency to a public repo for formatting alone.

## What Changed
### Build configuration
- `gradle.properties` pins `jacocoVersion=0.8.15`, published 2026-06-04 and so past the ENTSEC-1742 seven-day soak window. No inline or dynamic version.
- `build.gradle` applies `jacoco` across `subprojects`, enables XML alongside Gradle's default HTML, makes `test` finalize with `jacocoTestReport`, and configures `jacocoTestCoverageVerification` with the floors above before wiring it into `check`.
- `build.gradle` declares `ext.coverageMinimums` and `ext.coverageExcludedClassFiles` at the root, and fails the build with an actionable message if a module has no declared floor.
- `build.gradle` registers `coverageSummary`, which parses the JaCoCo XML and emits a Markdown table that reads correctly both in a terminal and when appended to the CI job summary.

### CI
- `.github/workflows/build.yml` adds `jacocoTestCoverageVerification` to the existing Gradle line, appends the summary to `GITHUB_STEP_SUMMARY`, and uploads reports via `actions/upload-artifact` pinned to `043fb46` (v7.0.1). Both new steps use `if: always()` so a coverage failure still publishes the evidence needed to diagnose it.

### Developer workflow and docs
- `Makefile` adds a `coverage` target and includes it in `check-test`.
- `CLAUDE.md` and `CONTRIBUTING.md` document the target, the report paths, and the rule that floors get raised as coverage improves and never lowered to make a build pass.

`McpContrastApplication` is the only excluded class, being `main()` plus bean wiring that unit tests do not exercise.

## Testing
`make check-test` passes from clean, with 870 unit tests, 0 failures, static analysis clean, and both modules over their floors.

The gate was mutation-tested rather than assumed. Temporarily raising the stdio-app line floor to `0.99` failed the build with `Rule violated for bundle contrast-mcp-stdio-app: lines covered ratio is 0.75, but expected minimum is 0.99`. This matters because a coverage gate that silently enforces nothing is the exact defect AIML-1170 describes.

`coverageSummary` output was cross-checked against an independent parse of the same XML reports, and the figures agree to the decimal.

The exclusion was verified by class count. stdio-app drops from 12 classes to 11, with line coverage moving 73.9 percent to 75.3 percent, confirming the filter takes effect on both the report and the enforced floor.

`.github/workflows/build.yml` was parsed to confirm valid YAML, and every action in it resolves to a 40-character SHA.

**Honest gap.** There are no automated tests for the build logic itself. The floors and the summary parser are Groovy in `build.gradle`, and testing them properly needs a `buildSrc` module with a GradleRunner harness, which is what `aiml-services` has for its Kotlin equivalent. Both were verified by hand as described above, but that is not a regression test.

## Risks / Rollout / Follow-ups
**`make verify` does not pass on this branch, and it does not pass on `main` either.** Three integration tests fail. To check whether this PR caused them, the entire change was stashed and the tests were re-run against clean `main`, where two fail identically with no JaCoCo present.

- `ListApplicationLibrariesToolIT.listApplicationLibraries_should_populate_version_and_staleness_fields` asserts `monthsOutdated >= 0`, but TeamServer returns -112 for `doctrine/lexer` and -59 for `doctrine/annotations`, both reporting a `latestVersion` older than the installed version. Either a TeamServer data problem or a missing guard in the mapper.
- `SearchServersToolIT.searchServers_should_filter_by_tag` fails on its own seeded-data precondition. The test org is missing a server tag.
- `GetRouteCoverageToolIT` failed once on an HTTP 503 Varnish first-byte timeout and passed on re-run, so it is transient.

These are unrelated to coverage and need their own tickets. The repo rule is no PR until `make verify` passes, so this is flagged rather than glossed over.

Two follow-ups worth tracking separately. The stdio-app floors of 72 and 65 percent are a starting ratchet and should climb, with `SDKHelper` at 43 percent line coverage over 114 lines being the main drag. Separately, this branch began as a spike evaluating the CRAP metric via `crap-java`, which surfaced that `ServersResponseEnvelope` has zero test coverage despite encoding a subtle TeamServer tag-prefilter workaround where a wrong condition silently converts a genuine API failure into an empty result.


[AIML-501]: https://contrast.atlassian.net/browse/AIML-501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ