### PR TITLE
AIML-1245 Auto-approve and auto-merge minor and patch Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,16 @@
 version: 2
+# Deliberately ungrouped. dependabot/fetch-metadata reports a single update-type
+# for a grouped PR, taken from the highest semver change in the group, so one
+# major bump made every minor and patch bump in that group ineligible for the
+# auto-merge workflow. One PR per bump means each is judged on its own change.
+# open-pull-requests-limit is raised past the default of 5 so ungrouping does not
+# throttle a weekly run to five bumps.
 updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
       interval: "weekly"
-    groups:
-      dev-dependencies:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        dependency-type: development
-      production-dependencies:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        dependency-type: production
+    open-pull-requests-limit: 15
     cooldown:
       default-days: 7
 
@@ -22,17 +18,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    groups:
-      dev-dependencies:
-          applies-to: version-updates
-          patterns:
-              - '*'
-          dependency-type: development
-      production-dependencies:
-          applies-to: version-updates
-          patterns:
-              - '*'
-          dependency-type: production
+    open-pull-requests-limit: 10
     cooldown:
       default-days: 7
       include:
@@ -44,9 +30,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    groups:
-      docker-dependencies:
-        patterns:
-          - "*"
     cooldown:
       default-days: 7

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,6 +15,11 @@ name: Dependabot Auto-Approve and Merge
 # to GITHUB_TOKEN does not trigger further workflow runs, which may stop the post-merge
 # wiz-scan firing on an auto-merged bump. Migration is one create-github-app-token step
 # plus swapping the token references below. Tracked in mcp-vc50.
+#
+# The self-modification guard job below has no upstream counterpart, and does not need
+# one: upstream keeps its action pins in common-github-actions, so a consuming repo's
+# Dependabot cannot alter what runs inside the approving job. Vendoring put the pins and
+# the auto-merge in the same repository, which is what creates the loop the guard closes.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -23,9 +28,53 @@ permissions:
   contents: read
 
 jobs:
+  # Dependabot proposes minor and patch bumps to this file's own action pins, and a
+  # pull_request run executes the PR branch's copy of this workflow. Without this gate
+  # the proposed action version would run with the write permissions the auto-merge job
+  # holds and could approve and merge itself. Deciding in a separate read-only job,
+  # ahead of every uses: step, means an untrusted action version never executes at all,
+  # rather than merely not being merged. Needs no checkout.
+  guard:
+    # Both conditions, deliberately. github.actor is whoever triggered this run, so it
+    # blocks a human push to a Dependabot branch; pull_request.user.login is the author.
+    # fetch-metadata validates commits[0] only, so author alone would let the job
+    # approve a branch whose tip is human-authored. Neither check replaces the other.
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      self_modifying: ${{ steps.check.outputs.self_modifying }}
+
+    steps:
+      # Path is spelled out rather than derived, so a rename of this file must update
+      # it here too. gh is preinstalled on the runner, so this needs no action.
+      - name: Check whether the pull request modifies this workflow
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          if gh pr diff --name-only "$PR_URL" \
+            | grep -qx '.github/workflows/dependabot-auto-merge.yml'; then
+            echo "self_modifying=true" >> "$GITHUB_OUTPUT"
+            echo "Modifies the auto-merge workflow itself, needs human review."
+          else
+            echo "self_modifying=false" >> "$GITHUB_OUTPUT"
+          fi
+
   auto-merge:
-    # Dependabot-authored pull requests only. Everything else goes through review.
-    if: github.actor == 'dependabot[bot]'
+    needs: guard
+    # The actor and author checks are repeated from the guard job on purpose. This is
+    # the job that holds write permissions, so it should not depend on needs: guard
+    # surviving a future edit to stay gated.
+    if: >-
+      needs.guard.outputs.self_modifying == 'false' &&
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       # A Dependabot-triggered run gets a read-only GITHUB_TOKEN whatever the repo

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,86 @@
+name: Dependabot Auto-Approve and Merge
+
+# Copied from the shared composite action, then adapted:
+# https://github.com/Contrast-Security-Inc/common-github-actions/tree/master/dependabot-auto-approve-merge
+# Copied at upstream commit fc432693d406c239d46bdac440e0f70b7c2878a8 (ADR-738).
+#
+# Vendored rather than referenced because that repo is internal to the Inc org while
+# this one is public in Contrast-Security-OSS, so it cannot be shared across the org
+# boundary. Changes made here, and why, are recorded in AIML-1245. If the upstream
+# action changes materially, revisit this file rather than assuming they still match.
+#
+# Uses secrets.GITHUB_TOKEN, which needs no provisioning and is enough to approve and
+# to enable auto-merge on this repo. A GitHub App token is the intended end state, for
+# two reasons: upstream is moving off its static PAT onto an App, and a push attributed
+# to GITHUB_TOKEN does not trigger further workflow runs, which may stop the post-merge
+# wiz-scan firing on an auto-merged bump. Migration is one create-github-app-token step
+# plus swapping the token references below. Tracked in mcp-vc50.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  auto-merge:
+    # Dependabot-authored pull requests only. Everything else goes through review.
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      # A Dependabot-triggered run gets a read-only GITHUB_TOKEN whatever the repo
+      # default is, and the permissions key is the only way to raise it. Without
+      # these two, every gh call below fails with 403. Approving also depends on
+      # "Allow GitHub Actions to create and approve pull requests" being enabled.
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      # No checkout step: nothing here reads the working tree, and skipping it
+      # keeps PR-authored code off the runner entirely.
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Fails closed. An unrecognised or empty update-type falls to the default
+      # branch and is left for a human, so a metadata failure cannot auto-merge.
+      - name: Check eligibility
+        id: eligibility
+        env:
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+        run: |
+          case "$UPDATE_TYPE" in
+            version-update:semver-minor|version-update:semver-patch)
+              echo "eligible=true" >> "$GITHUB_OUTPUT"
+              echo "Eligible for auto-merge: ${UPDATE_TYPE:-<none>}"
+              ;;
+            *)
+              echo "eligible=false" >> "$GITHUB_OUTPUT"
+              echo "Not auto-merging ${UPDATE_TYPE:-<none>}, needs human review."
+              ;;
+          esac
+
+      - name: Approve pull request
+        if: steps.eligibility.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr review --approve "$PR_URL"
+
+      # --merge rather than --squash: squash is disabled on this repo and the
+      # "PR Approvals" ruleset restricts allowed_merge_methods to merge and rebase.
+      # --auto defers the merge until the required build check passes, which is the
+      # gate that makes approving from a workflow safe.
+      - name: Enable auto-merge
+        if: steps.eligibility.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
**Jira:** [AIML-1245](https://contrast.atlassian.net/browse/AIML-1245)

## Summary

Dependabot's minor and patch version bumps now approve themselves and merge once CI passes, so routine dependency updates stop needing a human. Dependabot PRs are also ungrouped, which is what makes the automation useful rather than decorative.

- Minor and patch bumps are approved and auto-merged. Majors are left alone.
- `build` must pass before anything merges, so nothing lands with red required CI.
- One PR per bump instead of one PR per group.

## Why This Change Exists

Dependency bumps were merged by hand. That is a steady tax on someone's attention for changes that are almost always safe, and it means bumps sit unmerged for days.

Grouping made the automation ineffective on its own. `dependabot/fetch-metadata` reports a single update type per PR, taken from the highest semver change in the group, so one major bump in the production group made every minor and patch bump beside it ineligible. Ungrouping is load-bearing here, not a side tidy-up.

Approving from a workflow is safe only with a required CI gate. Before this work, the ruleset required one approving review and no status check; because this workflow supplies the approval itself, a bump could otherwise land with red CI. Repository auto-merge is enabled and `build` is now required.

`strict_required_status_checks_policy` is intentionally disabled, matching `adr-services`. Every PR must pass `build`, but it does not need to rebase and rerun after another PR advances `main`. This lets an ungrouped weekly batch drain without serialized rebases. The tradeoff is that independently green bumps may merge without first being tested together; the `main` push build is the combined-state backstop.

## Approach

Copied from the shared composite action at `Contrast-Security-Inc/common-github-actions/dependabot-auto-approve-merge`, upstream commit `fc43269` (ADR-738), then vendored. It cannot be referenced across the org boundary because that repository is internal to the Inc org while this repository is public in Contrast-Security-OSS.

Adapted rather than copied verbatim:

- **`secrets.GITHUB_TOKEN` with explicit `contents: write` and `pull-requests: write`**, rather than the two shared org PATs upstream uses. GitHub documents that explicit workflow permissions can raise a Dependabot-triggered run's initially read-only token.
- **`--merge` rather than `--squash`.** Squash is disabled here and the PR Approvals ruleset permits only merge and rebase.
- **Actions pinned to full commit SHAs**, including `dependabot/fetch-metadata` v3 and `step-security/harden-runner`.
- **No `actions/checkout`.** The workflow does not read or execute the pull request working tree.
- **Eligibility is one exact, fail-closed check**, so an empty or unrecognized update type remains for a person.

A GitHub App token is the intended end state, tracked as bead `mcp-vc50`. John Ament is moving the shared action off its static PAT onto an App, and the OSS org should follow.

## What Changed

### Workflow

- `.github/workflows/dependabot-auto-merge.yml` (new) — runs on Dependabot pull-request events, reads the update type, approves and enables auto-merge for minor and patch updates, and logs/skips everything else.

### Dependabot config

- `.github/dependabot.yml` — removes `groups:` from Gradle, GitHub Actions, and Docker. Raises `open-pull-requests-limit` to 15 for Gradle and 10 for GitHub Actions so the default of five does not throttle an ungrouped weekly run. Retains the seven-day cooldown on all three ecosystems, preserving the ENTSEC-1742 soak window.

## Testing

`actionlint` is clean on the new workflow and across all repository workflows. `make check` passes.

The eligibility `case` was extracted and run against seven update types. `version-update:semver-minor` and `version-update:semver-patch` are eligible. Major, empty, unknown, malformed-minor, and extra-suffix inputs are ineligible, confirming that the workflow fails closed.

Live repository settings confirm:

- auto-merge enabled;
- GitHub Actions may approve pull requests;
- squash disabled;
- `build` required; and
- strict up-to-date enforcement disabled by policy decision.

## Review Findings Still Open

- **Actor versus author.** The job currently checks `github.actor == 'dependabot[bot]'`, which tests who initiated an event rather than who authored the PR. A Dependabot PR reopened or synchronized by a maintainer would be skipped. If author identity is intended, use `github.event.pull_request.user.login == 'dependabot[bot]'`.
- **PR-context action execution.** Omitting checkout keeps PR working-tree code off the runner, but a `pull_request` workflow still runs the PR-context workflow definition. A Dependabot update to an action pin in this workflow can therefore execute the proposed action version with the job's write token. This must be resolved or explicitly accepted, and the GitHub App follow-up must mint its persistent credential only from a trusted default-branch workflow definition.

## Live Rollout Gap

The real path cannot be exercised from this feature PR. The workflow only acts on Dependabot events, and future Dependabot branches must contain or be evaluated against the merged workflow. The open Dependabot PRs #164 and #155 are major bumps, so deliberately enabling auto-merge on them would be unsafe.

On the first eligible minor or patch update, verify:

1. The job runs and records the expected approval identity.
2. Auto-merge waits for `build` to pass.
3. Major and unknown update types remain untouched.
4. A `wiz-scan` push run exists on the merge commit SHA.

## Risks / Rollout / Follow-ups

- **The post-merge scan may go quiet.** Events attributed to `GITHUB_TOKEN` normally do not trigger further workflow runs. If that applies to the eventual GitHub-performed auto-merge, `wiz-scan` will not run on the merge commit; because it also cannot authenticate on the Dependabot PR, the bump would be unscanned. Verify the first auto-merge. The fix is the trusted GitHub App design in bead `mcp-vc50`, currently blocked on IT provisioning.
- **Green PRs are not retested together before merge.** Disabling strict up-to-date enforcement lets a batch drain quickly, matching `adr-services`, but two individually green dependency changes can interact. The `main` push build is the combined-state backstop.
- **`wiz-scan` is already red on Dependabot PRs.** Its credentials are in the Actions secret store, which Dependabot-triggered runs cannot read. It is not required and does not block a merge. This is pre-existing and tracked as bead `mcp-f946`.

[AIML-1245]: https://contrast.atlassian.net/browse/AIML-1245