### PR TITLE
AIML-1249 Document where authorization scope is enforced in hosted MCP README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Any MCP client that supports Streamable HTTP transport and OAuth 2.0 with PKCE c
 
 Your client discovers the OAuth configuration automatically through the `WWW-Authenticate` response header, which points to the standard `/.well-known/oauth-protected-resource` metadata document. Clients that support Dynamic Client Registration can register at `/oauth2/connect/register` on the Contrast origin.
 
+These OAuth scopes cover identity only, and that is deliberate. The token grants no data permissions of its own. Authorization is decided by the Contrast platform on every request, using the signed-in user's existing role-based access control. This means there is no broadly-scoped token for an agent to hold or leak, and no authorization scope to get wrong at connection time. See [Security and privacy](#security-and-privacy) for the full model.
+
 ### Supported clients
 
 | Client | Status |
@@ -94,7 +96,8 @@ The hosted server changes how access works without changing what you are allowed
 - **OAuth, not API keys.** You sign in through your browser, so there are no long-lived keys to distribute or store on developer machines.
 - **Read-only.** Every hosted tool is read-only. You cannot modify, update, or delete data through the hosted server.
 - **Organization-scoped.** Each session is bound to the single organization you select at sign-in, so there is no organization ID to guess or get wrong.
-- **Your existing permissions apply.** Every request carries your identity to Contrast, which enforces the same role-based access control as the web interface. If you cannot see something in Contrast, your agent cannot see it either.
+- **Your existing permissions apply.** Every request carries your identity to Contrast, which enforces the same role-based access control as the web interface. If you cannot see something in Contrast, your agent cannot see it either. Authorization is a runtime decision made on each request, not a one-time grant encoded in the token, so scoping an agent is the same exercise as scoping its user.
+- **Every tool call is audited.** Contrast records each request with a unique identifier, the tool invoked, the user, the organization, and the outcome, supporting incident reconstruction.
 - **No data storage.** The hosted server stores none of your data, and your token never appears in a tool response.
 
 The shared warning above still applies. Tool results become part of your AI conversation, so follow your organization's policy on what security data can be sent to your chosen AI client and model.


### PR DESCRIPTION
**Jira:** [AIML-1249](https://contrast.atlassian.net/browse/AIML-1249)

## Summary
Documents where authorization scope is enforced for the hosted MCP server, so security reviewers can answer their standard vendor-risk question directly from the README.

- Explains that the identity-only OAuth scopes are deliberate, with authorization decided per request by the platform using the user's existing RBAC
- Adds a Security and privacy bullet stating that every tool call is audited

## Why This Change Exists
- A customer security reviewer read the README, saw OAuth scopes of `openid, profile, offline_access`, and concluded the token was unscoped, citing the "MCP authorization scope" spec-gap discussion circulating among security practitioners. That reading is backwards: the token carries no data permissions because authorization never lives in the token.
- The README states that existing RBAC applies but never connects that to the scopes table, and it says nothing about per-call auditing. Reviewers primed by the spec-gap articles will keep arriving with the question "where is authorization scope enforced?", and the README should answer it.
- Both claims are verified against the service code: `HostedMcpToolConfig` registers only read-only tools, and `AuditedToolCallback` records request ID, tool, user, organization, and outcome on every call.

## What Changed
### README
- `README.md` — after the OAuth scopes table, a paragraph explaining the scopes are identity-only by design and authorization is a per-request platform decision; in Security and privacy, a sentence extending the existing-permissions bullet (runtime decision, not a token grant) and a new bullet on per-call auditing

## Testing
- Docs-only change, no code. Verified the `#security-and-privacy` anchor is unique in the document.


[AIML-1249]: https://contrast.atlassian.net/browse/AIML-1249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ