### PR TITLE
AIML-942 MCP standards v2: descriptions, envelope, and enforcement

### DIFF
--- a/MCP_STANDARDS.md
+++ b/MCP_STANDARDS.md
@@ -1,8 +1,11 @@
-# MCP Tool Naming Standards
+# MCP Tool Standards
 
-**Version:** 1.0
-**JIRA:** AIML-238
+**Version:** 2.0
+**JIRA:** AIML-238 (naming, v1), AIML-942 (descriptions, envelope, enforcement, v2)
 **Created:** 2025-11-18
+**Updated:** 2026-07-30
+
+Scope note. This document covers the tools in this repository. Other applications that consume `contrast-mcp-core` may layer additional standards of their own. Content specific to any private deployment or internal infrastructure is rejected from this document by policy, and CI enforces a denylist to keep it that way.
 
 ---
 
@@ -134,6 +137,128 @@ Tools returning analytical data (reports, coverage, metadata) may use `get_*` ev
 
 ---
 
+## Tool Descriptions
+
+A tool description is read by an agent, not a human. It is also the most expensive prose in the interface. It ships in `tools/list` for every session whether or not the tool is used. The standard is structural, not judgment-based. Every fact about a tool has exactly one home, chosen by the moment the agent needs it.
+
+### One home per fact
+
+| When the agent needs it | Fact type | Home |
+|---|---|---|
+| Choosing a tool | Purpose, use-when/don't-use against overlapping siblings, prerequisite pointers | Description body |
+| Building the call | Formats, valid value sets, filter semantics, defaults, mutual exclusivity | `@ToolParam` description |
+| Reading the result, conditionally | A quirk that applies only when a condition occurs on this response | A notice in the response, emitted only when the condition fires |
+| Reading the result, always | The standing meaning of a field | A self-describing field name; fallback, one clause in the body |
+| Always, for every tool | A convention uniformly true across the whole exposed tool set | Server instructions, gated by the three-bar test below |
+
+Two rules make the table binding.
+
+**Earliest-moment tiebreaker.** A fact needed at more than one moment goes in the earliest home where it is needed, and only there. "Use score, not severity, when sorting by risk" shapes the `sort` argument, so it lives on the `sort` parameter even though it sounds like result interpretation.
+
+**Duplication ban.** A fact stated in a parameter description must not repeat in the body. Cross-checking body against params is part of review.
+
+### Templates and budgets
+
+Each verb shape has a fixed template. Every slot except the lead is optional. The budget is a ceiling a reviewer verifies by counting words in the body prose. `@ToolParam` text is not counted.
+
+**Search and list tools, 150 words or fewer.**
+
+1. Lead sentence. What it searches and its scope.
+2. Use-when/don't-use against siblings, only where genuine overlap exists in the exposed tool set.
+3. Prerequisite pointer ("Use search_applications to find application IDs by name").
+4. Call-shaping quirks that span more than one parameter. Mutual exclusivity between parameters is the canonical example ("sessionMetadataFilters and useLatestSession are mutually exclusive"). Single-parameter semantics belong on the parameter.
+5. Up to three usage examples, preferring filter combinations over single filters. Simple tools get none.
+
+**Get tools, 40 words or fewer.** Lead sentence plus a discovery pointer for the identifier ("Use search_vulnerabilities to find vulnerability IDs"). Interpretation quirks arrive as notices, not prose.
+
+**Update tools, 60 words or fewer.** Lead sentence, allowed transitions when not carried by the parameter, and an audit or reversibility note.
+
+**Escape hatch.** A description may exceed its budget only when the overage is use-when/don't-use disambiguation, and the overage must name the sibling it disambiguates against. The enforcement test records the exemption in a reviewed allowlist.
+
+### Transitional clauses
+
+Interpretation prose stays in a description until the notice, rename, or output-schema property that replaces it ships, and it moves in the same change as the code that replaces it. Transitional clauses count against the budget and are tagged in the definition snapshot, so shipping the replacement is how a tool reclaims its headroom.
+
+### Never in a description
+
+- A parameter the tool does not accept. The validation error teaches the rare misuse.
+- A field-by-field response inventory. Self-evident fields (title, ids, timestamps) carry nothing anywhere.
+- A "Related tools" footer that restates what siblings do. The agent holds every tool's description already. Keep the routing decision inline, in the use-when slot.
+- A fact already on a parameter (duplication ban).
+
+### Deprecation
+
+A deprecated tool announces it three ways. The description starts with `DEPRECATED:` naming the reason and the replacement, `doExecute()` emits a notice on every call, and the Java `@Deprecated` annotation covers human readers. When the reason is output size, say so concretely.
+
+---
+
+## Parameter Descriptions
+
+The `@ToolParam` description is the single home for call-construction facts.
+
+1. Name what the parameter filters or selects, in the parameter's own terms.
+2. List the valid value set once, here and nowhere else ("Comma-separated severities: CRITICAL,HIGH,MEDIUM,LOW,NOTE"). Validation enforces it on a miss.
+3. State the format only when non-obvious (dates accepting ISO-8601 or epoch milliseconds, a JSON object shape).
+4. Cross-reference the discovery tool when the value comes from another tool ("use search_applications to find").
+5. Clarify semantics when the name misleads ("lastSeenAfter filters on last activity, not discovery date") or when two parameters look interchangeable ("keyword is substring match across many fields, rules is exact match on rule IDs").
+
+Required-ness goes on the `@ToolParam(required=...)` flag, never in prose.
+
+---
+
+## Response Envelope, Errors, and Notices
+
+Every tool response wraps in a shared envelope with exactly two message tiers. The distinction is behavioral, an agent acts differently on each.
+
+- **`errors`** mean the call failed or was invalid. Fix the call and retry. `isSuccess()` keys off this list.
+- **`notices`** are informational. Read them while interpreting the result. They carry applied defaults, failed optional enrichments, empty-result explanations, and interpretation facts. (Migration note. The wire field is named `warnings` until the AIML-942 envelope rename ships. New code should target `notices`.)
+
+Do not add a third tier. A distinction that does not change agent behavior is taxonomy, not signal.
+
+### Notice wording
+
+State the fact affirmatively. Never phrase a teaching notice as a failure.
+
+- Good. "severity and score omitted means unscored, not low risk."
+- Good. "totalItems is available on the first page only."
+- Bad. "Warning: missing severity."
+
+Degradation notices keep the established suffix pattern ("route coverage not available (retrieval error, HTTP 403)") so agents can tell transient absence from legitimate absence.
+
+### Point-of-use teaching
+
+Interpretation facts are delivered where the confusion would occur, not up front.
+
+**Conditional quirks** become notices emitted only when the condition occurs on that response. An always-emitted notice is a smell, it belongs in another home.
+
+**Always-true field meaning** is carried by the field name itself. Prefer renaming a misleading field (`httpRequest` that has had sensitive headers stripped becomes `httpRequestRedacted`) over documenting it. A rename costs zero recurring tokens. When a rename is not feasible, the fallback is one clause in the description body, tagged transitional if a rename is planned.
+
+### Output schema, end state
+
+When the stack gains `outputSchema` support, always-true field facts that a rename cannot carry move onto the schema property's `description`. Notices are unaffected, conditional facts stay point-of-use. The schema then joins the same budget and snapshot discipline, property descriptions only where the name cannot carry the meaning, no auto-generated full-graph schemas, adoption per tool and justified. Nothing load-bearing moves exclusively to the schema until the consuming clients are confirmed to surface it.
+
+---
+
+## Server Instructions
+
+The MCP `instructions` string is read once near session start, far from any call site. A fact may move there only when it clears all three bars.
+
+1. **Delivered.** A captured `initialize` response from the running server proves the field is emitted, and the consuming clients are confirmed to surface it.
+2. **Recalled.** The agent plausibly still holds the fact when it builds a call. Mechanical call-shaping facts (1-based pages) fail this bar and stay on the tool.
+3. **Uniformly true.** The fact holds for every exposed tool. The moment it varies by tool, globalizing it makes it false for some.
+
+---
+
+## Enforcement
+
+The standard is enforced by tests, not by review-time judgment.
+
+- **Definition snapshots.** A test serializes every tool's name, description, parameter descriptions, and schema to a committed snapshot file. Any change to what agents actually see appears in review as a plain-text diff.
+- **Budget checks.** The same test counts body words per description against the template ceilings and the catalog-total size against a hard cap. Exceeding a ceiling fails the build unless the tool has a named allowlist entry, which is itself a reviewed artifact.
+- **Public-content denylist.** A docs test rejects terms that must never appear in this repository's standards or descriptions, keeping deployment-specific content out by construction.
+
+---
+
 ## Tool-per-Class Architecture
 
 All MCP tools follow a **one-class-per-tool** pattern with shared base classes. Each tool is a standalone `@Service` class that extends `PaginatedTool` for offset/page-backed search/list operations, `CursorPaginatedTool` for cursor/keyset-backed list operations, or `SingleTool` for single-item retrieval.
@@ -252,15 +377,39 @@ For any other application that consumes `contrast-mcp-core`, register tools thro
 
 ## Checklist
 
+**Naming and shape**
 - [ ] `action_entity` snake_case format
-- [ ] Verb matches capability (search/list/get)
+- [ ] Verb matches capability (search/list/get/update)
 - [ ] Entity clear and unabbreviated
 - [ ] Parameters camelCase and consistent
 - [ ] Return type follows standards
-- [ ] @Tool description clear and concise
-- [ ] Required vs optional documented
 - [ ] No redundant words
 - [ ] Extends `PaginatedTool`, `CursorPaginatedTool`, or `SingleTool`
 - [ ] Has corresponding Params class
 - [ ] Registered in the appropriate explicit `tools()` bean
 - [ ] Unit and integration tests present
+
+**Description**
+- [ ] Body follows the verb-shape template and is within budget (search/list ≤150 words, get ≤40, update ≤60), or carries a named allowlist exemption for sibling disambiguation
+- [ ] Every fact sits in its one home per the routing table, no body/param duplication
+- [ ] Prerequisite and discovery pointers inline, no "Related tools" footer
+- [ ] At most three usage examples, combinations preferred
+- [ ] No documented parameter the tool does not accept, no response-field inventory
+- [ ] Transitional clauses tagged and tied to the change that removes them
+- [ ] Deprecated tools start with `DEPRECATED:`, name the replacement, and notice on every call
+
+**Parameters**
+- [ ] Valid value set listed once on the parameter, nowhere else
+- [ ] Required-ness on the `@ToolParam(required=...)` flag, not prose
+- [ ] Format noted only when non-obvious, discovery cross-references present
+- [ ] Misleading names and confusable parameter pairs clarified on the parameter
+
+**Envelope**
+- [ ] Two tiers only, errors actionable, notices informational
+- [ ] Notices worded affirmatively, never as failure
+- [ ] Conditional interpretation facts emitted as notices at point of use
+- [ ] Misleading response field names renamed rather than documented, when feasible
+
+**Enforcement**
+- [ ] Definition snapshot updated and reviewed
+- [ ] Budget check passes or the exemption is in the reviewed allowlist

--- a/docs/adr/0001-notices-tier-and-point-of-use-teaching.md
+++ b/docs/adr/0001-notices-tier-and-point-of-use-teaching.md
@@ -1,0 +1,19 @@
+# Two-tier response envelope with notices, and point-of-use teaching
+
+**Status:** accepted (AIML-942)
+
+Tool descriptions had grown into multi-section documents that explained response quirks up front, costing context tokens in every session whether or not the quirk ever occurred. We decided to deliver interpretation facts at the point of use instead. Conditional quirks (an unscored item, a missing total, an empty session) are emitted as informational entries in the response envelope only when the condition occurs. Always-true field meaning is carried by self-describing field names, renaming a misleading field rather than documenting it.
+
+To support this, the envelope's informational tier is renamed from `warnings` to `notices`, full-depth, wire field, `WarningCollector` becoming `NoticeCollector`, and `warn()` becoming `notice()`. "Warnings" primed agents to relay teaching notes to users as problems and to spend turns resolving notes that describe normal behavior. The envelope keeps exactly two tiers, `errors` (actionable, fix the call and retry) and `notices` (informational, read while interpreting the result), because that is the only distinction that changes agent behavior.
+
+## Considered options
+
+- A third `notes` tier beside `errors` and `warnings`. Rejected. Agents behave identically on a warning and a note, and an earlier consolidation had already merged the informational tiers once.
+- Keeping the `warnings` name to avoid a breaking wire change. Rejected while the rename window is open. The field was nearly unused, and it is about to become the primary teaching channel, so the name will never be cheaper to fix than now.
+- Alternative names `messages` (collides with chat message arrays in LLM contexts), `advisories` (reads as security advisories in an appsec product), `info` (log-level connotation). `notices` fits both teaching notes and degradation reports.
+
+## Consequences
+
+- The rename is a breaking change for consumers that read the `warnings` field. It ships in one coordinated envelope sweep together with response-field renames, so the shape breaks once.
+- An always-emitted notice is a design smell. If a notice fires on every response, its fact is not conditional and belongs in another home (field name, parameter description, or description body per MCP_STANDARDS.md).
+- Degradation reporting keeps the "not available (retrieval error)" suffix convention so agents can distinguish transient absence from legitimate absence.


### PR DESCRIPTION
## What

Extends `MCP_STANDARDS.md` from naming-only (v1) to the full tool interface standard (v2), and adds ADR 0001 recording the envelope decision.

- **One home per fact.** Every fact about a tool lives in exactly one channel, chosen by when the agent needs it (description body / `@ToolParam` / point-of-use notices / self-describing field names / three-bar-gated server instructions), with an earliest-moment tiebreaker and a body/param duplication ban.
- **Templates and budgets.** Verb-shape templates with reviewer-countable ceilings: search/list ≤150 words, get ≤40, update ≤60, with a named-allowlist escape hatch for sibling disambiguation.
- **Notices.** The envelope's informational tier is renamed `warnings` → `notices` (ADR 0001, ships separately as a coordinated envelope sweep), with an affirmative wording rule and a conditional-emission rule for interpretation facts.
- **Enforcement.** Definition snapshot tests, budget gates, and a public-content denylist, to be implemented as follow-ons.

## Why

Descriptions in this repo drifted into multi-section prose that repeats the schema, the response, and shared conventions, spending hundreds of context tokens per tool per session. Earlier judgment-based standards (necessity test, cost test) were unreviewable. This version is structural: facts are classified, not weighed, and budgets are counted, not argued.

## Notes for reviewers

- Doc-only change. The envelope rename and description migrations land as separate PRs tracked under bead mcp-ayi0 / AIML-942.
- The scope note at the top and the denylist enforcement exist deliberately: this doc stays generic and public-safe by policy.

Companion change in aiml-services updates the hosted addendum and skill to reference this as canonical.