### PR TITLE
AIML-942 Rename MCP response notices and remediation hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+**Response notices and remediation hint renamed**: The published `contrast-mcp-core` response
+envelopes now expose `notices` instead of `warnings`, including the JSON field and the record
+component on `PaginatedToolResponse`, `SingleToolResponse`, and `CursorToolResponse`.
+`WarningCollector` is now `NoticeCollector`, `ToolParams.warnings()` is now
+`ToolParams.notices()`, and `Vulnerability.hint` is now `Vulnerability.remediationHint`.
+Java consumers must recompile and update these API references; JSON consumers must read
+`notices` and `remediationHint`.
+
 ## [2.1.0] - 2026-07-20
 
 ### Breaking Changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This is an MCP (Model Context Protocol) server for Contrast Security that enable
 
 ## Git Hooks
 
-Never skip git hooks (`--no-verify`) without explicit user approval.
+**ABSOLUTE RULE: NEVER skip git hooks.** Do not use `--no-verify`, `--no-gpg-sign`, `SKIP_COVERAGE_HOOK=1`, or any other mechanism to bypass pre-commit, pre-push, or any other git hook. No exceptions. No shortcuts. If a hook fails, fix the underlying problem. A skipped hook caused a CI build failure; this rule exists to prevent that from ever happening again. If you skip a hook, you have made an error.
 
 ## Branching Requirements
 

--- a/MCP_STANDARDS.md
+++ b/MCP_STANDARDS.md
@@ -211,7 +211,7 @@ Required-ness goes on the `@ToolParam(required=...)` flag, never in prose.
 Every tool response wraps in a shared envelope with exactly two message tiers. The distinction is behavioral, an agent acts differently on each.
 
 - **`errors`** mean the call failed or was invalid. Fix the call and retry. `isSuccess()` keys off this list.
-- **`notices`** are informational. Read them while interpreting the result. They carry applied defaults, failed optional enrichments, empty-result explanations, and interpretation facts. (Migration note. The wire field is named `warnings` until the AIML-942 envelope rename ships. New code should target `notices`.)
+- **`notices`** are informational. Read them while interpreting the result. They carry applied defaults, failed optional enrichments, empty-result explanations, and interpretation facts.
 
 Do not add a third tier. A distinction that does not change agent behavior is taxonomy, not signal.
 
@@ -231,7 +231,7 @@ Interpretation facts are delivered where the confusion would occur, not up front
 
 **Conditional quirks** become notices emitted only when the condition occurs on that response. An always-emitted notice is a smell, it belongs in another home.
 
-**Always-true field meaning** is carried by the field name itself. Prefer renaming a misleading field (`httpRequest` that has had sensitive headers stripped becomes `httpRequestRedacted`) over documenting it. A rename costs zero recurring tokens. When a rename is not feasible, the fallback is one clause in the description body, tagged transitional if a rename is planned.
+**Always-true field meaning** is carried by the field name itself. Prefer renaming a misleading field (`hint` containing AI-generated remediation guidance becomes `remediationHint`) over documenting it. A rename costs zero recurring tokens. When a rename is not feasible, the fallback is one clause in the description body, tagged transitional if a rename is planned.
 
 ### Output schema, end state
 
@@ -286,23 +286,23 @@ com.contrast.labs.ai.mcp.contrast.tool/
 **`PaginatedTool<P extends ToolParams, R>`** - For paginated search/list tools:
 - Template method `executePipeline()` handles pagination, validation, exceptions
 - Subclasses implement `doExecute()` returning `ExecutionResult<R>`
-- Returns `PaginatedToolResponse<R>` with items, pagination metadata, errors, warnings
+- Returns `PaginatedToolResponse<R>` with items, pagination metadata, errors, notices
 
 **`SingleTool<P extends ToolParams, R>`** - For single-item get tools:
 - Template method `executePipeline()` handles validation, exceptions
 - Subclasses implement `doExecute()` returning item or null
-- Returns `SingleToolResponse<R>` with item, errors, warnings
+- Returns `SingleToolResponse<R>` with item, errors, notices
 
 **`CursorPaginatedTool<P extends ToolParams, R>`** - For cursor/keyset-backed list tools:
 - Template method `executePipeline()` handles cursor pagination, validation, exceptions
 - Subclasses treat cursor values as opaque continuation tokens
-- Returns `CursorToolResponse<R>` with items, `nextCursor`, `hasMore`, errors, and warnings
+- Returns `CursorToolResponse<R>` with items, `nextCursor`, `hasMore`, errors, and notices
 
 ### Parameter Classes (Params Pattern)
 
 Each tool has an associated `*Params` class extending `BaseToolParams` and validating input through a `ToolValidationContext` used by composition:
 - Validates and parses input parameters
-- Collects errors and warnings via fluent API
+- Collects errors and notices via fluent API
 - Converts to SDK filter objects (e.g., `toTraceFilterForm()`)
 
 Example:
@@ -318,7 +318,7 @@ public class VulnerabilityFilterParams extends BaseToolParams {
     var ctx = new ToolValidationContext(); // composition, not inheritance
     params.severities = ctx.enumSetParam(severities, RuleSeverity.class, "severities").get();
     // ... more fluent validation on ctx
-    params.setValidationResult(ctx); // transfer errors/warnings
+    params.setValidationResult(ctx); // transfer errors/notices
     return params;
   }
 }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/Vulnerability.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/Vulnerability.java
@@ -21,8 +21,8 @@ import java.util.List;
 
 /**
  * Full vulnerability record for detail view. Contains all fields from VulnLight plus additional
- * remediation context (remediationHint, howToFix, stackTrace, vulnerableLibraries, httpRequest). The
- * environments field reflects the latest instance only, may omit environments from earlier
+ * remediation context (remediationHint, howToFix, stackTrace, vulnerableLibraries, httpRequest).
+ * The environments field reflects the latest instance only, may omit environments from earlier
  * instances.
  */
 public record Vulnerability(

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/Vulnerability.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/Vulnerability.java
@@ -21,12 +21,12 @@ import java.util.List;
 
 /**
  * Full vulnerability record for detail view. Contains all fields from VulnLight plus additional
- * remediation context (hint, howToFix, stackTrace, vulnerableLibraries, httpRequest). The
+ * remediation context (remediationHint, howToFix, stackTrace, vulnerableLibraries, httpRequest). The
  * environments field reflects the latest instance only, may omit environments from earlier
  * instances.
  */
 public record Vulnerability(
-    String hint,
+    String remediationHint,
     String vulnID,
     String title,
     String type,

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataTool.java
@@ -17,9 +17,9 @@ package com.contrast.labs.ai.mcp.contrast.tool.application;
 
 import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
 import com.contrast.labs.ai.mcp.contrast.tool.application.params.GetSessionMetadataParams;
+import com.contrast.labs.ai.mcp.contrast.tool.base.NoticeCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleTool;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleToolResponse;
-import com.contrast.labs.ai.mcp.contrast.tool.base.WarningCollector;
 import com.contrastsecurity.models.MetadataFilterResponse;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.annotation.Tool;
@@ -68,11 +68,11 @@ public class GetSessionMetadataTool
 
   @Override
   protected MetadataFilterResponse doExecute(
-      GetSessionMetadataParams params, WarningCollector collector) throws Exception {
+      GetSessionMetadataParams params, NoticeCollector collector) throws Exception {
     var response = contrastApiClient.getSessionMetadata(params.appId());
 
     if (response == null) {
-      collector.warn("No session metadata found for this application.");
+      collector.notice("No session metadata found for this application.");
       return null;
     }
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsTool.java
@@ -23,10 +23,10 @@ import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.Applicati
 import com.contrast.labs.ai.mcp.contrast.tool.application.params.ApplicationFilterParams;
 import com.contrast.labs.ai.mcp.contrast.tool.base.ExecutionResult;
 import com.contrast.labs.ai.mcp.contrast.tool.base.FilterHelper;
+import com.contrast.labs.ai.mcp.contrast.tool.base.NoticeCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginatedTool;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginatedToolResponse;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginationParams;
-import com.contrast.labs.ai.mcp.contrast.tool.base.WarningCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.validation.UnresolvedMetadataFilter;
 import java.util.HashMap;
 import java.util.List;
@@ -101,7 +101,7 @@ public class SearchApplicationsTool
 
   @Override
   protected ExecutionResult<ApplicationData> doExecute(
-      PaginationParams pagination, ApplicationFilterParams params, WarningCollector collector)
+      PaginationParams pagination, ApplicationFilterParams params, NoticeCollector collector)
       throws Exception {
 
     // Resolve metadata field names to IDs if metadata filters provided
@@ -123,7 +123,7 @@ public class SearchApplicationsTool
             pagination.offset());
 
     if (response == null || response.getApplications() == null) {
-      collector.warn("API returned no application data.");
+      collector.notice("API returned no application data.");
       return ExecutionResult.empty();
     }
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesTool.java
@@ -18,9 +18,9 @@ package com.contrast.labs.ai.mcp.contrast.tool.attack;
 import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.ProtectData;
 import com.contrast.labs.ai.mcp.contrast.tool.attack.params.GetProtectRulesParams;
+import com.contrast.labs.ai.mcp.contrast.tool.base.NoticeCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleTool;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleToolResponse;
-import com.contrast.labs.ai.mcp.contrast.tool.base.WarningCollector;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.ai.chat.model.ToolContext;
@@ -80,7 +80,7 @@ public class GetProtectRulesTool extends SingleTool<GetProtectRulesParams, Prote
   }
 
   @Override
-  protected ProtectData doExecute(GetProtectRulesParams params, WarningCollector collector)
+  protected ProtectData doExecute(GetProtectRulesParams params, NoticeCollector collector)
       throws Exception {
     var protectData = contrastApiClient.getProtectRules(params.appId());
 
@@ -90,7 +90,7 @@ public class GetProtectRulesTool extends SingleTool<GetProtectRulesParams, Prote
 
     var ruleCount = Optional.ofNullable(protectData.getRules()).map(List::size).orElse(0);
     if (ruleCount == 0) {
-      collector.warn("Application has Protect enabled but no rules are configured.");
+      collector.notice("Application has Protect enabled but no rules are configured.");
     }
 
     return protectData;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksTool.java
@@ -19,10 +19,10 @@ import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
 import com.contrast.labs.ai.mcp.contrast.result.AttackSummary;
 import com.contrast.labs.ai.mcp.contrast.tool.attack.params.AttackFilterParams;
 import com.contrast.labs.ai.mcp.contrast.tool.base.ExecutionResult;
+import com.contrast.labs.ai.mcp.contrast.tool.base.NoticeCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginatedTool;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginatedToolResponse;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginationParams;
-import com.contrast.labs.ai.mcp.contrast.tool.base.WarningCollector;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.annotation.Tool;
@@ -173,7 +173,7 @@ public class SearchAttacksTool extends PaginatedTool<AttackFilterParams, AttackS
 
   @Override
   protected ExecutionResult<AttackSummary> doExecute(
-      PaginationParams pagination, AttackFilterParams params, WarningCollector collector)
+      PaginationParams pagination, AttackFilterParams params, NoticeCollector collector)
       throws Exception {
 
     var filterBody = params.toAttacksFilterBody();
@@ -182,7 +182,7 @@ public class SearchAttacksTool extends PaginatedTool<AttackFilterParams, AttackS
             filterBody, pagination.limit(), pagination.offset(), params.getSort());
 
     if (attacksResponse == null || attacksResponse.getAttacks() == null) {
-      collector.warn("API returned no attack data. Verify permissions and filters.");
+      collector.notice("API returned no attack data. Verify permissions and filters.");
       return ExecutionResult.empty();
     }
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParams.java
@@ -124,13 +124,13 @@ public class AttackFilterParams extends BaseToolParams {
     // Parse includeSuppressed with smart default
     if (includeSuppressed == null) {
       params.includeSuppressed = false;
-      ctx.noticeIf(
-          true,
-          "Excluding suppressed attacks by default. "
-              + "To see all attacks including suppressed, set includeSuppressed=true.");
     } else {
       params.includeSuppressed = includeSuppressed;
     }
+    ctx.noticeIf(
+        includeSuppressed == null,
+        "Excluding suppressed attacks by default. "
+            + "To see all attacks including suppressed, set includeSuppressed=true.");
 
     // Parse other boolean filters (no defaults needed)
     params.includeBotBlockers = includeBotBlockers;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParams.java
@@ -124,7 +124,7 @@ public class AttackFilterParams extends BaseToolParams {
     // Parse includeSuppressed with smart default
     if (includeSuppressed == null) {
       params.includeSuppressed = false;
-      ctx.warnIf(
+      ctx.noticeIf(
           true,
           "Excluding suppressed attacks by default. "
               + "To see all attacks including suppressed, set includeSuppressed=true.");

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseToolParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseToolParams.java
@@ -35,7 +35,7 @@ import java.util.List;
  *     ctx.require(value, "myField");
  *     params.myField = value;
  *
- *     params.setValidationResult(ctx);  // Transfer errors/warnings
+ *     params.setValidationResult(ctx);  // Transfer errors/notices
  *     return params;
  *   }
  *
@@ -46,7 +46,7 @@ import java.util.List;
 public abstract class BaseToolParams implements ToolParams {
 
   private List<String> errors = List.of();
-  private List<String> warnings = List.of();
+  private List<String> notices = List.of();
 
   @Override
   public boolean isValid() {
@@ -59,18 +59,18 @@ public abstract class BaseToolParams implements ToolParams {
   }
 
   @Override
-  public List<String> warnings() {
-    return warnings;
+  public List<String> notices() {
+    return notices;
   }
 
   /**
    * Transfer validation results from a ToolValidationContext to this params instance. Call this at
    * the end of static factory methods after all validation is complete.
    *
-   * @param ctx the validation context containing errors and warnings
+   * @param ctx the validation context containing errors and notices
    */
   protected void setValidationResult(ToolValidationContext ctx) {
     this.errors = ctx.errors();
-    this.warnings = ctx.warnings();
+    this.notices = ctx.notices();
   }
 }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java
@@ -65,9 +65,9 @@ public abstract class CursorPaginatedTool<P extends ToolParams, R> extends BaseT
 
     var pagination = CursorPaginationParams.of(cursor, pageSize, getMaxPageSize());
     var params = paramsSupplier.get();
-    var collector = WarningCollector.forContext(Map.of(LoggingKeys.REQUEST_ID, requestId));
-    pagination.warnings().forEach(collector::warn);
-    params.warnings().forEach(collector::warn);
+    var collector = NoticeCollector.forContext(Map.of(LoggingKeys.REQUEST_ID, requestId));
+    pagination.notices().forEach(collector::notice);
+    params.notices().forEach(collector::notice);
 
     if (!params.isValid()) {
       logValidationError(requestId, params.errors(), pagination.cursorPresence());
@@ -105,12 +105,12 @@ public abstract class CursorPaginatedTool<P extends ToolParams, R> extends BaseT
    *
    * @param pagination validated cursor pagination params
    * @param params validated tool-specific params
-   * @param collector warning accumulator
+   * @param collector notice accumulator
    * @return cursor execution result
    * @throws Exception from downstream clients or processing
    */
   protected abstract CursorExecutionResult<R> doExecute(
-      CursorPaginationParams pagination, P params, WarningCollector collector) throws Exception;
+      CursorPaginationParams pagination, P params, NoticeCollector collector) throws Exception;
 
   private CursorToolResponse<R> handleException(
       Exception e, CursorPaginationParams pagination, String requestId, String userMessage) {
@@ -127,7 +127,7 @@ public abstract class CursorPaginatedTool<P extends ToolParams, R> extends BaseT
       HttpResponseException e,
       CursorPaginationParams pagination,
       String requestId,
-      WarningCollector collector) {
+      NoticeCollector collector) {
 
     String errorMessage = mapHttpErrorCode(e.getCode());
 
@@ -151,12 +151,12 @@ public abstract class CursorPaginatedTool<P extends ToolParams, R> extends BaseT
   private CursorToolResponse<R> buildSuccessResponse(
       CursorExecutionResult<R> result,
       CursorPaginationParams pagination,
-      WarningCollector collector,
+      NoticeCollector collector,
       long duration,
       String requestId) {
 
-    if (result.items().isEmpty() && !result.hasMore() && !collector.hasEmptyResultsWarning()) {
-      collector.warn("No results found matching the specified criteria.");
+    if (result.items().isEmpty() && !result.hasMore() && !collector.hasEmptyResultsNotice()) {
+      collector.notice("No results found matching the specified criteria.");
     }
 
     logSuccess(requestId, duration, result.items().size(), pagination.cursorPresence());

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParams.java
@@ -30,17 +30,17 @@ import org.springframework.util.StringUtils;
  * @param cursor opaque continuation token, or null for the first page
  * @param pageSize validated page size
  * @param limit same as pageSize, for downstream client clarity
- * @param warnings validation warnings
+ * @param notices validation notices
  */
 public record CursorPaginationParams(
-    @Nullable String cursor, int pageSize, int limit, List<String> warnings) {
+    @Nullable String cursor, int pageSize, int limit, List<String> notices) {
 
   private static final String CURSOR_PRESENT = "present";
   private static final String CURSOR_ABSENT = "absent";
 
   public CursorPaginationParams {
     cursor = StringUtils.hasText(cursor) ? cursor : null;
-    warnings = warnings != null ? List.copyOf(warnings) : List.of();
+    notices = notices != null ? List.copyOf(notices) : List.of();
   }
 
   /**
@@ -64,26 +64,26 @@ public record CursorPaginationParams(
    */
   public static CursorPaginationParams of(
       @Nullable String cursor, @Nullable Integer pageSize, int maxPageSize) {
-    List<String> warnings = new ArrayList<>();
+    List<String> notices = new ArrayList<>();
     int defaultSize = Math.min(DEFAULT_PAGE_SIZE, maxPageSize);
     int actualSize = pageSize != null && pageSize > 0 ? pageSize : defaultSize;
 
     if (pageSize != null && pageSize < 1) {
-      warnings.add(String.format("Invalid pageSize %d, using default %d", pageSize, defaultSize));
+      notices.add(String.format("Invalid pageSize %d, using default %d", pageSize, defaultSize));
       actualSize = defaultSize;
     } else if (pageSize != null && pageSize > maxPageSize) {
-      warnings.add(
+      notices.add(
           String.format(
               "Requested pageSize %d exceeds maximum %d, capped to %d",
               pageSize, maxPageSize, maxPageSize));
       actualSize = maxPageSize;
     }
 
-    return new CursorPaginationParams(cursor, actualSize, actualSize, warnings);
+    return new CursorPaginationParams(cursor, actualSize, actualSize, notices);
   }
 
   /**
-   * Cursor pagination uses soft validation only; invalid page sizes are corrected with warnings.
+   * Cursor pagination uses soft validation only; invalid page sizes are corrected with notices.
    *
    * @return true always
    */

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorToolResponse.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorToolResponse.java
@@ -28,7 +28,8 @@ import org.springframework.lang.Nullable;
  * @param nextCursor opaque continuation token, or null when absent
  * @param hasMore true when another page can be fetched
  * @param errors validation or execution errors
- * @param warnings non-fatal warnings
+ * @param notices Informational notices: applied defaults, failed optional enrichments, empty-result
+ *     explanations, interpretation facts
  * @param durationMs execution duration in milliseconds
  */
 public record CursorToolResponse<T>(
@@ -37,13 +38,13 @@ public record CursorToolResponse<T>(
     @Nullable String nextCursor,
     boolean hasMore,
     List<String> errors,
-    List<String> warnings,
+    List<String> notices,
     @Nullable Long durationMs) {
 
   public CursorToolResponse {
     items = items != null ? List.copyOf(items) : List.of();
     errors = errors != null ? List.copyOf(errors) : List.of();
-    warnings = warnings != null ? List.copyOf(warnings) : List.of();
+    notices = notices != null ? List.copyOf(notices) : List.of();
   }
 
   /**
@@ -60,10 +61,10 @@ public record CursorToolResponse<T>(
       int pageSize,
       @Nullable String nextCursor,
       boolean hasMore,
-      List<String> warnings,
+      List<String> notices,
       @Nullable Long durationMs) {
     return new CursorToolResponse<>(
-        items, pageSize, nextCursor, hasMore, List.of(), warnings, durationMs);
+        items, pageSize, nextCursor, hasMore, List.of(), notices, durationMs);
   }
 
   public static <T> CursorToolResponse<T> validationError(int pageSize, List<String> errors) {

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/LoggingKeys.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/LoggingKeys.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
  * String constants for structured log keys used across the codebase.
  *
  * <p>Use these instead of inline string literals when calling {@code addKeyValue(...)} or building
- * a {@code WarningCollector} context map, so the key set stays consistent and renames are
+ * a {@code NoticeCollector} context map, so the key set stays consistent and renames are
  * compiler-enforced.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/NoticeCollector.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/NoticeCollector.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Accumulates warnings during MCP tool execution and encapsulates the try/catch/warn pattern for
+ * Accumulates notices during MCP tool execution and encapsulates the try/catch/notice pattern for
  * optional data fetches.
  *
  * <p>Constructed once per request by the base classes and passed into {@code doExecute}. Tool
@@ -34,7 +34,7 @@ import lombok.extern.slf4j.Slf4j;
  * <p>{@link #snapshot()} is package-private — only base classes call it when building the response.
  */
 @Slf4j
-public final class WarningCollector {
+public final class NoticeCollector {
 
   /** Checked supplier that may throw any exception. */
   @FunctionalInterface
@@ -49,10 +49,10 @@ public final class WarningCollector {
   }
 
   private final Map<String, Object> context;
-  private final List<String> warnings = new ArrayList<>();
-  private boolean emptyResultsWarningRecorded;
+  private final List<String> notices = new ArrayList<>();
+  private boolean emptyResultsNoticeRecorded;
 
-  private WarningCollector(Map<String, Object> context) {
+  private NoticeCollector(Map<String, Object> context) {
     this.context = context;
   }
 
@@ -60,28 +60,28 @@ public final class WarningCollector {
    * Creates a new collector bound to the given log context key/values. The context entries are
    * added to every WARN log emitted by {@link #tryFetch} and {@link #tryRun}.
    */
-  public static WarningCollector forContext(Map<String, Object> context) {
-    return new WarningCollector(context);
+  public static NoticeCollector forContext(Map<String, Object> context) {
+    return new NoticeCollector(context);
   }
 
   /**
    * Executes {@code fetch} and returns the result wrapped in an Optional.
    *
-   * <p>Null return is treated as absent — no warning emitted. Use this when null is a legitimate
+   * <p>Null return is treated as absent — no notice emitted. Use this when null is a legitimate
    * outcome (e.g. optional enrichment that may simply not exist).
    *
    * <p>On exception: logs WARN, records {@code description + " not available (retrieval error)"} as
-   * a warning, returns empty. The {@code (retrieval error)} suffix signals to AI agents that the
+   * a notice, returns empty. The {@code (retrieval error)} suffix signals to AI agents that the
    * data was absent due to a fetch failure (e.g. permission denied, network error), not because the
    * data legitimately does not exist. Exception details are logged server-side but excluded from
-   * the agent-visible warning to avoid leaking internal API information.
+   * the agent-visible notice to avoid leaking internal API information.
    */
   public <T> Optional<T> tryFetch(String description, CheckedSupplier<T> fetch) {
     try {
       return Optional.ofNullable(fetch.get());
     } catch (Exception e) {
       logWarn(description, e);
-      warnings.add(description + retrievalErrorSuffix(e));
+      notices.add(description + retrievalErrorSuffix(e));
       return Optional.empty();
     }
   }
@@ -89,11 +89,11 @@ public final class WarningCollector {
   /**
    * Executes {@code operation}. Returns {@code true} on success, {@code false} if an exception is
    * thrown. On exception: logs WARN, records {@code description + " not available (retrieval
-   * error)"} as a warning.
+   * error)"} as a notice.
    *
    * <p>The {@code (retrieval error)} suffix signals to AI agents that the data was absent due to a
    * fetch failure. Exception details are logged server-side but excluded from the agent-visible
-   * warning to avoid leaking internal API information.
+   * notice to avoid leaking internal API information.
    */
   public boolean tryRun(String description, CheckedRunnable operation) {
     try {
@@ -101,44 +101,44 @@ public final class WarningCollector {
       return true;
     } catch (Exception e) {
       logWarn(description, e);
-      warnings.add(description + retrievalErrorSuffix(e));
+      notices.add(description + retrievalErrorSuffix(e));
       return false;
     }
   }
 
   /**
-   * Appends {@code message} to the warning list. Throws if {@code message} is null; silently skips
+   * Appends {@code message} to the notice list. Throws if {@code message} is null; silently skips
    * blank strings.
    */
-  public void warn(String message) {
-    Objects.requireNonNull(message, "warning message must not be null");
+  public void notice(String message) {
+    Objects.requireNonNull(message, "notice message must not be null");
     if (!message.isBlank()) {
-      warnings.add(message);
+      notices.add(message);
     }
   }
 
   /**
-   * Appends a warning that explains why an otherwise successful result set is empty. Base
-   * pagination classes use this marker to avoid adding their generic empty-result warning on top of
-   * a more specific tool-level explanation.
+   * Appends a notice that explains why an otherwise successful result set is empty. Base pagination
+   * classes use this marker to avoid adding their generic empty-result notice on top of a more
+   * specific tool-level explanation.
    */
-  public void warnForEmptyResults(String message) {
-    warn(message);
+  public void noticeForEmptyResults(String message) {
+    notice(message);
     if (!message.isBlank()) {
-      emptyResultsWarningRecorded = true;
+      emptyResultsNoticeRecorded = true;
     }
   }
 
-  boolean hasEmptyResultsWarning() {
-    return emptyResultsWarningRecorded;
+  boolean hasEmptyResultsNotice() {
+    return emptyResultsNoticeRecorded;
   }
 
   /**
-   * Returns an immutable snapshot of all warnings accumulated so far. Package-private — only base
+   * Returns an immutable snapshot of all notices accumulated so far. Package-private — only base
    * classes call this when building the response.
    */
   List<String> snapshot() {
-    return List.copyOf(warnings);
+    return List.copyOf(notices);
   }
 
   private String retrievalErrorSuffix(Exception e) {

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
@@ -84,16 +84,16 @@ public abstract class PaginatedTool<P extends ToolParams, R> extends BaseTool {
     var requestId = UUID.randomUUID().toString().substring(0, REQUEST_ID_PREFIX_LENGTH);
     long startTime = System.currentTimeMillis();
 
-    // 1. Parse pagination FIRST with tool-specific max (always succeeds with warnings)
+    // 1. Parse pagination FIRST with tool-specific max (always succeeds with notices)
     var pagination = PaginationParams.of(page, pageSize, getMaxPageSize());
 
     // 2. Parse tool-specific params (collects all errors)
     var params = paramsSupplier.get();
 
-    // 3. Collector accumulates warnings from all stages
-    var collector = WarningCollector.forContext(Map.of(LoggingKeys.REQUEST_ID, requestId));
-    pagination.warnings().forEach(collector::warn);
-    params.warnings().forEach(collector::warn);
+    // 3. Collector accumulates notices from all stages
+    var collector = NoticeCollector.forContext(Map.of(LoggingKeys.REQUEST_ID, requestId));
+    pagination.notices().forEach(collector::notice);
+    params.notices().forEach(collector::notice);
 
     // 4. Single validation checkpoint - ALL errors collected
     if (!params.isValid()) {
@@ -102,7 +102,7 @@ public abstract class PaginatedTool<P extends ToolParams, R> extends BaseTool {
           pagination.page(), pagination.pageSize(), params.errors());
     }
 
-    // 5. Execute - doExecute returns intermediate result, can add warnings via collector
+    // 5. Execute - doExecute returns intermediate result, can add notices via collector
     try (var ignored = authenticate(toolContext)) {
       var result = doExecute(pagination, params, collector);
       var duration = System.currentTimeMillis() - startTime;
@@ -138,13 +138,13 @@ public abstract class PaginatedTool<P extends ToolParams, R> extends BaseTool {
    *
    * @param pagination validated pagination params
    * @param params validated tool-specific params
-   * @param collector warning accumulator - call {@link WarningCollector#warn}, {@link
-   *     WarningCollector#tryFetch}, or {@link WarningCollector#tryRun} to record warnings
+   * @param collector notice accumulator - call {@link NoticeCollector#notice}, {@link
+   *     NoticeCollector#tryFetch}, or {@link NoticeCollector#tryRun} to record notices
    * @return ExecutionResult with items and optional total count
    * @throws Exception any exception from SDK or processing
    */
   protected abstract ExecutionResult<R> doExecute(
-      PaginationParams pagination, P params, WarningCollector collector) throws Exception;
+      PaginationParams pagination, P params, NoticeCollector collector) throws Exception;
 
   private PaginatedToolResponse<R> handleException(
       Exception e, PaginationParams pagination, String requestId, String userMessage) {
@@ -160,7 +160,7 @@ public abstract class PaginatedTool<P extends ToolParams, R> extends BaseTool {
       HttpResponseException e,
       PaginationParams pagination,
       String requestId,
-      WarningCollector collector) {
+      NoticeCollector collector) {
 
     String errorMessage = mapHttpErrorCode(e.getCode());
 
@@ -184,15 +184,15 @@ public abstract class PaginatedTool<P extends ToolParams, R> extends BaseTool {
   private PaginatedToolResponse<R> buildSuccessResponse(
       ExecutionResult<R> result,
       PaginationParams pagination,
-      WarningCollector collector,
+      NoticeCollector collector,
       long duration,
       String requestId) {
 
     if (result.items().isEmpty()
         && result.totalItems() != null
         && result.totalItems() == 0
-        && !collector.hasEmptyResultsWarning()) {
-      collector.warn("No results found matching the specified criteria.");
+        && !collector.hasEmptyResultsNotice()) {
+      collector.notice("No results found matching the specified criteria.");
     }
 
     boolean hasMore = calculateHasMorePages(result, pagination);

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolResponse.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolResponse.java
@@ -19,10 +19,10 @@ import java.util.List;
 
 /**
  * Generic paginated response wrapper for all list-returning MCP tools. Provides consistent
- * pagination metadata, error/warning separation, and timing across all endpoints.
+ * pagination metadata, error/notice separation, and timing across all endpoints.
  *
  * <p>AI agents can use {@link #isSuccess()} to determine if the request succeeded, and examine
- * {@link #errors()} for actionable problems vs {@link #warnings()} for informational messages.
+ * {@link #errors()} for actionable problems vs {@link #notices()} for informational messages.
  *
  * @param <T> The type of items in the paginated response
  * @param items The data for the current page (never null, empty list if no results)
@@ -31,7 +31,8 @@ import java.util.List;
  * @param totalItems Total count across all pages (null if unavailable or expensive to compute)
  * @param hasMorePages true if additional pages exist beyond this page
  * @param errors Validation or execution errors (empty if success) - actionable problems
- * @param warnings Non-fatal warnings (e.g., applied defaults, empty results) - informational
+ * @param notices Informational notices: applied defaults, failed optional enrichments, empty-result
+ *     explanations, interpretation facts
  * @param durationMs Execution duration in milliseconds (null for validation errors)
  */
 public record PaginatedToolResponse<T>(
@@ -41,14 +42,14 @@ public record PaginatedToolResponse<T>(
     Integer totalItems,
     boolean hasMorePages,
     List<String> errors,
-    List<String> warnings,
+    List<String> notices,
     Long durationMs) {
 
   /** Compact constructor ensures non-null, immutable lists. */
   public PaginatedToolResponse {
     items = items != null ? List.copyOf(items) : List.of();
     errors = errors != null ? List.copyOf(errors) : List.of();
-    warnings = warnings != null ? List.copyOf(warnings) : List.of();
+    notices = notices != null ? List.copyOf(notices) : List.of();
   }
 
   /**
@@ -61,14 +62,14 @@ public record PaginatedToolResponse<T>(
   }
 
   /**
-   * Creates a successful response with items and optional warnings.
+   * Creates a successful response with items and optional notices.
    *
    * @param items the response items
    * @param page page number (1-based)
    * @param pageSize items per page
    * @param totalItems total count (null if unavailable)
    * @param hasMorePages true if more pages exist
-   * @param warnings non-fatal warnings
+   * @param notices informational notices
    * @param durationMs execution time in milliseconds
    * @param <T> item type
    * @return successful paginated response
@@ -79,10 +80,10 @@ public record PaginatedToolResponse<T>(
       int pageSize,
       Integer totalItems,
       boolean hasMorePages,
-      List<String> warnings,
+      List<String> notices,
       Long durationMs) {
     return new PaginatedToolResponse<>(
-        items, page, pageSize, totalItems, hasMorePages, List.of(), warnings, durationMs);
+        items, page, pageSize, totalItems, hasMorePages, List.of(), notices, durationMs);
   }
 
   /**
@@ -101,17 +102,17 @@ public record PaginatedToolResponse<T>(
   }
 
   /**
-   * Creates an empty paginated response with a warning message.
+   * Creates an empty paginated response with a notice message.
    *
    * @param page page number (1-based)
    * @param pageSize items per page
-   * @param warningMessage informational message about empty results
+   * @param noticeMessage informational message about empty results
    * @param <T> item type
-   * @return empty response with warning
+   * @return empty response with notice
    */
-  public static <T> PaginatedToolResponse<T> empty(int page, int pageSize, String warningMessage) {
+  public static <T> PaginatedToolResponse<T> empty(int page, int pageSize, String noticeMessage) {
     return new PaginatedToolResponse<>(
-        List.of(), page, pageSize, 0, false, List.of(), List.of(warningMessage), null);
+        List.of(), page, pageSize, 0, false, List.of(), List.of(noticeMessage), null);
   }
 
   /**

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParams.java
@@ -29,18 +29,18 @@ import java.util.List;
  * @param pageSize Validated page size (range: 1-100, default: 50)
  * @param offset Calculated 0-based offset for SDK
  * @param limit Same as pageSize, for SDK clarity
- * @param warnings Validation warnings (soft failures - execution continues with corrected values)
+ * @param notices Validation notices (soft failures - execution continues with corrected values)
  */
 public record PaginationParams(
-    int page, int pageSize, int offset, int limit, List<String> warnings) {
+    int page, int pageSize, int offset, int limit, List<String> notices) {
 
   /**
    * Parse and validate pagination parameters with default max page size. Invalid values are clamped
-   * to acceptable defaults with warnings.
+   * to acceptable defaults with notices.
    *
    * @param page Requested page number (1-based), null defaults to 1
    * @param pageSize Requested page size, null defaults to 50
-   * @return PaginationParams with validated values and warnings
+   * @return PaginationParams with validated values and notices
    */
   public static PaginationParams of(Integer page, Integer pageSize) {
     return of(page, pageSize, MAX_PAGE_SIZE);
@@ -48,30 +48,30 @@ public record PaginationParams(
 
   /**
    * Parse and validate pagination parameters with custom max page size. Invalid values are clamped
-   * to acceptable defaults with warnings.
+   * to acceptable defaults with notices.
    *
    * @param page Requested page number (1-based), null defaults to 1
    * @param pageSize Requested page size, null defaults to 50
    * @param maxPageSize Tool-specific maximum page size (e.g., 50 for APIs with stricter limits)
-   * @return PaginationParams with validated values and warnings
+   * @return PaginationParams with validated values and notices
    */
   public static PaginationParams of(Integer page, Integer pageSize, int maxPageSize) {
-    List<String> warnings = new ArrayList<>();
+    List<String> notices = new ArrayList<>();
 
     // Soft failure: invalid page → clamp to 1
     int actualPage = page != null && page > 0 ? page : 1;
     if (page != null && page < 1) {
-      warnings.add(String.format("Invalid page number %d, using page 1", page));
+      notices.add(String.format("Invalid page number %d, using page 1", page));
     }
 
     // Soft failure: invalid pageSize → clamp to range with tool-specific max
     int actualSize = pageSize != null && pageSize > 0 ? pageSize : DEFAULT_PAGE_SIZE;
     if (pageSize != null && pageSize < 1) {
-      warnings.add(
+      notices.add(
           String.format("Invalid pageSize %d, using default %d", pageSize, DEFAULT_PAGE_SIZE));
       actualSize = DEFAULT_PAGE_SIZE;
     } else if (pageSize != null && pageSize > maxPageSize) {
-      warnings.add(
+      notices.add(
           String.format(
               "Requested pageSize %d exceeds maximum %d, capped to %d",
               pageSize, maxPageSize, maxPageSize));
@@ -83,7 +83,7 @@ public record PaginationParams(
         actualSize,
         (actualPage - 1) * actualSize, // 0-based offset
         actualSize, // limit
-        List.copyOf(warnings));
+        List.copyOf(notices));
   }
 
   /**

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
@@ -68,9 +68,9 @@ public abstract class SingleTool<P extends ToolParams, R> extends BaseTool {
     // 1. Parse tool-specific params (collects all errors)
     var params = paramsSupplier.get();
 
-    // 2. Collector accumulates warnings from all stages
-    var collector = WarningCollector.forContext(Map.of(LoggingKeys.REQUEST_ID, requestId));
-    params.warnings().forEach(collector::warn);
+    // 2. Collector accumulates notices from all stages
+    var collector = NoticeCollector.forContext(Map.of(LoggingKeys.REQUEST_ID, requestId));
+    params.notices().forEach(collector::notice);
 
     // 3. Single validation checkpoint - ALL errors collected
     if (!params.isValid()) {
@@ -117,15 +117,15 @@ public abstract class SingleTool<P extends ToolParams, R> extends BaseTool {
    * Subclasses implement single-item retrieval logic.
    *
    * @param params validated tool-specific params
-   * @param collector warning accumulator - call {@link WarningCollector#warn}, {@link
-   *     WarningCollector#tryFetch}, or {@link WarningCollector#tryRun} to record warnings
+   * @param collector notice accumulator - call {@link NoticeCollector#notice}, {@link
+   *     NoticeCollector#tryFetch}, or {@link NoticeCollector#tryRun} to record notices
    * @return the item, or null if not found
    * @throws Exception any exception from SDK or processing
    */
-  protected abstract R doExecute(P params, WarningCollector collector) throws Exception;
+  protected abstract R doExecute(P params, NoticeCollector collector) throws Exception;
 
   private SingleToolResponse<R> handleException(
-      Exception e, String requestId, String userMessage, WarningCollector collector) {
+      Exception e, String requestId, String userMessage, NoticeCollector collector) {
     log.atWarn()
         .addKeyValue(LoggingKeys.REQUEST_ID, requestId)
         .addKeyValue(LoggingKeys.EXCEPTION_TYPE, e.getClass().getSimpleName())
@@ -135,7 +135,7 @@ public abstract class SingleTool<P extends ToolParams, R> extends BaseTool {
   }
 
   private SingleToolResponse<R> handleHttpResponseException(
-      HttpResponseException e, String requestId, WarningCollector collector) {
+      HttpResponseException e, String requestId, NoticeCollector collector) {
 
     String errorMessage = mapHttpErrorCode(e.getCode());
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolResponse.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolResponse.java
@@ -19,22 +19,23 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Response wrapper for non-paginated tools (get_* tools). Separates errors from warnings like
+ * Response wrapper for non-paginated tools (get_* tools). Separates errors from notices like
  * PaginatedToolResponse.
  *
  * @param <T> the type of data in the response
  * @param data the response data (null if not found or error)
  * @param errors validation or execution errors (empty if success)
- * @param warnings non-fatal warnings (e.g., applied defaults)
+ * @param notices Informational notices: applied defaults, failed optional enrichments, empty-result
+ *     explanations, interpretation facts
  * @param found true if the requested item was found, false if not found or error
  */
 public record SingleToolResponse<T>(
-    T data, List<String> errors, List<String> warnings, boolean found) {
+    T data, List<String> errors, List<String> notices, boolean found) {
 
-  /** Compact constructor ensures non-null, immutable error and warning lists. */
+  /** Compact constructor ensures non-null, immutable error and notice lists. */
   public SingleToolResponse {
     errors = errors != null ? List.copyOf(errors) : List.of();
-    warnings = warnings != null ? List.copyOf(warnings) : List.of();
+    notices = notices != null ? List.copyOf(notices) : List.of();
   }
 
   /**
@@ -47,19 +48,19 @@ public record SingleToolResponse<T>(
   }
 
   /**
-   * Creates a successful response with data and warnings.
+   * Creates a successful response with data and notices.
    *
    * @param data the response data
-   * @param warnings non-fatal warnings
+   * @param notices informational notices
    * @param <T> the data type
    * @return successful response
    */
-  public static <T> SingleToolResponse<T> success(T data, List<String> warnings) {
-    return new SingleToolResponse<>(data, List.of(), warnings, true);
+  public static <T> SingleToolResponse<T> success(T data, List<String> notices) {
+    return new SingleToolResponse<>(data, List.of(), notices, true);
   }
 
   /**
-   * Creates a successful response with data and no warnings.
+   * Creates a successful response with data and no notices.
    *
    * @param data the response data
    * @param <T> the data type
@@ -70,17 +71,17 @@ public record SingleToolResponse<T>(
   }
 
   /**
-   * Creates a not-found response. The message is added to warnings to inform the AI.
+   * Creates a not-found response. The message is added to notices to inform the AI.
    *
    * @param message description of what was not found
-   * @param warnings existing warnings to include
+   * @param notices existing notices to include
    * @param <T> the data type
    * @return not-found response with found=false
    */
-  public static <T> SingleToolResponse<T> notFound(String message, List<String> warnings) {
-    var allWarnings = new ArrayList<>(warnings != null ? warnings : List.of());
-    allWarnings.add(message);
-    return new SingleToolResponse<>(null, List.of(), allWarnings, false);
+  public static <T> SingleToolResponse<T> notFound(String message, List<String> notices) {
+    var allNotices = new ArrayList<>(notices != null ? notices : List.of());
+    allNotices.add(message);
+    return new SingleToolResponse<>(null, List.of(), allNotices, false);
   }
 
   /**

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/ToolParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/ToolParams.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 /**
  * Contract for all tool parameter classes. Implementations use ToolValidationContext to collect
- * errors/warnings during validation.
+ * errors/notices during validation.
  */
 public interface ToolParams {
 
@@ -38,10 +38,9 @@ public interface ToolParams {
   List<String> errors();
 
   /**
-   * Non-fatal warnings (e.g., applied defaults, deprecated values). Execution continues with
-   * warnings.
+   * Informational notices (e.g., applied defaults, deprecated values). Execution continues.
    *
-   * @return immutable list of warning messages
+   * @return immutable list of notice messages
    */
-  List<String> warnings();
+  List<String> notices();
 }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageTool.java
@@ -18,9 +18,9 @@ package com.contrast.labs.ai.mcp.contrast.tool.coverage;
 import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
 import com.contrast.labs.ai.mcp.contrast.result.RouteCoverageResponseLight;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.routecoverage.RouteCoverageBySessionIDAndMetadataRequestExtended;
+import com.contrast.labs.ai.mcp.contrast.tool.base.NoticeCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleTool;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleToolResponse;
-import com.contrast.labs.ai.mcp.contrast.tool.base.WarningCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.coverage.params.RouteCoverageParams;
 import com.contrastsecurity.models.RouteCoverageMetadataLabelValues;
 import java.util.Collections;
@@ -124,7 +124,7 @@ public class GetRouteCoverageTool
 
   @Override
   protected RouteCoverageResponseLight doExecute(
-      RouteCoverageParams params, WarningCollector collector) throws Exception {
+      RouteCoverageParams params, NoticeCollector collector) throws Exception {
 
     // Build request based on parameters
     RouteCoverageBySessionIDAndMetadataRequestExtended request = null;
@@ -136,13 +136,13 @@ public class GetRouteCoverageTool
 
       if (latest == null) {
         log.warn("No session metadata found for application ID: {}", params.appId());
-        collector.warn("Session metadata not available for this application");
+        collector.notice("Session metadata not available for this application");
         return null; // SingleTool converts this to notFound response
       }
 
       if (latest.getAgentSession() == null) {
         log.warn("No agent session found for application ID: {}", params.appId());
-        collector.warn("Agent session not available for this application");
+        collector.notice("Agent session not available for this application");
         return null; // SingleTool converts this to notFound response
       }
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/params/RouteCoverageParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/params/RouteCoverageParams.java
@@ -75,7 +75,7 @@ public class RouteCoverageParams extends BaseToolParams {
         "sessionMetadataName is required when sessionMetadataValue is provided");
 
     // Warn if both useLatestSession and metadata params provided (mutually exclusive)
-    ctx.warnIf(
+    ctx.noticeIf(
         Boolean.TRUE.equals(useLatestSession) && hasName,
         "Both useLatestSession and sessionMetadataName provided - "
             + "useLatestSession takes precedence and sessionMetadata filter will be ignored");

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesTool.java
@@ -18,10 +18,10 @@ package com.contrast.labs.ai.mcp.contrast.tool.library;
 import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.LibraryExtended;
 import com.contrast.labs.ai.mcp.contrast.tool.base.ExecutionResult;
+import com.contrast.labs.ai.mcp.contrast.tool.base.NoticeCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginatedTool;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginatedToolResponse;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginationParams;
-import com.contrast.labs.ai.mcp.contrast.tool.base.WarningCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.library.params.ListApplicationLibrariesParams;
 import com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants;
 import java.util.List;
@@ -97,9 +97,7 @@ public class ListApplicationLibrariesTool
 
   @Override
   protected ExecutionResult<LibraryExtended> doExecute(
-      PaginationParams pagination,
-      ListApplicationLibrariesParams params,
-      WarningCollector collector)
+      PaginationParams pagination, ListApplicationLibrariesParams params, NoticeCollector collector)
       throws Exception {
 
     log.debug("Retrieving libraries for application: {}", params.appId());
@@ -113,7 +111,7 @@ public class ListApplicationLibrariesTool
 
     if (libraries == null || libraries.isEmpty()) {
       if (pagination.offset() == 0 && total == 0) {
-        collector.warnForEmptyResults(
+        collector.noticeForEmptyResults(
             "No libraries found for this application. "
                 + "The application may not have any third-party dependencies, "
                 + "or library data may not have been collected yet.");

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
@@ -22,9 +22,9 @@ import com.contrast.labs.ai.mcp.contrast.sdkextension.data.CveData;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.Library;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.LibraryExtended;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.Server;
+import com.contrast.labs.ai.mcp.contrast.tool.base.NoticeCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleTool;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleToolResponse;
-import com.contrast.labs.ai.mcp.contrast.tool.base.WarningCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.library.params.ListApplicationsByCveParams;
 import java.time.Duration;
 import java.time.Instant;
@@ -89,7 +89,7 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
   }
 
   @Override
-  protected CveData doExecute(ListApplicationsByCveParams params, WarningCollector collector)
+  protected CveData doExecute(ListApplicationsByCveParams params, NoticeCollector collector)
       throws Exception {
 
     log.debug("Retrieving applications vulnerable to CVE: {}", params.cveId());
@@ -106,7 +106,7 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
     var apps = cveData.getApps() != null ? cveData.getApps() : Collections.<App>emptyList();
 
     if (apps.isEmpty()) {
-      collector.warn(
+      collector.notice(
           "No applications found with this CVE. "
               + "The CVE may not affect any libraries in your organization, "
               + "or the CVE ID may be invalid.");
@@ -149,7 +149,7 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
   }
 
   private void enrichAppsWithClassUsage(
-      List<App> apps, List<Library> vulnerableLibs, WarningCollector collector) {
+      List<App> apps, List<Library> vulnerableLibs, NoticeCollector collector) {
 
     for (App app : apps) {
       collector.tryRun(

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectTool.java
@@ -17,9 +17,9 @@ package com.contrast.labs.ai.mcp.contrast.tool.sast;
 
 import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
 import com.contrast.labs.ai.mcp.contrast.result.ScanProject;
+import com.contrast.labs.ai.mcp.contrast.tool.base.NoticeCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleTool;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleToolResponse;
-import com.contrast.labs.ai.mcp.contrast.tool.base.WarningCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.sast.params.GetSastProjectParams;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -71,7 +71,7 @@ public class GetSastProjectTool extends SingleTool<GetSastProjectParams, ScanPro
   }
 
   @Override
-  protected ScanProject doExecute(GetSastProjectParams params, WarningCollector collector)
+  protected ScanProject doExecute(GetSastProjectParams params, NoticeCollector collector)
       throws Exception {
     log.debug("Retrieving scan project details for project: {}", params.projectName());
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/server/SearchServersTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/server/SearchServersTool.java
@@ -18,10 +18,10 @@ package com.contrast.labs.ai.mcp.contrast.tool.server;
 import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
 import com.contrast.labs.ai.mcp.contrast.result.ServerSummary;
 import com.contrast.labs.ai.mcp.contrast.tool.base.ExecutionResult;
+import com.contrast.labs.ai.mcp.contrast.tool.base.NoticeCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginatedTool;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginatedToolResponse;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginationParams;
-import com.contrast.labs.ai.mcp.contrast.tool.base.WarningCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.server.params.ServerFilterParams;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.model.ToolContext;
@@ -147,7 +147,7 @@ public class SearchServersTool extends PaginatedTool<ServerFilterParams, ServerS
 
   @Override
   protected ExecutionResult<ServerSummary> doExecute(
-      PaginationParams pagination, ServerFilterParams params, WarningCollector collector)
+      PaginationParams pagination, ServerFilterParams params, NoticeCollector collector)
       throws Exception {
     var filterBody = params.toServerFilterBody();
     var response =

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/EnumSetSpec.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/EnumSetSpec.java
@@ -55,7 +55,7 @@ public class EnumSetSpec<E extends Enum<E>> {
    * Sets a default value to use when the parameter is null or blank.
    *
    * @param val the default EnumSet value
-   * @param reason explanation for AI feedback (added as warning when default is used)
+   * @param reason explanation for AI feedback (added as a notice when default is used)
    * @return this for fluent chaining
    */
   public EnumSetSpec<E> defaultTo(EnumSet<E> val, String reason) {
@@ -74,7 +74,7 @@ public class EnumSetSpec<E extends Enum<E>> {
 
     if (items == null) {
       if (defaultValue != null) {
-        ctx.addWarning(defaultReason);
+        ctx.addNotice(defaultReason);
         return EnumSet.copyOf(defaultValue);
       }
       return null;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/IntSpec.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/IntSpec.java
@@ -17,7 +17,7 @@ package com.contrast.labs.ai.mcp.contrast.tool.validation;
 
 /**
  * Fluent validation spec for integer parameters. Supports default values and range clamping with
- * warnings.
+ * notices.
  *
  * <p>Usage:
  *
@@ -48,7 +48,7 @@ public class IntSpec {
    * Sets a default value to use when the parameter is null.
    *
    * @param val the default value
-   * @param reason explanation for AI feedback (added as warning when default is used)
+   * @param reason explanation for AI feedback (added as a notice when default is used)
    * @return this for fluent chaining
    */
   public IntSpec defaultTo(int val, String reason) {
@@ -58,7 +58,7 @@ public class IntSpec {
   }
 
   /**
-   * Sets valid range. Values outside range are clamped with a warning.
+   * Sets valid range. Values outside range are clamped with a notice.
    *
    * @param min minimum value (inclusive)
    * @param max maximum value (inclusive)
@@ -78,7 +78,7 @@ public class IntSpec {
   public Integer get() {
     if (value == null) {
       if (defaultValue != null) {
-        ctx.addWarning(defaultReason);
+        ctx.addNotice(defaultReason);
         return defaultValue;
       }
       return null;
@@ -87,10 +87,10 @@ public class IntSpec {
     int result = value;
 
     if (min != null && value < min) {
-      ctx.addWarning(String.format("%s clamped from %d to minimum %d", name, value, min));
+      ctx.addNotice(String.format("%s clamped from %d to minimum %d", name, value, min));
       result = min;
     } else if (max != null && value > max) {
-      ctx.addWarning(String.format("%s clamped from %d to maximum %d", name, value, max));
+      ctx.addNotice(String.format("%s clamped from %d to maximum %d", name, value, max));
       result = max;
     }
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringListSpec.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringListSpec.java
@@ -53,7 +53,7 @@ public class StringListSpec {
    * Sets a default value to use when the parameter is null or blank.
    *
    * @param val the default list value
-   * @param reason explanation for AI feedback (added as warning when default is used)
+   * @param reason explanation for AI feedback (added as a notice when default is used)
    * @return this for fluent chaining
    */
   public StringListSpec defaultTo(List<String> val, String reason) {
@@ -94,7 +94,7 @@ public class StringListSpec {
 
     if (parsed == null) {
       if (defaultValue != null) {
-        ctx.addWarning(defaultReason);
+        ctx.addNotice(defaultReason);
         return List.copyOf(defaultValue);
       }
       return null;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringSpec.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringSpec.java
@@ -55,7 +55,7 @@ public class StringSpec {
    * Sets a default value to use when the parameter is null or blank.
    *
    * @param val the default value
-   * @param reason explanation for AI feedback (added as warning when default is used)
+   * @param reason explanation for AI feedback (added as a notice when default is used)
    * @return this for fluent chaining
    */
   public StringSpec defaultTo(String val, String reason) {
@@ -65,7 +65,7 @@ public class StringSpec {
   }
 
   /**
-   * Sets a default value without adding a warning when the default is used.
+   * Sets a default value without adding a notice when the default is used.
    *
    * @param val the default value
    * @return this for fluent chaining
@@ -119,7 +119,7 @@ public class StringSpec {
 
     if (result == null && defaultValue != null) {
       if (defaultReason != null) {
-        ctx.addWarning(defaultReason);
+        ctx.addNotice(defaultReason);
       }
       result = defaultValue;
     }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContext.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContext.java
@@ -24,8 +24,8 @@ import java.util.UUID;
 import org.springframework.util.StringUtils;
 
 /**
- * Fluent validation context for MCP tool parameters. Collects errors and warnings during
- * validation, providing AI-friendly feedback messages.
+ * Fluent validation context for MCP tool parameters. Collects errors and notices during validation,
+ * providing AI-friendly feedback messages.
  *
  * <p>Usage example:
  *
@@ -48,7 +48,7 @@ import org.springframework.util.StringUtils;
  */
 public class ToolValidationContext implements ToolParams {
 
-  private final List<String> warnings = new ArrayList<>();
+  private final List<String> notices = new ArrayList<>();
   private final List<String> errors = new ArrayList<>();
 
   /**
@@ -260,14 +260,14 @@ public class ToolValidationContext implements ToolParams {
   }
 
   /**
-   * Adds a warning if the condition is true.
+   * Adds a notice if the condition is true.
    *
    * @param condition the condition to check
-   * @param message the warning message if condition is true
+   * @param message the notice message if condition is true
    */
-  public void warnIf(boolean condition, String message) {
+  public void noticeIf(boolean condition, String message) {
     if (condition) {
-      warnings.add(message);
+      notices.add(message);
     }
   }
 
@@ -293,12 +293,12 @@ public class ToolValidationContext implements ToolParams {
   }
 
   /**
-   * Adds a warning message. Protected for use by Spec classes and subclasses.
+   * Adds a notice message. Protected for use by Spec classes and subclasses.
    *
-   * @param message the warning message
+   * @param message the notice message
    */
-  protected void addWarning(String message) {
-    warnings.add(message);
+  protected void addNotice(String message) {
+    notices.add(message);
   }
 
   @Override
@@ -312,7 +312,7 @@ public class ToolValidationContext implements ToolParams {
   }
 
   @Override
-  public List<String> warnings() {
-    return List.copyOf(warnings);
+  public List<String> notices() {
+    return List.copyOf(notices);
   }
 }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
@@ -21,9 +21,9 @@ import com.contrast.labs.ai.mcp.contrast.result.StackLib;
 import com.contrast.labs.ai.mcp.contrast.result.Vulnerability;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.LibraryExtended;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.sca.LibraryObservation;
+import com.contrast.labs.ai.mcp.contrast.tool.base.NoticeCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleTool;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleToolResponse;
-import com.contrast.labs.ai.mcp.contrast.tool.base.WarningCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants;
 import com.contrast.labs.ai.mcp.contrast.tool.vulnerability.params.GetVulnerabilityParams;
 import com.contrastsecurity.http.TraceFilterForm;
@@ -65,7 +65,7 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
           stack traces, and vulnerable library information when available.
 
           Response fields:
-          - hint: AI-generated remediation hint based on vulnerability type
+          - remediationHint: AI-generated remediation hint based on vulnerability type
           - howToFix: Official remediation recommendation from Contrast
           - stackTrace: Stack frames with library hash links (available when trigger events exist)
           - vulnerableLibraries: Libraries in the stack with known CVEs
@@ -76,7 +76,7 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
           - Get vulnerability details: vulnId="VULN-ABC123", appId="app-123"
 
           Note: Some fields may be null if data wasn't captured or isn't available.
-          Warnings indicate retrieval errors (transient failures where retrying may help).
+          Notices indicate retrieval errors (transient failures where retrying may help).
 
           Related tools:
           - search_vulnerabilities: Find vulnerability IDs by filtering on severity, status, etc.
@@ -95,7 +95,7 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
   }
 
   @Override
-  protected Vulnerability doExecute(GetVulnerabilityParams params, WarningCollector collector)
+  protected Vulnerability doExecute(GetVulnerabilityParams params, NoticeCollector collector)
       throws Exception {
 
     // Fetch trace with expanded data
@@ -120,7 +120,7 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
   }
 
   private VulnerabilityContext buildVulnerabilityContext(
-      String vulnId, String appId, WarningCollector collector) {
+      String vulnId, String appId, NoticeCollector collector) {
 
     var recommendationText =
         collector

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesTool.java
@@ -16,9 +16,9 @@
 package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 
 import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
+import com.contrast.labs.ai.mcp.contrast.tool.base.NoticeCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleTool;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleToolResponse;
-import com.contrast.labs.ai.mcp.contrast.tool.base.WarningCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.vulnerability.params.ListVulnerabilityTypesParams;
 import com.contrastsecurity.models.Rules;
 import java.util.List;
@@ -66,12 +66,12 @@ public class ListVulnerabilityTypesTool
   }
 
   @Override
-  protected List<String> doExecute(ListVulnerabilityTypesParams params, WarningCollector collector)
+  protected List<String> doExecute(ListVulnerabilityTypesParams params, NoticeCollector collector)
       throws Exception {
     var rules = contrastApiClient.getRules();
 
     if (rules == null || rules.getRules() == null) {
-      collector.warn("No rules returned from Contrast API");
+      collector.notice("No rules returned from Contrast API");
       return List.of();
     }
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java
@@ -18,10 +18,10 @@ package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
 import com.contrast.labs.ai.mcp.contrast.result.VulnLight;
 import com.contrast.labs.ai.mcp.contrast.tool.base.ExecutionResult;
+import com.contrast.labs.ai.mcp.contrast.tool.base.NoticeCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginatedTool;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginatedToolResponse;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginationParams;
-import com.contrast.labs.ai.mcp.contrast.tool.base.WarningCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.validation.UnresolvedMetadataFilter;
 import com.contrast.labs.ai.mcp.contrast.tool.vulnerability.params.SearchAppVulnerabilitiesParams;
 import com.contrastsecurity.http.TraceFilterForm.TraceExpandValue;
@@ -68,7 +68,7 @@ public class SearchAppVulnerabilitiesTool
 
           Note: useLatestSession and sessionMetadataFilters are mutually exclusive.
           If useLatestSession=true and no sessions exist, returns all vulnerabilities
-          for the application with a warning message.
+          for the application with a notice.
 
           Common usage examples:
           - All vulns in app: appId="abc123"
@@ -184,9 +184,7 @@ public class SearchAppVulnerabilitiesTool
 
   @Override
   protected ExecutionResult<VulnLight> doExecute(
-      PaginationParams pagination,
-      SearchAppVulnerabilitiesParams params,
-      WarningCollector collector)
+      PaginationParams pagination, SearchAppVulnerabilitiesParams params, NoticeCollector collector)
       throws Exception {
 
     var appId = params.appId();
@@ -201,7 +199,7 @@ public class SearchAppVulnerabilitiesTool
         agentSessionId = latestSession.getAgentSession().getAgentSessionId();
         log.debug("Using latest session ID: {}", agentSessionId);
       } else {
-        collector.warn(
+        collector.notice(
             "No sessions found for this application. Returning all vulnerabilities across all"
                 + " sessions for this application.");
         log.warn("No sessions found for application: {}", appId);
@@ -236,7 +234,7 @@ public class SearchAppVulnerabilitiesTool
             appId, filterBody, pagination.limit(), pagination.offset(), expand);
 
     if (traces == null || traces.getTraces() == null) {
-      collector.warn("API returned no trace data. Verify permissions and filters.");
+      collector.notice("API returned no trace data. Verify permissions and filters.");
       return ExecutionResult.empty();
     }
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesTool.java
@@ -18,10 +18,10 @@ package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
 import com.contrast.labs.ai.mcp.contrast.result.VulnLight;
 import com.contrast.labs.ai.mcp.contrast.tool.base.ExecutionResult;
+import com.contrast.labs.ai.mcp.contrast.tool.base.NoticeCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginatedTool;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginatedToolResponse;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginationParams;
-import com.contrast.labs.ai.mcp.contrast.tool.base.WarningCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.vulnerability.params.VulnerabilityFilterParams;
 import com.contrastsecurity.http.TraceFilterForm.TraceExpandValue;
 import java.util.EnumSet;
@@ -65,7 +65,7 @@ public class SearchVulnerabilitiesTool extends PaginatedTool<VulnerabilityFilter
           vulnerability data.
 
           Returns paginated results with metadata including totalItems (when available) and hasMorePages.
-          Check 'warnings' field for informational notices and 'errors' field for validation failures.
+          Check 'notices' for informational context and 'errors' for validation failures.
 
           Response fields:
           - environments: Latest instance only, may omit environments from earlier instances.
@@ -169,7 +169,7 @@ public class SearchVulnerabilitiesTool extends PaginatedTool<VulnerabilityFilter
 
   @Override
   protected ExecutionResult<VulnLight> doExecute(
-      PaginationParams pagination, VulnerabilityFilterParams params, WarningCollector collector)
+      PaginationParams pagination, VulnerabilityFilterParams params, NoticeCollector collector)
       throws Exception {
 
     var filterBody = params.toTraceFilterBody();
@@ -185,7 +185,7 @@ public class SearchVulnerabilitiesTool extends PaginatedTool<VulnerabilityFilter
                 TraceExpandValue.APPLICATION));
 
     if (traces == null || traces.getTraces() == null) {
-      collector.warn("API returned no trace data. Verify permissions and filters.");
+      collector.notice("API returned no trace data. Verify permissions and filters.");
       return ExecutionResult.empty();
     }
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityMapper.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityMapper.java
@@ -80,7 +80,7 @@ public class VulnerabilityMapper {
    * @return Vulnerability object with complete vulnerability information
    */
   public Vulnerability toFullVulnerability(Trace trace, VulnerabilityContext context) {
-    var hint = HintGenerator.generateVulnerabilityFixHint(trace.getRule());
+    var remediationHint = HintGenerator.generateVulnerabilityFixHint(trace.getRule());
 
     // Extract application info safely, handling null cases
     String appId = null;
@@ -91,7 +91,7 @@ public class VulnerabilityMapper {
     }
 
     return new Vulnerability(
-        hint,
+        remediationHint,
         trace.getUuid(),
         trace.getTitle(),
         trace.getRule(),

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParams.java
@@ -121,7 +121,7 @@ public class SearchAppVulnerabilitiesParams extends BaseToolParams {
 
     // Add time filter note if dates were specified
     if (params.lastSeenAfter != null || params.lastSeenBefore != null) {
-      ctx.warnIf(
+      ctx.noticeIf(
           true, "Time filters apply to LAST ACTIVITY DATE (lastTimeSeen), not discovery date.");
     }
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParams.java
@@ -120,10 +120,9 @@ public class SearchAppVulnerabilitiesParams extends BaseToolParams {
         params.lastSeenAfter, params.lastSeenBefore, "lastSeenAfter", "lastSeenBefore");
 
     // Add time filter note if dates were specified
-    if (params.lastSeenAfter != null || params.lastSeenBefore != null) {
-      ctx.noticeIf(
-          true, "Time filters apply to LAST ACTIVITY DATE (lastTimeSeen), not discovery date.");
-    }
+    ctx.noticeIf(
+        params.lastSeenAfter != null || params.lastSeenBefore != null,
+        "Time filters apply to LAST ACTIVITY DATE (lastTimeSeen), not discovery date.");
 
     params.vulnTags = ctx.stringListParam(vulnTagsParam, "vulnTags").get();
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParams.java
@@ -104,10 +104,9 @@ public class VulnerabilityFilterParams extends BaseToolParams {
         params.lastSeenAfter, params.lastSeenBefore, "lastSeenAfter", "lastSeenBefore");
 
     // Add time filter note if dates were specified
-    if (params.lastSeenAfter != null || params.lastSeenBefore != null) {
-      ctx.noticeIf(
-          true, "Time filters apply to LAST ACTIVITY DATE (lastTimeSeen), not discovery date.");
-    }
+    ctx.noticeIf(
+        params.lastSeenAfter != null || params.lastSeenBefore != null,
+        "Time filters apply to LAST ACTIVITY DATE (lastTimeSeen), not discovery date.");
 
     params.vulnTags = ctx.stringListParam(vulnTagsParam, "vulnTags").get();
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParams.java
@@ -105,7 +105,7 @@ public class VulnerabilityFilterParams extends BaseToolParams {
 
     // Add time filter note if dates were specified
     if (params.lastSeenAfter != null || params.lastSeenBefore != null) {
-      ctx.warnIf(
+      ctx.noticeIf(
           true, "Time filters apply to LAST ACTIVITY DATE (lastTimeSeen), not discovery date.");
     }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/result/VulnerabilityTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/result/VulnerabilityTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.result;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class VulnerabilityTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  void serialization_should_expose_remediationHint_without_legacy_hint() throws Exception {
+    var vulnerability =
+        new Vulnerability(
+            "Apply parameterized queries",
+            "vuln-id",
+            "SQL Injection",
+            "sql-injection",
+            "HIGH",
+            "app-id",
+            "Application",
+            null,
+            List.of(),
+            List.of(),
+            null,
+            "Reported",
+            null,
+            null,
+            null,
+            List.of(),
+            List.of(),
+            List.of());
+
+    var json = objectMapper.writeValueAsString(vulnerability);
+
+    assertThat(json)
+        .contains("\"remediationHint\":\"Apply parameterized queries\"")
+        .doesNotContain("\"hint\"");
+  }
+}

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataToolTest.java
@@ -91,7 +91,7 @@ class GetSessionMetadataToolTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.found()).isFalse();
     assertThat(result.data()).isNull();
-    assertThat(result.warnings()).contains("No session metadata found for this application.");
+    assertThat(result.notices()).contains("No session metadata found for this application.");
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolTest.java
@@ -156,7 +156,7 @@ class SearchApplicationsToolTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.items()).isEmpty();
     assertThat(result.pageSize()).isEqualTo(100);
-    assertThat(result.warnings())
+    assertThat(result.notices())
         .contains(
             "Requested pageSize 1000 exceeds maximum 100, capped to 100",
             "No results found matching the specified criteria.");

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/params/GetSessionMetadataParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/params/GetSessionMetadataParamsTest.java
@@ -28,7 +28,7 @@ class GetSessionMetadataParamsTest {
     assertThat(params.isValid()).isTrue();
     assertThat(params.appId()).isEqualTo("app-123");
     assertThat(params.errors()).isEmpty();
-    assertThat(params.warnings()).isEmpty();
+    assertThat(params.notices()).isEmpty();
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolTest.java
@@ -67,7 +67,7 @@ class GetProtectRulesToolTest {
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors()).containsExactly("appId is required");
-    assertThat(result.warnings()).isEmpty();
+    assertThat(result.notices()).isEmpty();
   }
 
   @Test
@@ -76,7 +76,7 @@ class GetProtectRulesToolTest {
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors()).containsExactly("appId is required");
-    assertThat(result.warnings()).isEmpty();
+    assertThat(result.notices()).isEmpty();
   }
 
   @Test
@@ -88,7 +88,7 @@ class GetProtectRulesToolTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.found()).isFalse();
     assertThat(result.data()).isNull();
-    assertThat(result.warnings()).containsExactly("Resource not found");
+    assertThat(result.notices()).containsExactly("Resource not found");
   }
 
   @Test
@@ -101,7 +101,7 @@ class GetProtectRulesToolTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.data().getRules()).isEmpty();
-    assertThat(result.warnings())
+    assertThat(result.notices())
         .containsExactly("Application has Protect enabled but no rules are configured.");
   }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksToolTest.java
@@ -159,7 +159,7 @@ class SearchAttacksToolTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.pageSize()).isEqualTo(100);
-    assertThat(result.warnings())
+    assertThat(result.notices())
         .contains("Requested pageSize 250 exceeds maximum 100, capped to 100");
     verify(contrastApiClient, never()).searchAttacks(any(), eq(250), anyInt(), any());
   }
@@ -174,7 +174,7 @@ class SearchAttacksToolTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.items()).isEmpty();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("API returned no attack data"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("API returned no attack data"));
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParamsTest.java
@@ -105,7 +105,7 @@ class AttackFilterParamsTest {
     assertThat(params.getIncludeSuppressed()).isTrue();
     assertThat(params.getIncludeBotBlockers()).isFalse();
     assertThat(params.getIncludeIpBlacklist()).isTrue();
-    // When includeSuppressed is explicitly set, no default warning
+    // When includeSuppressed is explicitly set, no default notice
     assertThat(params.notices()).noneMatch(w -> w.contains("Excluding suppressed"));
   }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParamsTest.java
@@ -34,7 +34,7 @@ class AttackFilterParamsTest {
     assertThat(params.errors()).isEmpty();
     assertThat(params.getQuickFilter()).isEqualTo("ALL");
     assertThat(params.getIncludeSuppressed()).isFalse();
-    assertThat(params.warnings())
+    assertThat(params.notices())
         .anyMatch(w -> w.contains("No quickFilter applied"))
         .anyMatch(w -> w.contains("Excluding suppressed attacks by default"));
   }
@@ -106,7 +106,7 @@ class AttackFilterParamsTest {
     assertThat(params.getIncludeBotBlockers()).isFalse();
     assertThat(params.getIncludeIpBlacklist()).isTrue();
     // When includeSuppressed is explicitly set, no default warning
-    assertThat(params.warnings()).noneMatch(w -> w.contains("Excluding suppressed"));
+    assertThat(params.notices()).noneMatch(w -> w.contains("Excluding suppressed"));
   }
 
   @Nested

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseToolAuthenticationStrategyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseToolAuthenticationStrategyTest.java
@@ -217,7 +217,7 @@ class BaseToolAuthenticationStrategyTest {
     }
 
     @Override
-    protected String doExecute(TestParams params, WarningCollector collector) {
+    protected String doExecute(TestParams params, NoticeCollector collector) {
       events.add("doExecute");
       return "ok";
     }
@@ -233,7 +233,7 @@ class BaseToolAuthenticationStrategyTest {
 
     @Override
     protected ExecutionResult<String> doExecute(
-        PaginationParams pagination, TestParams params, WarningCollector collector) {
+        PaginationParams pagination, TestParams params, NoticeCollector collector) {
       events.add("doExecute");
       return ExecutionResult.of(List.of("ok"), 1);
     }
@@ -256,7 +256,7 @@ class BaseToolAuthenticationStrategyTest {
     }
 
     @Override
-    public List<String> warnings() {
+    public List<String> notices() {
       return List.of();
     }
   }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
@@ -99,7 +99,7 @@ class CursorPaginatedToolTest {
   }
 
   @Test
-  void executePipeline_should_include_page_size_warnings_without_cursor_value() {
+  void executePipeline_should_include_page_size_notices_without_cursor_value() {
     tool.setDoExecuteHandler(
         (pagination, params, collector) -> CursorExecutionResult.of(List.of("item"), null, false));
 
@@ -107,29 +107,29 @@ class CursorPaginatedToolTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.pageSize()).isEqualTo(50);
-    assertThat(result.warnings())
+    assertThat(result.notices())
         .singleElement()
-        .satisfies(warning -> assertThat(warning).contains("Invalid pageSize 0"));
-    assertThat(result.warnings()).noneMatch(warning -> warning.contains(OPAQUE_CURSOR));
+        .satisfies(notice -> assertThat(notice).contains("Invalid pageSize 0"));
+    assertThat(result.notices()).noneMatch(notice -> notice.contains(OPAQUE_CURSOR));
   }
 
   @Test
-  void executePipeline_should_preserve_warnings_when_http_response_exception_occurs() {
+  void executePipeline_should_preserve_notices_when_http_response_exception_occurs() {
     tool.setDoExecuteHandler(
         (pagination, params, collector) -> {
-          collector.warn("Warning added before exception");
+          collector.notice("Notice added before exception");
           throw new HttpResponseException("Expired cursor", "GET", "/api/test", 400, "Bad Request");
         });
 
     var result =
-        tool.executePipeline(OPAQUE_CURSOR, 25, () -> TestParams.withWarning("Initial warning"));
+        tool.executePipeline(OPAQUE_CURSOR, 25, () -> TestParams.withNotice("Initial notice"));
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors()).containsExactly("API error (HTTP 400)");
     assertThat(result.errors()).noneMatch(error -> error.contains(OPAQUE_CURSOR));
-    assertThat(result.warnings())
-        .containsExactlyInAnyOrder("Initial warning", "Warning added before exception");
-    assertThat(result.warnings()).noneMatch(warning -> warning.contains(OPAQUE_CURSOR));
+    assertThat(result.notices())
+        .containsExactlyInAnyOrder("Initial notice", "Notice added before exception");
+    assertThat(result.notices()).noneMatch(notice -> notice.contains(OPAQUE_CURSOR));
   }
 
   @Test
@@ -220,7 +220,7 @@ class CursorPaginatedToolTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.items()).isEmpty();
-    assertThat(result.warnings())
+    assertThat(result.notices())
         .containsExactly("No results found matching the specified criteria.");
   }
 
@@ -228,7 +228,7 @@ class CursorPaginatedToolTest {
   void executePipeline_should_not_add_generic_empty_warning_when_tool_explains_empty_result() {
     tool.setDoExecuteHandler(
         (pagination, params, collector) -> {
-          collector.warnForEmptyResults("No cursor widgets found.");
+          collector.noticeForEmptyResults("No cursor widgets found.");
           return CursorExecutionResult.of(List.of(), null, false);
         });
 
@@ -236,7 +236,7 @@ class CursorPaginatedToolTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.items()).isEmpty();
-    assertThat(result.warnings()).containsExactly("No cursor widgets found.");
+    assertThat(result.notices()).containsExactly("No cursor widgets found.");
   }
 
   private static class TestCursorTool extends CursorPaginatedTool<TestParams, String> {
@@ -248,7 +248,7 @@ class CursorPaginatedToolTest {
 
     @Override
     protected CursorExecutionResult<String> doExecute(
-        CursorPaginationParams pagination, TestParams params, WarningCollector collector)
+        CursorPaginationParams pagination, TestParams params, NoticeCollector collector)
         throws Exception {
       if (handler != null) {
         return handler.execute(pagination, params, collector);
@@ -259,12 +259,12 @@ class CursorPaginatedToolTest {
     @FunctionalInterface
     interface DoExecuteHandler {
       CursorExecutionResult<String> execute(
-          CursorPaginationParams pagination, TestParams params, WarningCollector collector)
+          CursorPaginationParams pagination, TestParams params, NoticeCollector collector)
           throws Exception;
     }
   }
 
-  private record TestParams(boolean isValid, List<String> errors, List<String> warnings)
+  private record TestParams(boolean isValid, List<String> errors, List<String> notices)
       implements ToolParams {
 
     static TestParams valid() {
@@ -275,8 +275,8 @@ class CursorPaginatedToolTest {
       return new TestParams(false, List.of(error), List.of());
     }
 
-    static TestParams withWarning(String warning) {
-      return new TestParams(true, List.of(), List.of(warning));
+    static TestParams withNotice(String notice) {
+      return new TestParams(true, List.of(), List.of(notice));
     }
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
@@ -212,7 +212,7 @@ class CursorPaginatedToolTest {
   }
 
   @Test
-  void executePipeline_should_add_empty_results_warning() {
+  void executePipeline_should_add_empty_results_notice() {
     tool.setDoExecuteHandler(
         (pagination, params, collector) -> CursorExecutionResult.of(List.of(), null, false));
 
@@ -225,7 +225,7 @@ class CursorPaginatedToolTest {
   }
 
   @Test
-  void executePipeline_should_not_add_generic_empty_warning_when_tool_explains_empty_result() {
+  void executePipeline_should_not_add_generic_empty_notice_when_tool_explains_empty_result() {
     tool.setDoExecuteHandler(
         (pagination, params, collector) -> {
           collector.noticeForEmptyResults("No cursor widgets found.");

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParamsTest.java
@@ -33,7 +33,7 @@ class CursorPaginationParamsTest {
     assertThat(params.pageSize()).isEqualTo(50);
     assertThat(params.limit()).isEqualTo(50);
     assertThat(params.cursorPresence()).isEqualTo("absent");
-    assertThat(params.warnings()).isEmpty();
+    assertThat(params.notices()).isEmpty();
     assertThat(params.isValid()).isTrue();
   }
 
@@ -45,7 +45,7 @@ class CursorPaginationParamsTest {
     assertThat(params.cursorPresence()).isEqualTo("present");
     assertThat(params.pageSize()).isEqualTo(25);
     assertThat(params.limit()).isEqualTo(25);
-    assertThat(params.warnings()).isEmpty();
+    assertThat(params.notices()).isEmpty();
   }
 
   @Test
@@ -61,10 +61,10 @@ class CursorPaginationParamsTest {
     var params = CursorPaginationParams.of(OPAQUE_CURSOR, 0);
 
     assertThat(params.pageSize()).isEqualTo(50);
-    assertThat(params.warnings())
+    assertThat(params.notices())
         .singleElement()
-        .satisfies(warning -> assertThat(warning).contains("Invalid pageSize 0"));
-    assertThat(params.warnings()).noneMatch(warning -> warning.contains(OPAQUE_CURSOR));
+        .satisfies(notice -> assertThat(notice).contains("Invalid pageSize 0"));
+    assertThat(params.notices()).noneMatch(notice -> notice.contains(OPAQUE_CURSOR));
   }
 
   @Test
@@ -72,11 +72,11 @@ class CursorPaginationParamsTest {
     var params = CursorPaginationParams.of(OPAQUE_CURSOR, 200);
 
     assertThat(params.pageSize()).isEqualTo(100);
-    assertThat(params.warnings())
+    assertThat(params.notices())
         .singleElement()
         .satisfies(
-            warning -> assertThat(warning).contains("Requested pageSize 200 exceeds maximum 100"));
-    assertThat(params.warnings()).noneMatch(warning -> warning.contains(OPAQUE_CURSOR));
+            notice -> assertThat(notice).contains("Requested pageSize 200 exceeds maximum 100"));
+    assertThat(params.notices()).noneMatch(notice -> notice.contains(OPAQUE_CURSOR));
   }
 
   @Test
@@ -84,10 +84,10 @@ class CursorPaginationParamsTest {
     var params = CursorPaginationParams.of(OPAQUE_CURSOR, 100, 50);
 
     assertThat(params.pageSize()).isEqualTo(50);
-    assertThat(params.warnings())
+    assertThat(params.notices())
         .singleElement()
         .satisfies(
-            warning -> assertThat(warning).contains("Requested pageSize 100 exceeds maximum 50"));
+            notice -> assertThat(notice).contains("Requested pageSize 100 exceeds maximum 50"));
   }
 
   @Test
@@ -98,15 +98,15 @@ class CursorPaginationParamsTest {
             .toList();
 
     assertThat(componentNames)
-        .containsExactly("cursor", "pageSize", "limit", "warnings")
+        .containsExactly("cursor", "pageSize", "limit", "notices")
         .doesNotContain("page", "offset", "totalPages", "totalItems");
   }
 
   @Test
-  void warnings_should_be_immutable() {
+  void notices_should_be_immutable() {
     var params = CursorPaginationParams.of(null, -1);
 
-    assertThatThrownBy(() -> params.warnings().add("mutated"))
+    assertThatThrownBy(() -> params.notices().add("mutated"))
         .isInstanceOf(UnsupportedOperationException.class);
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorToolResponseTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorToolResponseTest.java
@@ -34,7 +34,7 @@ class CursorToolResponseTest {
     assertThat(response.nextCursor()).isEqualTo("next-opaque-token");
     assertThat(response.hasMore()).isTrue();
     assertThat(response.errors()).isEmpty();
-    assertThat(response.warnings()).isEmpty();
+    assertThat(response.notices()).isEmpty();
     assertThat(response.durationMs()).isEqualTo(10L);
     assertThat(response.isSuccess()).isTrue();
   }
@@ -61,7 +61,7 @@ class CursorToolResponseTest {
     assertThat(response.nextCursor()).isNull();
     assertThat(response.hasMore()).isFalse();
     assertThat(response.errors()).containsExactly("Invalid cursor");
-    assertThat(response.warnings()).isEmpty();
+    assertThat(response.notices()).isEmpty();
   }
 
   @Test
@@ -85,7 +85,7 @@ class CursorToolResponseTest {
 
     assertThat(componentNames)
         .containsExactly(
-            "items", "pageSize", "nextCursor", "hasMore", "errors", "warnings", "durationMs")
+            "items", "pageSize", "nextCursor", "hasMore", "errors", "notices", "durationMs")
         .doesNotContain("page", "offset", "totalPages", "totalItems", "hasMorePages");
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/NoticeCollectorTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/NoticeCollectorTest.java
@@ -23,17 +23,17 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class WarningCollectorTest {
+class NoticeCollectorTest {
 
-  private WarningCollector collector;
+  private NoticeCollector collector;
 
   @BeforeEach
   void setUp() {
-    collector = WarningCollector.forContext(Map.of());
+    collector = NoticeCollector.forContext(Map.of());
   }
 
   @Test
-  void tryFetch_should_return_empty_without_warning_when_supplier_returns_null() {
+  void tryFetch_should_return_empty_without_notice_when_supplier_returns_null() {
     var result = collector.<String>tryFetch("Optional data", () -> null);
 
     assertThat(result).isEmpty();
@@ -49,7 +49,7 @@ class WarningCollectorTest {
   }
 
   @Test
-  void tryFetch_should_return_empty_and_record_warning_when_supplier_throws() {
+  void tryFetch_should_return_empty_and_record_notice_when_supplier_throws() {
     var result =
         collector.<String>tryFetch(
             "Optional data",
@@ -71,7 +71,7 @@ class WarningCollectorTest {
   }
 
   @Test
-  void tryRun_should_return_false_and_record_warning_when_operation_throws() {
+  void tryRun_should_return_false_and_record_notice_when_operation_throws() {
     var success =
         collector.tryRun(
             "Stack trace data",
@@ -85,7 +85,7 @@ class WarningCollectorTest {
   }
 
   @Test
-  void tryFetch_should_indicate_retrieval_error_in_warning_when_supplier_throws() {
+  void tryFetch_should_indicate_retrieval_error_in_notice_when_supplier_throws() {
     collector.<String>tryFetch(
         "HTTP request data",
         () -> {
@@ -97,7 +97,7 @@ class WarningCollectorTest {
   }
 
   @Test
-  void tryRun_should_indicate_retrieval_error_in_warning_when_operation_throws() {
+  void tryRun_should_indicate_retrieval_error_in_notice_when_operation_throws() {
     collector.tryRun(
         "Stack trace data",
         () -> {
@@ -109,35 +109,35 @@ class WarningCollectorTest {
   }
 
   @Test
-  void warn_should_unconditionally_append_warning() {
-    collector.warn("Something happened");
+  void notice_should_unconditionally_append_notice() {
+    collector.notice("Something happened");
 
     assertThat(collector.snapshot()).containsExactly("Something happened");
   }
 
   @Test
-  void warnForEmptyResults_should_append_warning_and_mark_empty_result_explained() {
-    collector.warnForEmptyResults("No domain objects found");
+  void noticeForEmptyResults_should_append_notice_and_mark_empty_result_explained() {
+    collector.noticeForEmptyResults("No domain objects found");
 
     assertThat(collector.snapshot()).containsExactly("No domain objects found");
-    assertThat(collector.hasEmptyResultsWarning()).isTrue();
+    assertThat(collector.hasEmptyResultsNotice()).isTrue();
   }
 
   @Test
-  void warn_should_throw_when_message_is_null() {
-    assertThatThrownBy(() -> collector.warn(null)).isInstanceOf(NullPointerException.class);
+  void notice_should_throw_when_message_is_null() {
+    assertThatThrownBy(() -> collector.notice(null)).isInstanceOf(NullPointerException.class);
   }
 
   @Test
-  void warn_should_silently_skip_when_message_is_blank() {
-    collector.warn("");
-    collector.warn("   ");
+  void notice_should_silently_skip_when_message_is_blank() {
+    collector.notice("");
+    collector.notice("   ");
 
     assertThat(collector.snapshot()).isEmpty();
   }
 
   @Test
-  void multiple_failed_fetches_should_accumulate_warnings_independently() {
+  void multiple_failed_fetches_should_accumulate_notices_independently() {
     collector.<String>tryFetch(
         "First data",
         () -> {
@@ -158,7 +158,7 @@ class WarningCollectorTest {
   }
 
   @Test
-  void tryFetch_should_include_http_status_code_in_warning_when_http_exception_thrown() {
+  void tryFetch_should_include_http_status_code_in_notice_when_http_exception_thrown() {
     collector.<String>tryFetch(
         "Stack trace data",
         () -> {
@@ -171,7 +171,7 @@ class WarningCollectorTest {
   }
 
   @Test
-  void tryRun_should_include_http_status_code_in_warning_when_http_exception_thrown() {
+  void tryRun_should_include_http_status_code_in_notice_when_http_exception_thrown() {
     collector.tryRun(
         "Class usage data",
         () -> {
@@ -185,12 +185,12 @@ class WarningCollectorTest {
 
   @Test
   void snapshot_should_return_immutable_copy() {
-    collector.warn("existing warning");
+    collector.notice("existing notice");
 
     var snapshot = collector.snapshot();
     assertThatThrownBy(() -> snapshot.add("injected"))
         .isInstanceOf(UnsupportedOperationException.class);
 
-    assertThat(collector.snapshot()).containsExactly("existing warning");
+    assertThat(collector.snapshot()).containsExactly("existing notice");
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolResponseTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolResponseTest.java
@@ -31,20 +31,20 @@ class PaginatedToolResponseTest {
 
     assertThat(response.items()).containsExactly("item1");
     assertThat(response.errors()).isEmpty();
-    assertThat(response.warnings()).isEmpty();
+    assertThat(response.notices()).isEmpty();
     assertThat(response.isSuccess()).isTrue();
     assertThat(response.durationMs()).isEqualTo(100L);
   }
 
   @Test
-  void success_should_includeWarnings() {
+  void success_should_includeNotices() {
     var response =
         PaginatedToolResponse.success(
             List.of("item1"), 1, 50, 1, false, List.of("Applied default status"), 100L);
 
     assertThat(response.items()).containsExactly("item1");
     assertThat(response.errors()).isEmpty();
-    assertThat(response.warnings()).containsExactly("Applied default status");
+    assertThat(response.notices()).containsExactly("Applied default status");
     assertThat(response.isSuccess()).isTrue();
   }
 
@@ -59,7 +59,7 @@ class PaginatedToolResponseTest {
     assertThat(response.items()).isEmpty();
     assertThat(response.errors())
         .containsExactly("Invalid severity: CRIT", "Invalid status: UNKNOWN");
-    assertThat(response.warnings()).isEmpty();
+    assertThat(response.notices()).isEmpty();
     assertThat(response.isSuccess()).isFalse();
     assertThat(response.totalItems()).isEqualTo(0);
     assertThat(response.durationMs()).isNull();
@@ -73,7 +73,7 @@ class PaginatedToolResponseTest {
 
     assertThat(response.items()).isEmpty();
     assertThat(response.errors()).containsExactly("Page 2 exceeds available pages");
-    assertThat(response.warnings()).isEmpty();
+    assertThat(response.notices()).isEmpty();
     assertThat(response.isSuccess()).isFalse();
     assertThat(response.page()).isEqualTo(2);
     assertThat(response.pageSize()).isEqualTo(25);
@@ -82,12 +82,12 @@ class PaginatedToolResponseTest {
   // ========== empty() factory method tests ==========
 
   @Test
-  void empty_should_createEmptyResponseWithWarning() {
+  void empty_should_createEmptyResponseWithNotice() {
     var response = PaginatedToolResponse.empty(1, 50, "No items found.");
 
     assertThat(response.items()).isEmpty();
     assertThat(response.errors()).isEmpty();
-    assertThat(response.warnings()).containsExactly("No items found.");
+    assertThat(response.notices()).containsExactly("No items found.");
     assertThat(response.isSuccess()).isTrue();
   }
 
@@ -126,10 +126,10 @@ class PaginatedToolResponseTest {
   }
 
   @Test
-  void compactConstructor_should_ensureNonNullLists_whenWarningsNull() {
+  void compactConstructor_should_ensureNonNullLists_whenNoticesNull() {
     var response = new PaginatedToolResponse<>(List.of(), 1, 50, 0, false, List.of(), null, null);
 
-    assertThat(response.warnings()).isNotNull().isEmpty();
+    assertThat(response.notices()).isNotNull().isEmpty();
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolResponseTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolResponseTest.java
@@ -103,7 +103,7 @@ class PaginatedToolResponseTest {
   @Test
   void isSuccess_should_returnTrueWhenNoErrors() {
     var response =
-        PaginatedToolResponse.success(List.of(), 1, 50, 0, false, List.of("warning"), null);
+        PaginatedToolResponse.success(List.of(), 1, 50, 0, false, List.of("notice"), null);
 
     assertThat(response.isSuccess()).isTrue();
   }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolTest.java
@@ -254,7 +254,7 @@ class PaginatedToolTest {
   }
 
   @Test
-  void executePipeline_should_add_empty_results_warning() {
+  void executePipeline_should_add_empty_results_notice() {
     tool.setDoExecuteHandler((pagination, params, collector) -> ExecutionResult.of(List.of(), 0));
 
     var result = tool.executePipeline(1, 10, () -> TestParams.valid());
@@ -265,7 +265,7 @@ class PaginatedToolTest {
   }
 
   @Test
-  void executePipeline_should_not_add_generic_empty_warning_when_tool_explains_empty_result() {
+  void executePipeline_should_not_add_generic_empty_notice_when_tool_explains_empty_result() {
     tool.setDoExecuteHandler(
         (pagination, params, collector) -> {
           collector.noticeForEmptyResults("No widgets found for this account.");

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolTest.java
@@ -162,7 +162,7 @@ class PaginatedToolTest {
   @Test
   void executePipeline_should_not_expose_exception_message_in_error() {
     tool.setDoExecuteHandler(
-        (pagination, params, warnings) -> {
+        (pagination, params, notices) -> {
           throw new RuntimeException("sensitive: /api/ng/org-id/traces");
         });
 
@@ -261,14 +261,14 @@ class PaginatedToolTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.items()).isEmpty();
-    assertThat(result.warnings()).contains("No results found matching the specified criteria.");
+    assertThat(result.notices()).contains("No results found matching the specified criteria.");
   }
 
   @Test
   void executePipeline_should_not_add_generic_empty_warning_when_tool_explains_empty_result() {
     tool.setDoExecuteHandler(
         (pagination, params, collector) -> {
-          collector.warnForEmptyResults("No widgets found for this account.");
+          collector.noticeForEmptyResults("No widgets found for this account.");
           return ExecutionResult.of(List.of(), 0);
         });
 
@@ -277,43 +277,43 @@ class PaginatedToolTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.items()).isEmpty();
     assertThat(result.totalItems()).isZero();
-    assertThat(result.warnings()).containsExactly("No widgets found for this account.");
+    assertThat(result.notices()).containsExactly("No widgets found for this account.");
   }
 
   @Test
-  void executePipeline_should_include_pagination_warnings() {
+  void executePipeline_should_include_pagination_notices() {
     tool.setDoExecuteHandler(
         (pagination, params, collector) -> ExecutionResult.of(List.of("item"), 1));
 
     var result = tool.executePipeline(-1, 10, () -> TestParams.valid()); // Invalid page
 
     assertThat(result.isSuccess()).isTrue();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("Invalid page number"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("Invalid page number"));
   }
 
   @Test
-  void executePipeline_should_include_params_warnings() {
+  void executePipeline_should_include_params_notices() {
     tool.setDoExecuteHandler(
         (pagination, params, collector) -> ExecutionResult.of(List.of("item"), 1));
 
-    var result = tool.executePipeline(1, 10, () -> TestParams.withWarning("Deprecated parameter"));
+    var result = tool.executePipeline(1, 10, () -> TestParams.withNotice("Deprecated parameter"));
 
     assertThat(result.isSuccess()).isTrue();
-    assertThat(result.warnings()).contains("Deprecated parameter");
+    assertThat(result.notices()).contains("Deprecated parameter");
   }
 
   @Test
-  void executePipeline_should_allow_doExecute_to_add_warnings() {
+  void executePipeline_should_allow_doExecute_to_add_notices() {
     tool.setDoExecuteHandler(
         (pagination, params, collector) -> {
-          collector.warn("Session filtering applied");
+          collector.notice("Session filtering applied");
           return ExecutionResult.of(List.of("item"), 1);
         });
 
     var result = tool.executePipeline(1, 10, () -> TestParams.valid());
 
     assertThat(result.isSuccess()).isTrue();
-    assertThat(result.warnings()).contains("Session filtering applied");
+    assertThat(result.notices()).contains("Session filtering applied");
   }
 
   @Test
@@ -329,20 +329,20 @@ class PaginatedToolTest {
   }
 
   @Test
-  void executePipeline_should_preserve_warnings_when_http_response_exception_occurs() {
+  void executePipeline_should_preserve_notices_when_http_response_exception_occurs() {
     tool.setDoExecuteHandler(
         (pagination, params, collector) -> {
-          collector.warn("Warning added before exception");
+          collector.notice("Notice added before exception");
           throw new HttpResponseException(
               "Rate limited", "GET", "/api/test", 429, "Too Many Requests");
         });
 
-    var result = tool.executePipeline(1, 10, () -> TestParams.withWarning("Initial warning"));
+    var result = tool.executePipeline(1, 10, () -> TestParams.withNotice("Initial notice"));
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors()).containsExactly("Rate limit exceeded. Retry after a brief pause.");
-    assertThat(result.warnings())
-        .containsExactlyInAnyOrder("Initial warning", "Warning added before exception");
+    assertThat(result.notices())
+        .containsExactlyInAnyOrder("Initial notice", "Notice added before exception");
   }
 
   // Test implementation of PaginatedTool
@@ -355,7 +355,7 @@ class PaginatedToolTest {
 
     @Override
     protected ExecutionResult<String> doExecute(
-        PaginationParams pagination, TestParams params, WarningCollector collector)
+        PaginationParams pagination, TestParams params, NoticeCollector collector)
         throws Exception {
       if (handler != null) {
         return handler.execute(pagination, params, collector);
@@ -366,13 +366,13 @@ class PaginatedToolTest {
     @FunctionalInterface
     interface DoExecuteHandler {
       ExecutionResult<String> execute(
-          PaginationParams pagination, TestParams params, WarningCollector collector)
+          PaginationParams pagination, TestParams params, NoticeCollector collector)
           throws Exception;
     }
   }
 
   // Test params implementation
-  private record TestParams(boolean isValid, List<String> errors, List<String> warnings)
+  private record TestParams(boolean isValid, List<String> errors, List<String> notices)
       implements ToolParams {
 
     static TestParams valid() {
@@ -383,8 +383,8 @@ class PaginatedToolTest {
       return new TestParams(false, List.of(error), List.of());
     }
 
-    static TestParams withWarning(String warning) {
-      return new TestParams(true, List.of(), List.of(warning));
+    static TestParams withNotice(String notice) {
+      return new TestParams(true, List.of(), List.of(notice));
     }
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsTest.java
@@ -30,7 +30,7 @@ class PaginationParamsTest {
     assertThat(params.pageSize()).isEqualTo(50);
     assertThat(params.offset()).isEqualTo(0);
     assertThat(params.limit()).isEqualTo(50);
-    assertThat(params.warnings()).isEmpty();
+    assertThat(params.notices()).isEmpty();
     assertThat(params.isValid()).isTrue();
   }
 
@@ -42,7 +42,7 @@ class PaginationParamsTest {
     assertThat(params.pageSize()).isEqualTo(25);
     assertThat(params.offset()).isEqualTo(50); // (3-1) * 25
     assertThat(params.limit()).isEqualTo(25);
-    assertThat(params.warnings()).isEmpty();
+    assertThat(params.notices()).isEmpty();
     assertThat(params.isValid()).isTrue();
   }
 
@@ -54,8 +54,8 @@ class PaginationParamsTest {
     assertThat(params.pageSize()).isEqualTo(50);
     assertThat(params.offset()).isEqualTo(0);
     assertThat(params.isValid()).isTrue(); // Always valid with soft failures
-    assertThat(params.warnings().size()).isEqualTo(1);
-    assertThat(params.warnings().get(0)).contains("Invalid page number -5");
+    assertThat(params.notices().size()).isEqualTo(1);
+    assertThat(params.notices().get(0)).contains("Invalid page number -5");
   }
 
   @Test
@@ -66,8 +66,8 @@ class PaginationParamsTest {
     assertThat(params.pageSize()).isEqualTo(50);
     assertThat(params.offset()).isEqualTo(0);
     assertThat(params.isValid()).isTrue();
-    assertThat(params.warnings().size()).isEqualTo(1);
-    assertThat(params.warnings().get(0)).contains("Invalid page number 0");
+    assertThat(params.notices().size()).isEqualTo(1);
+    assertThat(params.notices().get(0)).contains("Invalid page number 0");
   }
 
   @Test
@@ -78,8 +78,8 @@ class PaginationParamsTest {
     assertThat(params.pageSize()).isEqualTo(50); // Clamped to default 50
     assertThat(params.offset()).isEqualTo(0);
     assertThat(params.isValid()).isTrue();
-    assertThat(params.warnings().size()).isEqualTo(1);
-    assertThat(params.warnings().get(0)).contains("Invalid pageSize -10");
+    assertThat(params.notices().size()).isEqualTo(1);
+    assertThat(params.notices().get(0)).contains("Invalid pageSize -10");
   }
 
   @Test
@@ -90,8 +90,8 @@ class PaginationParamsTest {
     assertThat(params.pageSize()).isEqualTo(50); // Clamped to default 50
     assertThat(params.offset()).isEqualTo(0);
     assertThat(params.isValid()).isTrue();
-    assertThat(params.warnings().size()).isEqualTo(1);
-    assertThat(params.warnings().get(0)).contains("Invalid pageSize 0");
+    assertThat(params.notices().size()).isEqualTo(1);
+    assertThat(params.notices().get(0)).contains("Invalid pageSize 0");
   }
 
   @Test
@@ -102,21 +102,21 @@ class PaginationParamsTest {
     assertThat(params.pageSize()).isEqualTo(100); // Capped to 100
     assertThat(params.offset()).isEqualTo(0);
     assertThat(params.isValid()).isTrue();
-    assertThat(params.warnings().size()).isEqualTo(1);
-    assertThat(params.warnings().get(0)).contains("Requested pageSize 200 exceeds maximum 100");
+    assertThat(params.notices().size()).isEqualTo(1);
+    assertThat(params.notices().get(0)).contains("Requested pageSize 200 exceeds maximum 100");
   }
 
   @Test
-  void testMultipleValidationWarnings() {
+  void testMultipleValidationNotices() {
     var params = PaginationParams.of(-5, 200);
 
     assertThat(params.page()).isEqualTo(1); // Clamped to 1
     assertThat(params.pageSize()).isEqualTo(100); // Capped to 100
     assertThat(params.offset()).isEqualTo(0);
     assertThat(params.isValid()).isTrue();
-    assertThat(params.warnings().size()).isEqualTo(2);
-    assertThat(params.warnings().get(0)).contains("Invalid page number -5");
-    assertThat(params.warnings().get(1)).contains("Requested pageSize 200 exceeds maximum 100");
+    assertThat(params.notices().size()).isEqualTo(2);
+    assertThat(params.notices().get(0)).contains("Invalid page number -5");
+    assertThat(params.notices().get(1)).contains("Requested pageSize 200 exceeds maximum 100");
   }
 
   @Test
@@ -147,27 +147,27 @@ class PaginationParamsTest {
     // Min valid
     var pMin = PaginationParams.of(1, 1);
     assertThat(pMin.pageSize()).isEqualTo(1);
-    assertThat(pMin.warnings()).isEmpty();
+    assertThat(pMin.notices()).isEmpty();
 
     // Max valid
     var pMax = PaginationParams.of(1, 100);
     assertThat(pMax.pageSize()).isEqualTo(100);
-    assertThat(pMax.warnings()).isEmpty();
+    assertThat(pMax.notices()).isEmpty();
 
     // Just over max
     var pOver = PaginationParams.of(1, 101);
     assertThat(pOver.pageSize()).isEqualTo(100);
-    assertThat(pOver.warnings().size()).isEqualTo(1);
+    assertThat(pOver.notices().size()).isEqualTo(1);
   }
 
   @Test
-  void testWarningsAreImmutable() {
+  void testNoticesAreImmutable() {
     var params = PaginationParams.of(-1, 200);
 
     // Should throw UnsupportedOperationException
     assertThatThrownBy(
             () -> {
-              params.warnings().add("This should fail");
+              params.notices().add("This should fail");
             })
         .isInstanceOf(UnsupportedOperationException.class);
   }
@@ -179,8 +179,8 @@ class PaginationParamsTest {
 
     assertThat(params.page()).isEqualTo(1);
     assertThat(params.pageSize()).isEqualTo(50); // Capped to custom max 50
-    assertThat(params.warnings()).hasSize(1);
-    assertThat(params.warnings().get(0)).contains("Requested pageSize 100 exceeds maximum 50");
+    assertThat(params.notices()).hasSize(1);
+    assertThat(params.notices().get(0)).contains("Requested pageSize 100 exceeds maximum 50");
   }
 
   @Test
@@ -190,7 +190,7 @@ class PaginationParamsTest {
 
     assertThat(params.page()).isEqualTo(1);
     assertThat(params.pageSize()).isEqualTo(30);
-    assertThat(params.warnings()).isEmpty();
+    assertThat(params.notices()).isEmpty();
   }
 
   @Test
@@ -200,6 +200,6 @@ class PaginationParamsTest {
 
     assertThat(params.page()).isEqualTo(1);
     assertThat(params.pageSize()).isEqualTo(50);
-    assertThat(params.warnings()).isEmpty();
+    assertThat(params.notices()).isEmpty();
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/ResponseEnvelopeSerializationTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/ResponseEnvelopeSerializationTest.java
@@ -50,9 +50,24 @@ class ResponseEnvelopeSerializationTest {
     assertNoticesWireShape(response);
   }
 
+  @Test
+  void responseEnvelopes_should_serialize_empty_notices_arrays() throws Exception {
+    assertEmptyNoticesWireShape(
+        PaginatedToolResponse.success(List.of("item"), 1, 50, 1, false, List.of(), 1L));
+    assertEmptyNoticesWireShape(SingleToolResponse.success("item", List.of()));
+    assertEmptyNoticesWireShape(
+        CursorToolResponse.success(List.of("item"), 50, null, false, List.of(), 1L));
+  }
+
   private void assertNoticesWireShape(Object response) throws Exception {
     var json = objectMapper.writeValueAsString(response);
 
     assertThat(json).contains("\"notices\":[").doesNotContain("\"warnings\"");
+  }
+
+  private void assertEmptyNoticesWireShape(Object response) throws Exception {
+    var json = objectMapper.writeValueAsString(response);
+
+    assertThat(json).contains("\"notices\":[]").doesNotContain("\"warnings\"");
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/ResponseEnvelopeSerializationTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/ResponseEnvelopeSerializationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool.base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ResponseEnvelopeSerializationTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  void paginatedResponse_should_serialize_notices_without_legacy_warnings_field() throws Exception {
+    var response =
+        PaginatedToolResponse.success(
+            List.of("item"), 1, 50, 1, false, List.of("Applied default"), 1L);
+
+    assertNoticesWireShape(response);
+  }
+
+  @Test
+  void singleResponse_should_serialize_notices_without_legacy_warnings_field() throws Exception {
+    var response = SingleToolResponse.success("item", List.of("Optional enrichment unavailable"));
+
+    assertNoticesWireShape(response);
+  }
+
+  @Test
+  void cursorResponse_should_serialize_notices_without_legacy_warnings_field() throws Exception {
+    var response =
+        CursorToolResponse.success(
+            List.of("item"), 50, "next-cursor", true, List.of("Applied default"), 1L);
+
+    assertNoticesWireShape(response);
+  }
+
+  private void assertNoticesWireShape(Object response) throws Exception {
+    var json = objectMapper.writeValueAsString(response);
+
+    assertThat(json).contains("\"notices\":[").doesNotContain("\"warnings\"");
+  }
+}

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolResponseTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolResponseTest.java
@@ -25,13 +25,13 @@ import org.junit.jupiter.api.Test;
 class SingleToolResponseTest {
 
   @Test
-  void success_should_create_response_with_data_and_warnings() {
-    var warnings = List.of("warning1", "warning2");
+  void success_should_create_response_with_data_and_notices() {
+    var notices = List.of("warning1", "warning2");
 
-    var response = SingleToolResponse.success("data", warnings);
+    var response = SingleToolResponse.success("data", notices);
 
     assertThat(response.data()).isEqualTo("data");
-    assertThat(response.warnings()).containsExactly("warning1", "warning2");
+    assertThat(response.notices()).containsExactly("warning1", "warning2");
     assertThat(response.errors()).isEmpty();
     assertThat(response.found()).isTrue();
     assertThat(response.isSuccess()).isTrue();
@@ -42,38 +42,38 @@ class SingleToolResponseTest {
     var response = SingleToolResponse.success("data");
 
     assertThat(response.data()).isEqualTo("data");
-    assertThat(response.warnings()).isEmpty();
+    assertThat(response.notices()).isEmpty();
     assertThat(response.errors()).isEmpty();
     assertThat(response.found()).isTrue();
     assertThat(response.isSuccess()).isTrue();
   }
 
   @Test
-  void notFound_should_create_response_with_message_in_warnings() {
-    var existingWarnings = List.of("existing");
+  void notFound_should_create_response_with_message_in_notices() {
+    var existingNotices = List.of("existing");
 
-    var response = SingleToolResponse.<String>notFound("Item not found", existingWarnings);
+    var response = SingleToolResponse.<String>notFound("Item not found", existingNotices);
 
     assertThat(response.data()).isNull();
-    assertThat(response.warnings()).containsExactly("existing", "Item not found");
+    assertThat(response.notices()).containsExactly("existing", "Item not found");
     assertThat(response.errors()).isEmpty();
     assertThat(response.found()).isFalse();
     assertThat(response.isSuccess()).isTrue(); // No errors = success
   }
 
   @Test
-  void notFound_should_work_with_empty_warnings() {
+  void notFound_should_work_with_empty_notices() {
     var response = SingleToolResponse.<String>notFound("Not found", List.of());
 
-    assertThat(response.warnings()).containsExactly("Not found");
+    assertThat(response.notices()).containsExactly("Not found");
     assertThat(response.found()).isFalse();
   }
 
   @Test
-  void notFound_should_handle_null_warnings() {
+  void notFound_should_handle_null_notices() {
     var response = SingleToolResponse.<String>notFound("Not found", null);
 
-    assertThat(response.warnings()).containsExactly("Not found");
+    assertThat(response.notices()).containsExactly("Not found");
     assertThat(response.found()).isFalse();
     assertThat(response.isSuccess()).isTrue();
   }
@@ -84,7 +84,7 @@ class SingleToolResponseTest {
 
     assertThat(response.data()).isNull();
     assertThat(response.errors()).containsExactly("Something went wrong");
-    assertThat(response.warnings()).isEmpty();
+    assertThat(response.notices()).isEmpty();
     assertThat(response.found()).isFalse();
     assertThat(response.isSuccess()).isFalse();
   }
@@ -97,7 +97,7 @@ class SingleToolResponseTest {
 
     assertThat(response.data()).isNull();
     assertThat(response.errors()).containsExactly("error1", "error2");
-    assertThat(response.warnings()).isEmpty();
+    assertThat(response.notices()).isEmpty();
     assertThat(response.found()).isFalse();
     assertThat(response.isSuccess()).isFalse();
   }
@@ -107,15 +107,15 @@ class SingleToolResponseTest {
     var response = new SingleToolResponse<>("data", null, List.of("warn"), true);
 
     assertThat(response.errors()).isEmpty();
-    assertThat(response.warnings()).containsExactly("warn");
+    assertThat(response.notices()).containsExactly("warn");
   }
 
   @Test
-  void constructor_should_handle_null_warnings() {
+  void constructor_should_handle_null_notices() {
     var response = new SingleToolResponse<>("data", List.of("err"), null, true);
 
     assertThat(response.errors()).containsExactly("err");
-    assertThat(response.warnings()).isEmpty();
+    assertThat(response.notices()).isEmpty();
   }
 
   @Test
@@ -127,10 +127,10 @@ class SingleToolResponseTest {
   }
 
   @Test
-  void warnings_should_be_immutable() {
+  void notices_should_be_immutable() {
     var response = SingleToolResponse.success("data", List.of("warning"));
 
-    assertThatThrownBy(() -> response.warnings().add("new warning"))
+    assertThatThrownBy(() -> response.notices().add("new warning"))
         .isInstanceOf(UnsupportedOperationException.class);
   }
 
@@ -145,13 +145,13 @@ class SingleToolResponseTest {
   }
 
   @Test
-  void warnings_should_be_defensive_copy() {
-    var mutableWarnings = new ArrayList<>(List.of("warning1"));
-    var response = new SingleToolResponse<>("data", List.of(), mutableWarnings, true);
+  void notices_should_be_defensive_copy() {
+    var mutableNotices = new ArrayList<>(List.of("warning1"));
+    var response = new SingleToolResponse<>("data", List.of(), mutableNotices, true);
 
-    mutableWarnings.add("warning2");
+    mutableNotices.add("warning2");
 
-    assertThat(response.warnings()).containsExactly("warning1");
+    assertThat(response.notices()).containsExactly("warning1");
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolResponseTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolResponseTest.java
@@ -26,12 +26,12 @@ class SingleToolResponseTest {
 
   @Test
   void success_should_create_response_with_data_and_notices() {
-    var notices = List.of("warning1", "warning2");
+    var notices = List.of("notice1", "notice2");
 
     var response = SingleToolResponse.success("data", notices);
 
     assertThat(response.data()).isEqualTo("data");
-    assertThat(response.notices()).containsExactly("warning1", "warning2");
+    assertThat(response.notices()).containsExactly("notice1", "notice2");
     assertThat(response.errors()).isEmpty();
     assertThat(response.found()).isTrue();
     assertThat(response.isSuccess()).isTrue();
@@ -128,9 +128,9 @@ class SingleToolResponseTest {
 
   @Test
   void notices_should_be_immutable() {
-    var response = SingleToolResponse.success("data", List.of("warning"));
+    var response = SingleToolResponse.success("data", List.of("notice"));
 
-    assertThatThrownBy(() -> response.notices().add("new warning"))
+    assertThatThrownBy(() -> response.notices().add("new notice"))
         .isInstanceOf(UnsupportedOperationException.class);
   }
 
@@ -146,17 +146,17 @@ class SingleToolResponseTest {
 
   @Test
   void notices_should_be_defensive_copy() {
-    var mutableNotices = new ArrayList<>(List.of("warning1"));
+    var mutableNotices = new ArrayList<>(List.of("notice1"));
     var response = new SingleToolResponse<>("data", List.of(), mutableNotices, true);
 
-    mutableNotices.add("warning2");
+    mutableNotices.add("notice2");
 
-    assertThat(response.notices()).containsExactly("warning1");
+    assertThat(response.notices()).containsExactly("notice1");
   }
 
   @Test
   void isSuccess_should_return_true_when_no_errors() {
-    var response = new SingleToolResponse<>("data", List.of(), List.of("warning"), true);
+    var response = new SingleToolResponse<>("data", List.of(), List.of("notice"), true);
 
     assertThat(response.isSuccess()).isTrue();
   }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolTest.java
@@ -42,7 +42,7 @@ class SingleToolTest {
     var capturedParams = new AtomicReference<TestParams>();
 
     tool.setDoExecuteHandler(
-        (params, warnings) -> {
+        (params, notices) -> {
           capturedParams.set(params);
           return "result";
         });
@@ -58,7 +58,7 @@ class SingleToolTest {
   @Test
   void executePipeline_should_return_validation_error_when_params_invalid() {
     tool.setDoExecuteHandler(
-        (params, warnings) -> {
+        (params, notices) -> {
           throw new RuntimeException("Should not be called");
         });
 
@@ -71,20 +71,20 @@ class SingleToolTest {
 
   @Test
   void executePipeline_should_return_not_found_when_doExecute_returns_null() {
-    tool.setDoExecuteHandler((params, warnings) -> null);
+    tool.setDoExecuteHandler((params, notices) -> null);
 
     var result = tool.executePipeline(() -> TestParams.valid());
 
     assertThat(result.isSuccess()).isTrue(); // Not found is not an error
     assertThat(result.found()).isFalse();
     assertThat(result.data()).isNull();
-    assertThat(result.warnings()).contains("Resource not found");
+    assertThat(result.notices()).contains("Resource not found");
   }
 
   @Test
   void executePipeline_should_return_not_found_for_resource_not_found_exception() {
     tool.setDoExecuteHandler(
-        (params, warnings) -> {
+        (params, notices) -> {
           throw new ResourceNotFoundException(
               "Vuln not found", "GET", "/api/vulns/123", "Not Found");
         });
@@ -94,13 +94,13 @@ class SingleToolTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.found()).isFalse();
     assertThat(result.data()).isNull();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("not found"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("not found"));
   }
 
   @Test
   void executePipeline_should_handle_unauthorized_exception() {
     tool.setDoExecuteHandler(
-        (params, warnings) -> {
+        (params, notices) -> {
           throw new UnauthorizedException(
               "Invalid credentials", "GET", "/api/test", 401, "Unauthorized");
         });
@@ -114,7 +114,7 @@ class SingleToolTest {
   @Test
   void executePipeline_should_handle_unauthorized_exception_403() {
     tool.setDoExecuteHandler(
-        (params, warnings) -> {
+        (params, notices) -> {
           throw new UnauthorizedException("Forbidden", "GET", "/api/test", 403, "Forbidden");
         });
 
@@ -130,7 +130,7 @@ class SingleToolTest {
   @Test
   void executePipeline_should_handle_http_response_exception_429() {
     tool.setDoExecuteHandler(
-        (params, warnings) -> {
+        (params, notices) -> {
           throw new HttpResponseException(
               "Rate limited", "GET", "/api/test", 429, "Too Many Requests");
         });
@@ -144,7 +144,7 @@ class SingleToolTest {
   @Test
   void executePipeline_should_handle_http_response_exception_500() {
     tool.setDoExecuteHandler(
-        (params, warnings) -> {
+        (params, notices) -> {
           throw new HttpResponseException(
               "Server error", "GET", "/api/test", 500, "Internal Server Error");
         });
@@ -160,7 +160,7 @@ class SingleToolTest {
   @Test
   void executePipeline_should_handle_generic_exception() {
     tool.setDoExecuteHandler(
-        (params, warnings) -> {
+        (params, notices) -> {
           throw new RuntimeException("Unexpected failure");
         });
 
@@ -175,7 +175,7 @@ class SingleToolTest {
   @Test
   void executePipeline_should_not_expose_exception_message_in_error() {
     tool.setDoExecuteHandler(
-        (params, warnings) -> {
+        (params, notices) -> {
           throw new RuntimeException("sensitive: /api/ng/org-id/traces");
         });
 
@@ -216,61 +216,61 @@ class SingleToolTest {
   }
 
   @Test
-  void executePipeline_should_include_params_warnings() {
-    tool.setDoExecuteHandler((params, warnings) -> "result");
+  void executePipeline_should_include_params_notices() {
+    tool.setDoExecuteHandler((params, notices) -> "result");
 
-    var result = tool.executePipeline(() -> TestParams.withWarning("Deprecated parameter"));
+    var result = tool.executePipeline(() -> TestParams.withNotice("Deprecated parameter"));
 
     assertThat(result.isSuccess()).isTrue();
-    assertThat(result.warnings()).contains("Deprecated parameter");
+    assertThat(result.notices()).contains("Deprecated parameter");
   }
 
   @Test
-  void executePipeline_should_allow_doExecute_to_add_warnings() {
+  void executePipeline_should_allow_doExecute_to_add_notices() {
     tool.setDoExecuteHandler(
         (params, collector) -> {
-          collector.warn("Partial data returned");
+          collector.notice("Partial data returned");
           return "result";
         });
 
     var result = tool.executePipeline(() -> TestParams.valid());
 
     assertThat(result.isSuccess()).isTrue();
-    assertThat(result.warnings()).contains("Partial data returned");
+    assertThat(result.notices()).contains("Partial data returned");
   }
 
   @Test
-  void executePipeline_should_preserve_warnings_when_unauthorized_exception_occurs() {
+  void executePipeline_should_preserve_notices_when_unauthorized_exception_occurs() {
     tool.setDoExecuteHandler(
         (params, collector) -> {
-          collector.warn("Warning added before exception");
+          collector.notice("Notice added before exception");
           throw new UnauthorizedException(
               "Invalid credentials", "GET", "/api/test", 401, "Unauthorized");
         });
 
-    var result = tool.executePipeline(() -> TestParams.withWarning("Initial warning"));
+    var result = tool.executePipeline(() -> TestParams.withNotice("Initial notice"));
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors()).containsExactly(AUTH_OR_NOT_FOUND_MESSAGE);
-    assertThat(result.warnings())
-        .containsExactlyInAnyOrder("Initial warning", "Warning added before exception");
+    assertThat(result.notices())
+        .containsExactlyInAnyOrder("Initial notice", "Notice added before exception");
   }
 
   @Test
-  void executePipeline_should_preserve_warnings_when_http_response_exception_occurs() {
+  void executePipeline_should_preserve_notices_when_http_response_exception_occurs() {
     tool.setDoExecuteHandler(
         (params, collector) -> {
-          collector.warn("Warning added before exception");
+          collector.notice("Notice added before exception");
           throw new HttpResponseException(
               "Rate limited", "GET", "/api/test", 429, "Too Many Requests");
         });
 
-    var result = tool.executePipeline(() -> TestParams.withWarning("Initial warning"));
+    var result = tool.executePipeline(() -> TestParams.withNotice("Initial notice"));
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors()).containsExactly("Rate limit exceeded. Retry after a brief pause.");
-    assertThat(result.warnings())
-        .containsExactlyInAnyOrder("Initial warning", "Warning added before exception");
+    assertThat(result.notices())
+        .containsExactlyInAnyOrder("Initial notice", "Notice added before exception");
   }
 
   // Test implementation of SingleTool
@@ -282,7 +282,7 @@ class SingleToolTest {
     }
 
     @Override
-    protected String doExecute(TestParams params, WarningCollector collector) throws Exception {
+    protected String doExecute(TestParams params, NoticeCollector collector) throws Exception {
       if (handler != null) {
         return handler.execute(params, collector);
       }
@@ -291,12 +291,12 @@ class SingleToolTest {
 
     @FunctionalInterface
     interface DoExecuteHandler {
-      String execute(TestParams params, WarningCollector collector) throws Exception;
+      String execute(TestParams params, NoticeCollector collector) throws Exception;
     }
   }
 
   // Test params implementation
-  private record TestParams(boolean isValid, List<String> errors, List<String> warnings)
+  private record TestParams(boolean isValid, List<String> errors, List<String> notices)
       implements ToolParams {
 
     static TestParams valid() {
@@ -307,8 +307,8 @@ class SingleToolTest {
       return new TestParams(false, List.of(error), List.of());
     }
 
-    static TestParams withWarning(String warning) {
-      return new TestParams(true, List.of(), List.of(warning));
+    static TestParams withNotice(String notice) {
+      return new TestParams(true, List.of(), List.of(notice));
     }
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolTest.java
@@ -193,7 +193,7 @@ class GetRouteCoverageToolTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.found()).isFalse();
-    assertThat(result.warnings()).contains("Session metadata not available for this application");
+    assertThat(result.notices()).contains("Session metadata not available for this application");
     verify(contrastApiClient, never()).getRouteCoverage(any(), any());
   }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/params/RouteCoverageParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/params/RouteCoverageParamsTest.java
@@ -59,7 +59,7 @@ class RouteCoverageParamsTest {
 
     assertThat(params.isValid()).isTrue();
     assertThat(params.errors()).isEmpty();
-    assertThat(params.warnings()).isEmpty();
+    assertThat(params.notices()).isEmpty();
     assertThat(params.appId()).isEqualTo(VALID_APP_ID);
     assertThat(params.sessionMetadataName()).isNull();
     assertThat(params.sessionMetadataValue()).isNull();
@@ -169,7 +169,7 @@ class RouteCoverageParamsTest {
 
     assertThat(params.isValid()).isTrue(); // Valid but with warning
     assertThat(params.errors()).isEmpty();
-    assertThat(params.warnings()).anyMatch(w -> w.contains("useLatestSession takes precedence"));
+    assertThat(params.notices()).anyMatch(w -> w.contains("useLatestSession takes precedence"));
   }
 
   @Test
@@ -178,7 +178,7 @@ class RouteCoverageParamsTest {
         RouteCoverageParams.of(VALID_APP_ID, VALID_METADATA_NAME, VALID_METADATA_VALUE, false);
 
     assertThat(params.isValid()).isTrue();
-    assertThat(params.warnings()).isEmpty();
+    assertThat(params.notices()).isEmpty();
   }
 
   @Test
@@ -187,7 +187,7 @@ class RouteCoverageParamsTest {
         RouteCoverageParams.of(VALID_APP_ID, VALID_METADATA_NAME, VALID_METADATA_VALUE, null);
 
     assertThat(params.isValid()).isTrue();
-    assertThat(params.warnings()).isEmpty();
+    assertThat(params.notices()).isEmpty();
   }
 
   // ========== Multiple validation errors ==========

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/params/RouteCoverageParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/params/RouteCoverageParamsTest.java
@@ -160,14 +160,14 @@ class RouteCoverageParamsTest {
     assertThat(params.isUseLatestSession()).isFalse();
   }
 
-  // ========== Mutual exclusivity warning ==========
+  // ========== Mutual exclusivity notice ==========
 
   @Test
   void of_should_warn_when_both_useLatestSession_and_metadata_provided() {
     var params =
         RouteCoverageParams.of(VALID_APP_ID, VALID_METADATA_NAME, VALID_METADATA_VALUE, true);
 
-    assertThat(params.isValid()).isTrue(); // Valid but with warning
+    assertThat(params.isValid()).isTrue(); // Valid but with notice
     assertThat(params.errors()).isEmpty();
     assertThat(params.notices()).anyMatch(w -> w.contains("useLatestSession takes precedence"));
   }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolTest.java
@@ -121,7 +121,7 @@ class ListApplicationLibrariesToolTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.items()).isEmpty();
     assertThat(result.totalItems()).isEqualTo(0);
-    assertThat(result.warnings())
+    assertThat(result.notices())
         .containsExactly(
             "No libraries found for this application. "
                 + "The application may not have any third-party dependencies, "
@@ -141,7 +141,7 @@ class ListApplicationLibrariesToolTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.items()).isEmpty();
     assertThat(result.totalItems()).isEqualTo(5);
-    assertThat(result.warnings()).isEmpty();
+    assertThat(result.notices()).isEmpty();
   }
 
   @Test
@@ -156,7 +156,7 @@ class ListApplicationLibrariesToolTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.pageSize()).isEqualTo(50);
-    assertThat(result.warnings())
+    assertThat(result.notices())
         .contains("Requested pageSize 100 exceeds maximum 50, capped to 50");
     verify(contrastApiClient, never()).getLibraryPage(eq(APP_ID), eq(100), anyInt());
   }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
@@ -293,7 +293,7 @@ class ListApplicationsByCveToolTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.data()).isSameAs(cveData);
-    assertThat(result.warnings()).anyMatch(w -> w.contains("No applications found"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("No applications found"));
   }
 
   @Test
@@ -362,7 +362,7 @@ class ListApplicationsByCveToolTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.found()).isFalse();
     assertThat(result.data()).isNull();
-    assertThat(result.warnings()).anyMatch(w -> w.toLowerCase().contains("not found"));
+    assertThat(result.notices()).anyMatch(w -> w.toLowerCase().contains("not found"));
   }
 
   @Test
@@ -415,7 +415,7 @@ class ListApplicationsByCveToolTest {
     var result = tool.listApplicationsByCve(CVE_ID, null);
 
     assertThat(result.isSuccess()).isTrue();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("(retrieval error)"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("(retrieval error)"));
     assertThat(result.toString()).doesNotContain(secretMessage);
   }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/params/ListApplicationLibrariesParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/params/ListApplicationLibrariesParamsTest.java
@@ -28,7 +28,7 @@ class ListApplicationLibrariesParamsTest {
     assertThat(params.isValid()).isTrue();
     assertThat(params.appId()).isEqualTo("app-123");
     assertThat(params.errors()).isEmpty();
-    assertThat(params.warnings()).isEmpty();
+    assertThat(params.notices()).isEmpty();
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/params/ListApplicationsByCveParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/params/ListApplicationsByCveParamsTest.java
@@ -30,7 +30,7 @@ class ListApplicationsByCveParamsTest {
     assertThat(params.isValid()).isTrue();
     assertThat(params.cveId()).isEqualTo("CVE-2021-44228");
     assertThat(params.errors()).isEmpty();
-    assertThat(params.warnings()).isEmpty();
+    assertThat(params.notices()).isEmpty();
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/params/GetSastProjectParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/params/GetSastProjectParamsTest.java
@@ -56,10 +56,10 @@ class GetSastProjectParamsTest {
   }
 
   @Test
-  void of_should_have_no_warnings_for_valid_input() {
+  void of_should_have_no_notices_for_valid_input() {
     var params = GetSastProjectParams.of("valid-project-name");
 
     assertThat(params.isValid()).isTrue();
-    assertThat(params.warnings()).isEmpty();
+    assertThat(params.notices()).isEmpty();
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/server/SearchServersToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/server/SearchServersToolTest.java
@@ -159,7 +159,7 @@ class SearchServersToolTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.pageSize()).isEqualTo(100);
-    assertThat(result.warnings())
+    assertThat(result.notices())
         .contains("Requested pageSize 250 exceeds maximum 100, capped to 100");
     verify(contrastApiClient, never())
         .searchServers(any(), eq(250), anyInt(), anyString(), anyBoolean());
@@ -174,7 +174,7 @@ class SearchServersToolTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.pageSize()).isEqualTo(100);
-    assertThat(result.warnings()).noneMatch(warning -> warning.contains("pageSize"));
+    assertThat(result.notices()).noneMatch(notice -> notice.contains("pageSize"));
     verify(contrastApiClient).searchServers(any(), eq(100), eq(0), anyString(), eq(false));
   }
 
@@ -187,7 +187,7 @@ class SearchServersToolTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.pageSize()).isEqualTo(50);
-    assertThat(result.warnings()).contains("Invalid pageSize 0, using default 50");
+    assertThat(result.notices()).contains("Invalid pageSize 0, using default 50");
     verify(contrastApiClient).searchServers(any(), eq(50), eq(0), anyString(), eq(false));
   }
 
@@ -225,7 +225,7 @@ class SearchServersToolTest {
     assertThat(result.items()).isEmpty();
     assertThat(result.totalItems()).isZero();
     assertThat(result.errors()).isEmpty();
-    assertThat(result.warnings())
+    assertThat(result.notices())
         .containsExactly("No results found matching the specified criteria.");
   }
 
@@ -250,7 +250,7 @@ class SearchServersToolTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.items()).isEmpty();
     assertThat(result.totalItems()).isZero();
-    assertThat(result.warnings())
+    assertThat(result.notices())
         .containsExactly("No results found matching the specified criteria.");
   }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/server/SearchServersToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/server/SearchServersToolTest.java
@@ -166,7 +166,7 @@ class SearchServersToolTest {
   }
 
   @Test
-  void searchServers_should_accept_maximum_page_size_without_cap_warning() throws Exception {
+  void searchServers_should_accept_maximum_page_size_without_cap_notice() throws Exception {
     when(contrastApiClient.searchServers(any(), eq(100), eq(0), anyString(), eq(false)))
         .thenReturn(response(1L, server(1L, "server-1")));
 
@@ -212,7 +212,7 @@ class SearchServersToolTest {
   }
 
   @Test
-  void searchServers_should_return_standard_warning_for_valid_empty_tag_filter_result()
+  void searchServers_should_return_standard_notice_for_valid_empty_tag_filter_result()
       throws Exception {
     var response = response(0L);
     when(contrastApiClient.searchServers(any(), eq(50), eq(0), anyString(), eq(false)))
@@ -241,7 +241,7 @@ class SearchServersToolTest {
   }
 
   @Test
-  void searchServers_should_return_standard_warning_for_valid_empty_result() throws Exception {
+  void searchServers_should_return_standard_notice_for_valid_empty_result() throws Exception {
     when(contrastApiClient.searchServers(any(), eq(50), eq(0), anyString(), eq(false)))
         .thenReturn(response(0L));
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/server/params/ServerFilterParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/server/params/ServerFilterParamsTest.java
@@ -30,7 +30,7 @@ class ServerFilterParamsTest {
     var params = params(null, null, null, null, null, null, null, null, null);
 
     assertThat(params.isValid()).isTrue();
-    assertThat(params.warnings()).isEmpty();
+    assertThat(params.notices()).isEmpty();
     assertThat(params.getQuickFilter()).isEqualTo("ALL");
     assertThat(params.getSort()).isEqualTo("-lastActivity");
     assertThat(params.isIncludeApplications()).isFalse();

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/EnumSetSpecTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/EnumSetSpecTest.java
@@ -77,7 +77,7 @@ class EnumSetSpecTest {
             .get();
 
     assertThat(result).containsExactlyInAnyOrder(Priority.HIGH, Priority.CRITICAL);
-    assertThat(ctx.warnings()).containsExactly("Using high priorities");
+    assertThat(ctx.notices()).containsExactly("Using high priorities");
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/IntSpecTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/IntSpecTest.java
@@ -35,7 +35,7 @@ class IntSpecTest {
 
     assertThat(result).isEqualTo(42);
     assertThat(ctx.isValid()).isTrue();
-    assertThat(ctx.warnings()).isEmpty();
+    assertThat(ctx.notices()).isEmpty();
   }
 
   @Test
@@ -44,7 +44,7 @@ class IntSpecTest {
 
     assertThat(result).isNull();
     assertThat(ctx.isValid()).isTrue();
-    assertThat(ctx.warnings()).isEmpty();
+    assertThat(ctx.notices()).isEmpty();
   }
 
   @Test
@@ -53,7 +53,7 @@ class IntSpecTest {
 
     assertThat(result).isEqualTo(1);
     assertThat(ctx.isValid()).isTrue();
-    assertThat(ctx.warnings()).containsExactly("Using default page");
+    assertThat(ctx.notices()).containsExactly("Using default page");
   }
 
   @Test
@@ -62,7 +62,7 @@ class IntSpecTest {
 
     assertThat(result).isEqualTo(1);
     assertThat(ctx.isValid()).isTrue();
-    assertThat(ctx.warnings()).containsExactly("page clamped from 0 to minimum 1");
+    assertThat(ctx.notices()).containsExactly("page clamped from 0 to minimum 1");
   }
 
   @Test
@@ -71,7 +71,7 @@ class IntSpecTest {
 
     assertThat(result).isEqualTo(100);
     assertThat(ctx.isValid()).isTrue();
-    assertThat(ctx.warnings()).containsExactly("pageSize clamped from 200 to maximum 100");
+    assertThat(ctx.notices()).containsExactly("pageSize clamped from 200 to maximum 100");
   }
 
   @Test
@@ -80,7 +80,7 @@ class IntSpecTest {
 
     assertThat(result).isEqualTo(50);
     assertThat(ctx.isValid()).isTrue();
-    assertThat(ctx.warnings()).isEmpty();
+    assertThat(ctx.notices()).isEmpty();
   }
 
   @Test
@@ -90,7 +90,7 @@ class IntSpecTest {
 
     assertThat(resultMin).isEqualTo(1);
     assertThat(resultMax).isEqualTo(100);
-    assertThat(ctx.warnings()).isEmpty();
+    assertThat(ctx.notices()).isEmpty();
   }
 
   @Test
@@ -98,7 +98,7 @@ class IntSpecTest {
     var result = ctx.intParam(null, "page").defaultTo(1, "Using default page").range(1, 100).get();
 
     assertThat(result).isEqualTo(1);
-    assertThat(ctx.warnings()).containsExactly("Using default page");
+    assertThat(ctx.notices()).containsExactly("Using default page");
   }
 
   @Test
@@ -106,6 +106,6 @@ class IntSpecTest {
     var result = ctx.intParam(-5, "page").range(1, 100).get();
 
     assertThat(result).isEqualTo(1);
-    assertThat(ctx.warnings()).containsExactly("page clamped from -5 to minimum 1");
+    assertThat(ctx.notices()).containsExactly("page clamped from -5 to minimum 1");
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringListSpecTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringListSpecTest.java
@@ -70,7 +70,7 @@ class StringListSpecTest {
             .get();
 
     assertThat(result).containsExactly("Reported", "Confirmed");
-    assertThat(ctx.warnings()).containsExactly("Using default statuses");
+    assertThat(ctx.notices()).containsExactly("Using default statuses");
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringSpecTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringSpecTest.java
@@ -85,7 +85,7 @@ class StringSpecTest {
   }
 
   @Test
-  void get_should_apply_quiet_default_without_warning() {
+  void get_should_apply_quiet_default_without_notice() {
     var result = ctx.stringParam(null, "quickFilter").defaultToQuietly("ALL").get();
 
     assertThat(result).isEqualTo("ALL");

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringSpecTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringSpecTest.java
@@ -73,7 +73,7 @@ class StringSpecTest {
     var result = ctx.stringParam(null, "status").defaultTo("active", "Using default status").get();
 
     assertThat(result).isEqualTo("active");
-    assertThat(ctx.warnings()).containsExactly("Using default status");
+    assertThat(ctx.notices()).containsExactly("Using default status");
   }
 
   @Test
@@ -81,7 +81,7 @@ class StringSpecTest {
     var result = ctx.stringParam("  ", "status").defaultTo("active", "Using default status").get();
 
     assertThat(result).isEqualTo("active");
-    assertThat(ctx.warnings()).containsExactly("Using default status");
+    assertThat(ctx.notices()).containsExactly("Using default status");
   }
 
   @Test
@@ -89,7 +89,7 @@ class StringSpecTest {
     var result = ctx.stringParam(null, "quickFilter").defaultToQuietly("ALL").get();
 
     assertThat(result).isEqualTo("ALL");
-    assertThat(ctx.warnings()).isEmpty();
+    assertThat(ctx.notices()).isEmpty();
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContextTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContextTest.java
@@ -318,7 +318,7 @@ class ToolValidationContextTest {
   // -- noticeIf tests --
 
   @Test
-  void warnIf_should_add_warning_when_condition_true() {
+  void noticeIf_should_add_notice_when_condition_true() {
     ctx.noticeIf(true, "This is a warning");
 
     assertThat(ctx.isValid()).isTrue();
@@ -326,7 +326,7 @@ class ToolValidationContextTest {
   }
 
   @Test
-  void warnIf_should_not_add_warning_when_condition_false() {
+  void noticeIf_should_not_add_notice_when_condition_false() {
     ctx.noticeIf(false, "This is a warning");
 
     assertThat(ctx.notices()).isEmpty();

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContextTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContextTest.java
@@ -55,9 +55,9 @@ class ToolValidationContextTest {
 
   @Test
   void notices_should_return_immutable_list() {
-    ctx.noticeIf(true, "A warning");
+    ctx.noticeIf(true, "A notice");
 
-    assertThatThrownBy(() -> ctx.notices().add("new warning"))
+    assertThatThrownBy(() -> ctx.notices().add("new notice"))
         .isInstanceOf(UnsupportedOperationException.class);
   }
 
@@ -319,15 +319,15 @@ class ToolValidationContextTest {
 
   @Test
   void noticeIf_should_add_notice_when_condition_true() {
-    ctx.noticeIf(true, "This is a warning");
+    ctx.noticeIf(true, "This is a notice");
 
     assertThat(ctx.isValid()).isTrue();
-    assertThat(ctx.notices()).containsExactly("This is a warning");
+    assertThat(ctx.notices()).containsExactly("This is a notice");
   }
 
   @Test
   void noticeIf_should_not_add_notice_when_condition_false() {
-    ctx.noticeIf(false, "This is a warning");
+    ctx.noticeIf(false, "This is a notice");
 
     assertThat(ctx.notices()).isEmpty();
   }
@@ -355,7 +355,7 @@ class ToolValidationContextTest {
 
   @Test
   void should_collect_both_errors_and_notices() {
-    ctx.noticeIf(true, "A warning");
+    ctx.noticeIf(true, "A notice");
     ctx.require(null, "appId");
 
     assertThat(ctx.isValid()).isFalse();

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContextTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContextTest.java
@@ -54,10 +54,10 @@ class ToolValidationContextTest {
   }
 
   @Test
-  void warnings_should_return_immutable_list() {
-    ctx.warnIf(true, "A warning");
+  void notices_should_return_immutable_list() {
+    ctx.noticeIf(true, "A warning");
 
-    assertThatThrownBy(() -> ctx.warnings().add("new warning"))
+    assertThatThrownBy(() -> ctx.notices().add("new warning"))
         .isInstanceOf(UnsupportedOperationException.class);
   }
 
@@ -315,21 +315,21 @@ class ToolValidationContextTest {
     assertThat(ctx.isValid()).isTrue();
   }
 
-  // -- warnIf tests --
+  // -- noticeIf tests --
 
   @Test
   void warnIf_should_add_warning_when_condition_true() {
-    ctx.warnIf(true, "This is a warning");
+    ctx.noticeIf(true, "This is a warning");
 
     assertThat(ctx.isValid()).isTrue();
-    assertThat(ctx.warnings()).containsExactly("This is a warning");
+    assertThat(ctx.notices()).containsExactly("This is a warning");
   }
 
   @Test
   void warnIf_should_not_add_warning_when_condition_false() {
-    ctx.warnIf(false, "This is a warning");
+    ctx.noticeIf(false, "This is a warning");
 
-    assertThat(ctx.warnings()).isEmpty();
+    assertThat(ctx.notices()).isEmpty();
   }
 
   // -- Multiple validations --
@@ -345,21 +345,21 @@ class ToolValidationContextTest {
   }
 
   @Test
-  void should_collect_multiple_warnings() {
-    ctx.warnIf(true, "Warning 1");
-    ctx.warnIf(true, "Warning 2");
+  void should_collect_multiple_notices() {
+    ctx.noticeIf(true, "Notice 1");
+    ctx.noticeIf(true, "Notice 2");
 
     assertThat(ctx.isValid()).isTrue();
-    assertThat(ctx.warnings()).containsExactly("Warning 1", "Warning 2");
+    assertThat(ctx.notices()).containsExactly("Notice 1", "Notice 2");
   }
 
   @Test
-  void should_collect_both_errors_and_warnings() {
-    ctx.warnIf(true, "A warning");
+  void should_collect_both_errors_and_notices() {
+    ctx.noticeIf(true, "A warning");
     ctx.require(null, "appId");
 
     assertThat(ctx.isValid()).isFalse();
     assertThat(ctx.errors()).hasSize(1);
-    assertThat(ctx.warnings()).hasSize(1);
+    assertThat(ctx.notices()).hasSize(1);
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolTest.java
@@ -86,7 +86,7 @@ class GetVulnerabilityToolTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.found()).isFalse();
     assertThat(result.data()).isNull();
-    assertThat(result.warnings()).contains("Resource not found");
+    assertThat(result.notices()).contains("Resource not found");
   }
 
   @Test
@@ -181,7 +181,7 @@ class GetVulnerabilityToolTest {
     var result = tool.getVulnerability(VALID_VULN_ID, VALID_APP_ID);
 
     assertThat(result.isSuccess()).isTrue();
-    assertThat(result.warnings())
+    assertThat(result.notices())
         .contains("Recommendation data not available (retrieval error, HTTP 403)");
     assertThat(result.toString()).doesNotContain(SECRET_BODY, "/ng/org/recommendation");
   }
@@ -205,8 +205,7 @@ class GetVulnerabilityToolTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.found()).isTrue();
-    assertThat(result.warnings())
-        .doesNotContain("Stack trace data not available (retrieval error)");
+    assertThat(result.notices()).doesNotContain("Stack trace data not available (retrieval error)");
 
     ArgumentCaptor<VulnerabilityContext> contextCaptor =
         ArgumentCaptor.forClass(VulnerabilityContext.class);

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesToolTest.java
@@ -102,7 +102,7 @@ class ListVulnerabilityTypesToolTest {
   }
 
   @Test
-  void listVulnerabilityTypes_should_add_warning_when_rules_null() throws Exception {
+  void listVulnerabilityTypes_should_add_notice_when_rules_null() throws Exception {
     when(contrastApiClient.getRules()).thenReturn(null);
 
     var result = tool.listVulnerabilityTypes(null);
@@ -113,7 +113,7 @@ class ListVulnerabilityTypesToolTest {
   }
 
   @Test
-  void listVulnerabilityTypes_should_add_warning_when_rules_list_null() throws Exception {
+  void listVulnerabilityTypes_should_add_notice_when_rules_list_null() throws Exception {
     Rules rules = mock();
     when(rules.getRules()).thenReturn(null);
     when(contrastApiClient.getRules()).thenReturn(rules);

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesToolTest.java
@@ -109,7 +109,7 @@ class ListVulnerabilityTypesToolTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.data()).isEmpty();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("No rules returned"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("No rules returned"));
   }
 
   @Test
@@ -122,7 +122,7 @@ class ListVulnerabilityTypesToolTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.data()).isEmpty();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("No rules returned"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("No rules returned"));
   }
 
   @Test
@@ -135,7 +135,7 @@ class ListVulnerabilityTypesToolTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.data()).isEmpty();
-    assertThat(result.warnings()).isEmpty();
+    assertThat(result.notices()).isEmpty();
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolTest.java
@@ -152,7 +152,7 @@ class SearchAppVulnerabilitiesToolTest {
             APP_ID, 1, 10, null, null, null, null, null, null, null, null, true);
 
     assertThat(result.isSuccess()).isTrue();
-    assertThat(result.warnings())
+    assertThat(result.notices())
         .anyMatch(w -> w.contains("No sessions found for this application"));
   }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolTest.java
@@ -151,7 +151,7 @@ class SearchVulnerabilitiesToolTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.items()).isEmpty();
     assertThat(result.pageSize()).isEqualTo(100);
-    assertThat(result.warnings())
+    assertThat(result.notices())
         .contains(
             "Requested pageSize 1000 exceeds maximum 100, capped to 100",
             "API returned no trace data. Verify permissions and filters.");

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityMapperTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityMapperTest.java
@@ -234,7 +234,7 @@ class VulnerabilityMapperTest {
   void toFullVulnerability_should_attach_the_rule_specific_hint() {
     var result = mapper.toFullVulnerability(trace(FULL_TRACE_JSON), emptyContext());
 
-    assertThat(result.hint())
+    assertThat(result.remediationHint())
         .contains("allow list / enum to break the dataflow")
         .contains("prepared statement");
   }
@@ -249,7 +249,7 @@ class VulnerabilityMapperTest {
                 """),
             emptyContext());
 
-    assertThat(result.hint()).isNotBlank().contains("a-rule-with-no-hints");
+    assertThat(result.remediationHint()).isNotBlank().contains("a-rule-with-no-hints");
   }
 
   @Test
@@ -262,7 +262,7 @@ class VulnerabilityMapperTest {
                 """),
             emptyContext());
 
-    assertThat(result.hint()).isNotBlank();
+    assertThat(result.remediationHint()).isNotBlank();
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/GetVulnerabilityParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/GetVulnerabilityParamsTest.java
@@ -76,9 +76,9 @@ class GetVulnerabilityParamsTest {
   }
 
   @Test
-  void of_should_have_empty_warnings_for_valid_params() {
+  void of_should_have_empty_notices_for_valid_params() {
     var params = GetVulnerabilityParams.of(VALID_VULN_ID, VALID_APP_ID);
 
-    assertThat(params.warnings()).isEmpty();
+    assertThat(params.notices()).isEmpty();
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/ListVulnerabilityTypesParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/ListVulnerabilityTypesParamsTest.java
@@ -30,9 +30,9 @@ class ListVulnerabilityTypesParamsTest {
   }
 
   @Test
-  void of_should_have_empty_warnings() {
+  void of_should_have_empty_notices() {
     var params = ListVulnerabilityTypesParams.of();
 
-    assertThat(params.warnings()).isEmpty();
+    assertThat(params.notices()).isEmpty();
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParamsTest.java
@@ -96,7 +96,7 @@ class SearchAppVulnerabilitiesParamsTest {
   // -- Status tests --
 
   @Test
-  void of_should_apply_default_statuses_with_warning() {
+  void of_should_apply_default_statuses_with_notice() {
     var params =
         SearchAppVulnerabilitiesParams.of(
             VALID_APP_ID, null, null, null, null, null, null, null, null, null);

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParamsTest.java
@@ -103,7 +103,7 @@ class SearchAppVulnerabilitiesParamsTest {
 
     assertThat(params.isValid()).isTrue();
     assertThat(params.getStatuses()).containsExactly("Reported", "Suspicious", "Confirmed");
-    assertThat(params.warnings()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+    assertThat(params.notices()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParamsTest.java
@@ -79,7 +79,7 @@ class VulnerabilityFilterParamsTest {
 
     assertThat(params.isValid()).isTrue();
     assertThat(params.getStatuses()).containsExactly("Reported", "Suspicious", "Confirmed");
-    assertThat(params.warnings()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+    assertThat(params.notices()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
   }
 
   @Test
@@ -121,7 +121,7 @@ class VulnerabilityFilterParamsTest {
 
     assertThat(params.isValid()).isTrue();
     assertThat(params.getLastSeenAfter()).isNotNull();
-    assertThat(params.warnings()).anyMatch(w -> w.contains("LAST ACTIVITY DATE"));
+    assertThat(params.notices()).anyMatch(w -> w.contains("LAST ACTIVITY DATE"));
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParamsTest.java
@@ -74,7 +74,7 @@ class VulnerabilityFilterParamsTest {
   }
 
   @Test
-  void of_should_apply_default_statuses_with_warning() {
+  void of_should_apply_default_statuses_with_notice() {
     var params = VulnerabilityFilterParams.of(null, null, null, null, null, null, null);
 
     assertThat(params.isValid()).isTrue();

--- a/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastResultsTool.java
+++ b/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastResultsTool.java
@@ -16,8 +16,8 @@
 package com.contrast.labs.ai.mcp.contrast.tool.sast;
 
 import com.contrast.labs.ai.mcp.contrast.tool.base.LocalSdkSingleTool;
+import com.contrast.labs.ai.mcp.contrast.tool.base.NoticeCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleToolResponse;
-import com.contrast.labs.ai.mcp.contrast.tool.base.WarningCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.sast.params.GetSastResultsParams;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -44,7 +44,7 @@ public class GetSastResultsTool extends LocalSdkSingleTool<GetSastResultsParams,
           """
           DEPRECATED: Takes a scan project name and returns the latest results in SARIF format.
 
-          WARNING: This tool returns raw SARIF JSON which is often very large (megabytes) and
+          NOTICE: This tool returns raw SARIF JSON which is often very large (megabytes) and
           may exceed AI context limits. Consider using future paginated SAST search tools instead.
 
           Returns the complete SARIF 2.1.0 JSON document including:
@@ -69,13 +69,13 @@ public class GetSastResultsTool extends LocalSdkSingleTool<GetSastResultsParams,
   }
 
   @Override
-  protected String doExecute(GetSastResultsParams params, WarningCollector collector)
+  protected String doExecute(GetSastResultsParams params, NoticeCollector collector)
       throws Exception {
     var sdk = getContrastSDK();
     var orgId = getOrgId();
 
-    // Add deprecation warning at start - shown on every call regardless of success/failure
-    collector.warn(
+    // Add deprecation notice at start - shown on every call regardless of success/failure
+    collector.notice(
         "DEPRECATED: This tool returns raw SARIF which may be very large. "
             + "Consider using future paginated SAST search tools for better AI-friendly access.");
 
@@ -95,7 +95,7 @@ public class GetSastResultsTool extends LocalSdkSingleTool<GetSastResultsParams,
 
     // Check if project has any completed scans
     if (project.lastScanId() == null) {
-      collector.warn(
+      collector.notice(
           String.format(
               "No scan results available for project: %s. "
                   + "Project exists but has no completed scans.",
@@ -109,7 +109,7 @@ public class GetSastResultsTool extends LocalSdkSingleTool<GetSastResultsParams,
 
     var scan = scans.get(project.lastScanId());
     if (scan == null) {
-      collector.warn("No scan results available for project: " + params.projectName());
+      collector.notice("No scan results available for project: " + params.projectName());
       return null;
     }
     log.debug("Retrieved scan with id: {}", project.lastScanId());

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataLocalParityTest.java
@@ -76,7 +76,7 @@ class GetSessionMetadataLocalParityTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.found()).isFalse();
     assertThat(result.data()).isNull();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("No session metadata found"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("No session metadata found"));
   }
 
   @Test

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataToolIT.java
@@ -69,8 +69,8 @@ public class GetSessionMetadataToolIT
       "Access denied or resource not found. Verify credentials and that the resource ID is"
           + " correct.";
 
-  // Tool warning emitted when the SDK returns null (no recorded sessions).
-  private static final String NO_METADATA_WARNING_FRAGMENT = "No session metadata found";
+  // Tool notice emitted when the SDK returns null (no recorded sessions).
+  private static final String NO_METADATA_NOTICE_FRAGMENT = "No session metadata found";
 
   // Probe depth for discovering an app with populated session metadata. Bounded to keep
   // discovery fast on orgs with many applications.
@@ -296,7 +296,7 @@ public class GetSessionMetadataToolIT
         .as("unknown appId must not be surfaced as a generic 5xx Contrast API error")
         .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
     assertThat(result.notices())
-        .as("error path must not also emit the no-metadata warning")
-        .noneMatch(w -> w.contains(NO_METADATA_WARNING_FRAGMENT));
+        .as("error path must not also emit the no-metadata notice")
+        .noneMatch(w -> w.contains(NO_METADATA_NOTICE_FRAGMENT));
   }
 }

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataToolIT.java
@@ -295,7 +295,7 @@ public class GetSessionMetadataToolIT
     assertThat(result.errors())
         .as("unknown appId must not be surfaced as a generic 5xx Contrast API error")
         .noneMatch(e -> e.contains(CONTRAST_API_ERROR));
-    assertThat(result.warnings())
+    assertThat(result.notices())
         .as("error path must not also emit the no-metadata warning")
         .noneMatch(w -> w.contains(NO_METADATA_WARNING_FRAGMENT));
   }

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsLocalParityTest.java
@@ -177,7 +177,7 @@ class SearchApplicationsLocalParityTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.items()).isEmpty();
     assertThat(result.totalItems()).isEqualTo(0);
-    assertThat(result.warnings()).anyMatch(w -> w.contains("No results found"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("No results found"));
   }
 
   @Test
@@ -230,7 +230,7 @@ class SearchApplicationsLocalParityTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.items()).isEmpty();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("API returned no application data"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("API returned no application data"));
   }
 
   // -- Helper methods --

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolIT.java
@@ -416,19 +416,19 @@ class SearchApplicationsToolIT extends AbstractIntegrationTest<SearchApplication
 
   @Test
   void searchApplications_should_clamp_page_below_one() {
-    // PaginationParams treats page < 1 as a soft failure: clamp to 1 and emit a warning.
+    // PaginationParams treats page < 1 as a soft failure: clamp to 1 and emit a notice.
     var response = searchApplicationsTool.searchApplications(0, 10, null, null, null);
 
     assertThat(response.isSuccess()).as("page=0 must soft-fail and continue").isTrue();
     assertThat(response.page()).as("page=0 must be clamped to 1").isEqualTo(1);
     assertThat(response.notices())
-        .as("clamping must emit an 'Invalid page number' warning")
+        .as("clamping must emit an 'Invalid page number' notice")
         .anyMatch(w -> w.contains("Invalid page number 0"));
   }
 
   @Test
   void searchApplications_should_clamp_non_positive_pageSize() {
-    // pageSize < 1 must be replaced with DEFAULT_PAGE_SIZE and a warning emitted.
+    // pageSize < 1 must be replaced with DEFAULT_PAGE_SIZE and a notice emitted.
     var response = searchApplicationsTool.searchApplications(1, 0, null, null, null);
 
     assertThat(response.isSuccess()).as("pageSize=0 must soft-fail and continue").isTrue();
@@ -436,14 +436,14 @@ class SearchApplicationsToolIT extends AbstractIntegrationTest<SearchApplication
         .as("pageSize=0 must fall back to default %d", DEFAULT_PAGE_SIZE)
         .isEqualTo(DEFAULT_PAGE_SIZE);
     assertThat(response.notices())
-        .as("clamping must emit an 'Invalid pageSize' warning")
+        .as("clamping must emit an 'Invalid pageSize' notice")
         .anyMatch(w -> w.contains("Invalid pageSize 0"));
   }
 
   @Test
   void searchApplications_should_clamp_oversized_pageSize() {
     // Tool-specific max is MAX_PAGE_SIZE (100). Requests above must be capped with a
-    // warning that names the cap.
+    // notice that names the cap.
     int oversized = MAX_PAGE_SIZE * 4;
     var response = searchApplicationsTool.searchApplications(1, oversized, null, null, null);
 
@@ -452,7 +452,7 @@ class SearchApplicationsToolIT extends AbstractIntegrationTest<SearchApplication
         .as("pageSize must be capped to MAX_PAGE_SIZE=%d", MAX_PAGE_SIZE)
         .isEqualTo(MAX_PAGE_SIZE);
     assertThat(response.notices())
-        .as("clamping must emit an 'exceeds maximum' warning citing the cap")
+        .as("clamping must emit an 'exceeds maximum' notice citing the cap")
         .anyMatch(w -> w.contains("exceeds maximum") && w.contains(String.valueOf(MAX_PAGE_SIZE)));
   }
 

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolIT.java
@@ -399,7 +399,7 @@ class SearchApplicationsToolIT extends AbstractIntegrationTest<SearchApplication
   @Test
   void searchApplications_should_default_page_and_pageSize_when_null() {
     // Null page/pageSize must route through PaginationParams defaults — page=1, pageSize=50
-    // — with no clamp warnings. A change to the default contract would surface here.
+    // — with no clamp notices. A change to the default contract would surface here.
     var response = searchApplicationsTool.searchApplications(null, null, null, null, null);
 
     assertThat(response.isSuccess()).as("defaults must not fail validation").isTrue();
@@ -407,8 +407,8 @@ class SearchApplicationsToolIT extends AbstractIntegrationTest<SearchApplication
     assertThat(response.pageSize())
         .as("null pageSize must default to %d", DEFAULT_PAGE_SIZE)
         .isEqualTo(DEFAULT_PAGE_SIZE);
-    assertThat(response.warnings())
-        .as("defaults must not produce pagination-clamp warnings")
+    assertThat(response.notices())
+        .as("defaults must not produce pagination-clamp notices")
         .noneMatch(w -> w.contains("Invalid page"))
         .noneMatch(w -> w.contains("Invalid pageSize"))
         .noneMatch(w -> w.contains("exceeds maximum"));
@@ -421,7 +421,7 @@ class SearchApplicationsToolIT extends AbstractIntegrationTest<SearchApplication
 
     assertThat(response.isSuccess()).as("page=0 must soft-fail and continue").isTrue();
     assertThat(response.page()).as("page=0 must be clamped to 1").isEqualTo(1);
-    assertThat(response.warnings())
+    assertThat(response.notices())
         .as("clamping must emit an 'Invalid page number' warning")
         .anyMatch(w -> w.contains("Invalid page number 0"));
   }
@@ -435,7 +435,7 @@ class SearchApplicationsToolIT extends AbstractIntegrationTest<SearchApplication
     assertThat(response.pageSize())
         .as("pageSize=0 must fall back to default %d", DEFAULT_PAGE_SIZE)
         .isEqualTo(DEFAULT_PAGE_SIZE);
-    assertThat(response.warnings())
+    assertThat(response.notices())
         .as("clamping must emit an 'Invalid pageSize' warning")
         .anyMatch(w -> w.contains("Invalid pageSize 0"));
   }
@@ -451,7 +451,7 @@ class SearchApplicationsToolIT extends AbstractIntegrationTest<SearchApplication
     assertThat(response.pageSize())
         .as("pageSize must be capped to MAX_PAGE_SIZE=%d", MAX_PAGE_SIZE)
         .isEqualTo(MAX_PAGE_SIZE);
-    assertThat(response.warnings())
+    assertThat(response.notices())
         .as("clamping must emit an 'exceeds maximum' warning citing the cap")
         .anyMatch(w -> w.contains("exceeds maximum") && w.contains(String.valueOf(MAX_PAGE_SIZE)));
   }

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesLocalParityTest.java
@@ -67,7 +67,7 @@ class GetProtectRulesLocalParityTest {
     assertThat(response.isSuccess()).isTrue();
     assertThat(response.found()).isTrue();
     assertThat(response.errors()).isEmpty();
-    assertThat(response.warnings()).isEmpty();
+    assertThat(response.notices()).isEmpty();
     assertThat(response.data().getRules())
         .extracting(Rule::getName)
         .containsExactly("sql-injection", "xss-reflected");

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolIT.java
@@ -63,10 +63,10 @@ public class GetRouteCoverageToolIT
   private static final String METADATA_NAME_REQUIRED_ERROR =
       "sessionMetadataName is required when sessionMetadataValue is provided";
 
-  // Mutually-exclusive-filter warning emitted by RouteCoverageParams when both useLatestSession and
+  // Mutually-exclusive-filter notice emitted by RouteCoverageParams when both useLatestSession and
   // session metadata filters are supplied together. The tool's contract documents that
   // useLatestSession takes precedence — this test verifies the user is told.
-  private static final String MUTUALLY_EXCLUSIVE_FILTERS_WARNING =
+  private static final String MUTUALLY_EXCLUSIVE_FILTERS_NOTICE =
       "Both useLatestSession and sessionMetadataName provided - "
           + "useLatestSession takes precedence and sessionMetadata filter will be ignored";
 
@@ -282,9 +282,9 @@ public class GetRouteCoverageToolIT
   }
 
   @Test
-  void getRouteCoverage_should_emit_warning_when_both_filters_provided() {
+  void getRouteCoverage_should_emit_notice_when_both_filters_provided() {
     // Tool contract: useLatestSession takes precedence over session metadata. The tool must
-    // surface this precedence to the caller via a warning so silent filter loss is impossible.
+    // surface this precedence to the caller via a notice so silent filter loss is impossible.
     assertThat(testData.hasSessionMetadata)
         .as("requires seeded session metadata on app %s — see INTEGRATION_TESTS.md", testData.appId)
         .isTrue();
@@ -298,7 +298,7 @@ public class GetRouteCoverageToolIT
         .isTrue();
     assertThat(response.notices())
         .as("must warn that the metadata filter is silently superseded by useLatestSession")
-        .contains(MUTUALLY_EXCLUSIVE_FILTERS_WARNING);
+        .contains(MUTUALLY_EXCLUSIVE_FILTERS_NOTICE);
   }
 
   // ========== Successful query tests ==========

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolIT.java
@@ -296,7 +296,7 @@ public class GetRouteCoverageToolIT
     assertThat(response.isSuccess())
         .as("query should succeed — useLatestSession path takes precedence")
         .isTrue();
-    assertThat(response.warnings())
+    assertThat(response.notices())
         .as("must warn that the metadata filter is silently superseded by useLatestSession")
         .contains(MUTUALLY_EXCLUSIVE_FILTERS_WARNING);
   }

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesLocalParityTest.java
@@ -107,7 +107,7 @@ class ListApplicationLibrariesLocalParityTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.items()).isEmpty();
     assertThat(result.totalItems()).isEqualTo(0);
-    assertThat(result.warnings()).anyMatch(w -> w.contains("No libraries found"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("No libraries found"));
   }
 
   @Test
@@ -126,7 +126,7 @@ class ListApplicationLibrariesLocalParityTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.items()).isEmpty();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("No libraries found"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("No libraries found"));
   }
 
   @Test
@@ -244,7 +244,7 @@ class ListApplicationLibrariesLocalParityTest {
     assertThat(result.items()).hasSize(50);
     assertThat(result.totalItems()).isEqualTo(200);
     assertThat(result.pageSize()).isEqualTo(50); // Response shows effective (capped) amount
-    assertThat(result.warnings()).anyMatch(w -> w.contains("exceeds maximum 50"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("exceeds maximum 50"));
   }
 
   private List<LibraryExtended> createMockLibraries(int count) {

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesLocalParityTest.java
@@ -92,7 +92,7 @@ class ListApplicationLibrariesLocalParityTest {
   }
 
   @Test
-  void listApplicationLibraries_should_return_empty_list_with_warning_when_no_libraries()
+  void listApplicationLibraries_should_return_empty_list_with_notice_when_no_libraries()
       throws IOException {
     var mockResponse = createMockResponse(new ArrayList<>(), 0L);
     mockedSDKHelper
@@ -225,7 +225,7 @@ class ListApplicationLibrariesLocalParityTest {
   }
 
   @Test
-  void listApplicationLibraries_should_cap_pageSize_at_50_with_warning() throws IOException {
+  void listApplicationLibraries_should_cap_pageSize_at_50_with_notice() throws IOException {
     var mockLibraries = createMockLibraries(50);
     var mockResponse = createMockResponse(mockLibraries, 200L);
 
@@ -237,7 +237,7 @@ class ListApplicationLibrariesLocalParityTest {
                     eq(TEST_APP_ID), eq(TEST_ORG_ID), eq(sdkExtension), eq(50), eq(0)))
         .thenReturn(mockResponse);
 
-    // Request pageSize 100, should be capped to 50 with warning
+    // Request pageSize 100, should be capped to 50 with notice
     var result = tool.listApplicationLibraries(1, 100, TEST_APP_ID);
 
     assertThat(result.isSuccess()).isTrue();

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolIT.java
@@ -163,7 +163,7 @@ class ListApplicationLibrariesToolIT
   @Test
   void listApplicationLibraries_should_default_page_and_pageSize_when_null() {
     // Null page/pageSize must route through PaginationParams defaults — page=1, pageSize=50 —
-    // with no pagination warnings. A change to the default contract would surface here.
+    // with no pagination notices. A change to the default contract would surface here.
     var result = tool.listApplicationLibraries(null, null, testData.appId);
 
     assertThat(result.isSuccess()).as("defaults must not fail validation").isTrue();
@@ -171,8 +171,8 @@ class ListApplicationLibrariesToolIT
     assertThat(result.pageSize())
         .as("null pageSize must default to %d", DEFAULT_PAGE_SIZE)
         .isEqualTo(DEFAULT_PAGE_SIZE);
-    assertThat(result.warnings())
-        .as("defaults must not produce pagination-clamp warnings")
+    assertThat(result.notices())
+        .as("defaults must not produce pagination-clamp notices")
         .noneMatch(w -> w.contains("Invalid page"))
         .noneMatch(w -> w.contains("Invalid pageSize"))
         .noneMatch(w -> w.contains("exceeds maximum"));
@@ -184,7 +184,7 @@ class ListApplicationLibrariesToolIT
     // payload. The specific HTTP status (403 vs 404) and mapped message are environment-dependent
     // (TeamServer deliberately conflates "unknown" with "forbidden" for enumeration defence), so
     // we assert the tool-contract shape: errors present, no items, no total, no more pages, and
-    // no warnings mixed in with the error.
+    // no notices mixed in with the error.
     var result = tool.listApplicationLibraries(null, null, "invalid-app-id-12345");
 
     assertThat(result.isSuccess())
@@ -197,7 +197,7 @@ class ListApplicationLibrariesToolIT
     assertThat(result.items()).as("error response must carry no items").isEmpty();
     assertThat(result.totalItems()).as("error response must report zero total").isZero();
     assertThat(result.hasMorePages()).as("error response must not claim more pages").isFalse();
-    assertThat(result.warnings()).as("error response must not mix in warnings").isEmpty();
+    assertThat(result.notices()).as("error response must not mix in notices").isEmpty();
   }
 
   @Test
@@ -329,7 +329,7 @@ class ListApplicationLibrariesToolIT
 
     assertThat(result.isSuccess()).as("page=0 must soft-fail and continue").isTrue();
     assertThat(result.page()).as("page=0 must be clamped to 1").isEqualTo(1);
-    assertThat(result.warnings())
+    assertThat(result.notices())
         .as("clamping must emit an 'Invalid page number' warning")
         .anyMatch(w -> w.contains("Invalid page number 0"));
   }
@@ -344,7 +344,7 @@ class ListApplicationLibrariesToolIT
     assertThat(result.pageSize())
         .as("pageSize must be capped to API_MAX_PAGE_SIZE=%d", API_MAX_PAGE_SIZE)
         .isEqualTo(API_MAX_PAGE_SIZE);
-    assertThat(result.warnings())
+    assertThat(result.notices())
         .as("clamping must emit an 'exceeds maximum' warning citing the cap")
         .anyMatch(
             w -> w.contains("exceeds maximum") && w.contains(String.valueOf(API_MAX_PAGE_SIZE)));
@@ -359,7 +359,7 @@ class ListApplicationLibrariesToolIT
     assertThat(result.pageSize())
         .as("pageSize=0 must fall back to default %d", DEFAULT_PAGE_SIZE)
         .isEqualTo(DEFAULT_PAGE_SIZE);
-    assertThat(result.warnings())
+    assertThat(result.notices())
         .as("clamping must emit an 'Invalid pageSize' warning")
         .anyMatch(w -> w.contains("Invalid pageSize 0"));
   }

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolIT.java
@@ -324,19 +324,19 @@ class ListApplicationLibrariesToolIT
 
   @Test
   void listApplicationLibraries_should_clamp_page_below_one() {
-    // PaginationParams treats page < 1 as a soft failure: clamp to 1 and emit a warning.
+    // PaginationParams treats page < 1 as a soft failure: clamp to 1 and emit a notice.
     var result = tool.listApplicationLibraries(0, PAGINATION_PROBE_SIZE, testData.appId);
 
     assertThat(result.isSuccess()).as("page=0 must soft-fail and continue").isTrue();
     assertThat(result.page()).as("page=0 must be clamped to 1").isEqualTo(1);
     assertThat(result.notices())
-        .as("clamping must emit an 'Invalid page number' warning")
+        .as("clamping must emit an 'Invalid page number' notice")
         .anyMatch(w -> w.contains("Invalid page number 0"));
   }
 
   @Test
   void listApplicationLibraries_should_clamp_oversized_pageSize() {
-    // Tool-specific max is API_MAX_PAGE_SIZE (50). Requests above must be capped with a warning.
+    // Tool-specific max is API_MAX_PAGE_SIZE (50). Requests above must be capped with a notice.
     int oversized = API_MAX_PAGE_SIZE * 4;
     var result = tool.listApplicationLibraries(1, oversized, testData.appId);
 
@@ -345,14 +345,14 @@ class ListApplicationLibrariesToolIT
         .as("pageSize must be capped to API_MAX_PAGE_SIZE=%d", API_MAX_PAGE_SIZE)
         .isEqualTo(API_MAX_PAGE_SIZE);
     assertThat(result.notices())
-        .as("clamping must emit an 'exceeds maximum' warning citing the cap")
+        .as("clamping must emit an 'exceeds maximum' notice citing the cap")
         .anyMatch(
             w -> w.contains("exceeds maximum") && w.contains(String.valueOf(API_MAX_PAGE_SIZE)));
   }
 
   @Test
   void listApplicationLibraries_should_clamp_non_positive_pageSize() {
-    // pageSize < 1 must be replaced with DEFAULT_PAGE_SIZE and a warning emitted.
+    // pageSize < 1 must be replaced with DEFAULT_PAGE_SIZE and a notice emitted.
     var result = tool.listApplicationLibraries(1, 0, testData.appId);
 
     assertThat(result.isSuccess()).as("pageSize=0 must soft-fail and continue").isTrue();
@@ -360,7 +360,7 @@ class ListApplicationLibrariesToolIT
         .as("pageSize=0 must fall back to default %d", DEFAULT_PAGE_SIZE)
         .isEqualTo(DEFAULT_PAGE_SIZE);
     assertThat(result.notices())
-        .as("clamping must emit an 'Invalid pageSize' warning")
+        .as("clamping must emit an 'Invalid pageSize' notice")
         .anyMatch(w -> w.contains("Invalid pageSize 0"));
   }
 

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveLocalParityTest.java
@@ -123,7 +123,7 @@ class ListApplicationsByCveLocalParityTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.data()).isNotNull();
     assertThat(result.data().getApps()).isEmpty();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("No applications found"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("No applications found"));
   }
 
   @Test
@@ -138,7 +138,7 @@ class ListApplicationsByCveLocalParityTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.data()).isNotNull();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("No applications found"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("No applications found"));
   }
 
   @Test
@@ -192,7 +192,7 @@ class ListApplicationsByCveLocalParityTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.found()).isFalse();
     assertThat(result.data()).isNull();
-    assertThat(result.warnings()).anyMatch(w -> w.toLowerCase().contains("not found"));
+    assertThat(result.notices()).anyMatch(w -> w.toLowerCase().contains("not found"));
   }
 
   @Test
@@ -228,8 +228,8 @@ class ListApplicationsByCveLocalParityTest {
     var result = tool.listApplicationsByCve(TEST_CVE_ID);
 
     assertThat(result.isSuccess()).isTrue();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("(retrieval error)"));
-    assertThat(result.warnings()).noneMatch(w -> w.contains(secretMessage));
+    assertThat(result.notices()).anyMatch(w -> w.contains("(retrieval error)"));
+    assertThat(result.notices()).noneMatch(w -> w.contains(secretMessage));
   }
 
   private CveData createMockCveDataWithApps() {

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveLocalParityTest.java
@@ -215,7 +215,7 @@ class ListApplicationsByCveLocalParityTest {
   }
 
   @Test
-  void listApplicationsByCve_should_not_leak_exception_message_in_warning_when_enrichment_fails()
+  void listApplicationsByCve_should_not_leak_exception_message_in_notice_when_enrichment_fails()
       throws IOException {
     var mockCveData = createMockCveDataWithApps();
     var secretMessage = "secret internal path /api/ng/ORG_ID/APP_ID/libs";

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectToolIT.java
@@ -53,7 +53,7 @@ class GetSastProjectToolIT {
   // against any unrelated message that happens to mention the parameter name.
   private static final String PROJECT_NAME_REQUIRED_ERROR = "projectName is required";
 
-  // Warning emitted by SingleTool when doExecute returns null (project not found).
+  // Notice emitted by SingleTool when doExecute returns null (project not found).
   private static final String RESOURCE_NOT_FOUND_WARNING = "Resource not found";
 
   @BeforeEach
@@ -154,7 +154,7 @@ class GetSastProjectToolIT {
     assertThat(response.errors()).as("notFound must produce no errors").isEmpty();
     assertThat(response.found()).as("nonexistent project must not be reported as found").isFalse();
     assertThat(response.data()).as("notFound response must not carry data").isNull();
-    assertThat(response.warnings())
+    assertThat(response.notices())
         .as("notFound path must surface the documented warning")
         .contains(RESOURCE_NOT_FOUND_WARNING);
   }

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectToolIT.java
@@ -54,7 +54,7 @@ class GetSastProjectToolIT {
   private static final String PROJECT_NAME_REQUIRED_ERROR = "projectName is required";
 
   // Notice emitted by SingleTool when doExecute returns null (project not found).
-  private static final String RESOURCE_NOT_FOUND_WARNING = "Resource not found";
+  private static final String RESOURCE_NOT_FOUND_NOTICE = "Resource not found";
 
   @BeforeEach
   void requireSeededProjectName() {
@@ -155,8 +155,8 @@ class GetSastProjectToolIT {
     assertThat(response.found()).as("nonexistent project must not be reported as found").isFalse();
     assertThat(response.data()).as("notFound response must not carry data").isNull();
     assertThat(response.notices())
-        .as("notFound path must surface the documented warning")
-        .contains(RESOURCE_NOT_FOUND_WARNING);
+        .as("notFound path must surface the documented notice")
+        .contains(RESOURCE_NOT_FOUND_NOTICE);
   }
 
   @Test

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastResultsToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastResultsToolIT.java
@@ -39,7 +39,7 @@ import org.springframework.test.context.TestPropertySource;
  * and run via {@code source .env.integration-test && ./gradlew
  * :contrast-mcp-stdio-app:integrationTest}. See INTEGRATION_TESTS.md.
  *
- * <p>The "no completed scans" and "scan id not found" warning paths are covered by {@link
+ * <p>The "no completed scans" and "scan id not found" notice paths are covered by {@link
  * GetSastResultsToolTest} (mocked) — they are not reproducible against a live organisation without
  * dedicated, brittle fixtures.
  */
@@ -57,10 +57,10 @@ class GetSastResultsToolIT {
   @Value("${test.scan.project-name:}")
   private String testProjectName;
 
-  // Verbatim deprecation warning emitted by GetSastResultsTool#doExecute. Pinning to the full
+  // Verbatim deprecation notice emitted by GetSastResultsTool#doExecute. Pinning to the full
   // message catches regressions where the wording drifts (and AI consumers' downstream parsing
   // breaks) far better than a "DEPRECATED" substring match.
-  private static final String DEPRECATION_WARNING =
+  private static final String DEPRECATION_NOTICE =
       "DEPRECATED: This tool returns raw SARIF which may be very large. "
           + "Consider using future paginated SAST search tools for better AI-friendly access.";
 
@@ -154,7 +154,7 @@ class GetSastResultsToolIT {
   }
 
   @Test
-  void getScanResults_should_emit_full_deprecation_warning() {
+  void getScanResults_should_emit_full_deprecation_notice() {
     var response = getSastResultsTool.getScanResults(testProjectName);
 
     assertThat(response.isSuccess())
@@ -163,8 +163,8 @@ class GetSastResultsToolIT {
     // Assert the verbatim message — substring "DEPRECATED" matches any rewording, including
     // garbage text that happens to contain the token, which would not actually warn AI consumers.
     assertThat(response.notices())
-        .as("response must contain the verbatim deprecation warning")
-        .contains(DEPRECATION_WARNING);
+        .as("response must contain the verbatim deprecation notice")
+        .contains(DEPRECATION_NOTICE);
   }
 
   // ---------- Validation errors ----------
@@ -222,12 +222,12 @@ class GetSastResultsToolIT {
     assertThat(response.found()).as("missing project must report found=false").isFalse();
     assertThat(response.data()).as("notFound must not carry data").isNull();
     assertThat(response.errors()).as("notFound must not surface as an error").isEmpty();
-    // Deprecation warning is added before the project lookup, so it must still be emitted on
+    // Deprecation notice is added before the project lookup, so it must still be emitted on
     // the notFound path. A regression that short-circuited notices on null doExecute would
     // surface here.
     assertThat(response.notices())
-        .as("deprecation warning must still be emitted for missing projects")
-        .contains(DEPRECATION_WARNING);
+        .as("deprecation notice must still be emitted for missing projects")
+        .contains(DEPRECATION_NOTICE);
   }
 
   @Test

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastResultsToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastResultsToolIT.java
@@ -158,11 +158,11 @@ class GetSastResultsToolIT {
     var response = getSastResultsTool.getScanResults(testProjectName);
 
     assertThat(response.isSuccess())
-        .as("query must succeed before warnings are inspected (single deterministic outcome)")
+        .as("query must succeed before notices are inspected (single deterministic outcome)")
         .isTrue();
     // Assert the verbatim message — substring "DEPRECATED" matches any rewording, including
     // garbage text that happens to contain the token, which would not actually warn AI consumers.
-    assertThat(response.warnings())
+    assertThat(response.notices())
         .as("response must contain the verbatim deprecation warning")
         .contains(DEPRECATION_WARNING);
   }
@@ -223,9 +223,9 @@ class GetSastResultsToolIT {
     assertThat(response.data()).as("notFound must not carry data").isNull();
     assertThat(response.errors()).as("notFound must not surface as an error").isEmpty();
     // Deprecation warning is added before the project lookup, so it must still be emitted on
-    // the notFound path. A regression that short-circuited warnings on null doExecute would
+    // the notFound path. A regression that short-circuited notices on null doExecute would
     // surface here.
-    assertThat(response.warnings())
+    assertThat(response.notices())
         .as("deprecation warning must still be emitted for missing projects")
         .contains(DEPRECATION_WARNING);
   }

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastResultsToolTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastResultsToolTest.java
@@ -120,7 +120,7 @@ class GetSastResultsToolTest {
     var result = tool.getScanResults(TEST_PROJECT_NAME);
 
     assertThat(result.isSuccess()).isTrue();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("DEPRECATED"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("DEPRECATED"));
   }
 
   @Test
@@ -147,7 +147,7 @@ class GetSastResultsToolTest {
 
     assertThat(result.found()).isFalse();
     assertThat(result.data()).isNull();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("DEPRECATED"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("DEPRECATED"));
   }
 
   @Test
@@ -165,8 +165,8 @@ class GetSastResultsToolTest {
 
     assertThat(result.found()).isFalse();
     assertThat(result.data()).isNull();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("No scan results available"));
-    assertThat(result.warnings()).anyMatch(w -> w.contains("DEPRECATED"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("No scan results available"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("DEPRECATED"));
   }
 
   @Test
@@ -186,9 +186,9 @@ class GetSastResultsToolTest {
 
     assertThat(result.found()).isFalse();
     assertThat(result.data()).isNull();
-    assertThat(result.warnings())
+    assertThat(result.notices())
         .anyMatch(w -> w.contains("No scan results available for project: " + TEST_PROJECT_NAME));
-    assertThat(result.warnings()).anyMatch(w -> w.contains("DEPRECATED"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("DEPRECATED"));
   }
 
   @Test

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastResultsToolTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastResultsToolTest.java
@@ -101,7 +101,7 @@ class GetSastResultsToolTest {
   }
 
   @Test
-  void getScanResults_should_include_deprecation_warning() throws IOException {
+  void getScanResults_should_include_deprecation_notice() throws IOException {
     var sarifJson = "{\"version\":\"2.1.0\",\"runs\":[]}";
 
     var mockProject =

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/params/GetSastResultsParamsTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/params/GetSastResultsParamsTest.java
@@ -56,10 +56,10 @@ class GetSastResultsParamsTest {
   }
 
   @Test
-  void of_should_have_no_warnings_for_valid_input() {
+  void of_should_have_no_notices_for_valid_input() {
     var params = GetSastResultsParams.of("valid-project-name");
 
     assertThat(params.isValid()).isTrue();
-    assertThat(params.warnings()).isEmpty();
+    assertThat(params.notices()).isEmpty();
   }
 }

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityLocalParityTest.java
@@ -67,7 +67,7 @@ class GetVulnerabilityLocalParityTest {
     assertThat(result.isSuccess()).isTrue(); // Not found is not an error
     assertThat(result.found()).isFalse();
     assertThat(result.data()).isNull();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("not found"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("not found"));
   }
 
   @Test
@@ -91,7 +91,7 @@ class GetVulnerabilityLocalParityTest {
   }
 
   @Test
-  void getVulnerability_should_add_warnings_for_partial_data() throws Exception {
+  void getVulnerability_should_add_notices_for_partial_data() throws Exception {
     Trace trace = mock();
     Vulnerability vulnerability = mock();
 
@@ -107,7 +107,7 @@ class GetVulnerabilityLocalParityTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.found()).isTrue();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("Recommendation data not available"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("Recommendation data not available"));
   }
 
   @Test

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java
@@ -563,10 +563,10 @@ public class GetVulnerabilityToolIT
     assertThat(response.notices())
         .as("notices list is part of the response contract — must never be null")
         .isNotNull();
-    // Each warning, if present, must carry a non-blank message — a blank warning provides no
+    // Each notice, if present, must carry a non-blank message — a blank notice provides no
     // diagnostic value to the AI consumer and would represent a producer-side bug.
     assertThat(response.notices())
-        .as("every warning must carry a non-blank message")
-        .allSatisfy(w -> assertThat(w).as("warning message").isNotBlank());
+        .as("every notice must carry a non-blank message")
+        .allSatisfy(w -> assertThat(w).as("notice message").isNotBlank());
   }
 }

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java
@@ -420,7 +420,7 @@ public class GetVulnerabilityToolIT
 
     // Detail-specific fields — built by the optional-data fetch in buildVulnerabilityContext.
     // These also have non-null contracts but may be empty when the underlying data isn't
-    // available (graceful degradation, signaled via warnings).
+    // available (graceful degradation, signaled via notices).
     assertThat(vuln.howToFix())
         .as("Vulnerability.howToFix must never be null (may be empty)")
         .isNotNull();
@@ -483,13 +483,13 @@ public class GetVulnerabilityToolIT
     var vuln = response.data();
     assertThat(vuln).as("response must carry data").isNotNull();
 
-    // The hint is generated from a static rule→guidance map in the hint subsystem and is keyed
-    // by the trace's rule. Every recognised rule produces a non-blank hint; an unrecognised
-    // rule produces a generic non-blank hint. A blank result would mean the hint subsystem was
-    // bypassed or returned the empty default — exactly the regression "Populate ≠ non-null"
-    // catches.
-    assertThat(vuln.hint())
-        .as("Vulnerability.hint must provide non-blank remediation guidance")
+    // The remediation hint is generated from a static rule→guidance map in the hint subsystem and
+    // is keyed by the trace's rule. Every recognised rule produces a non-blank hint; an
+    // unrecognised rule produces a generic non-blank hint. A blank result would mean the hint
+    // subsystem was bypassed or returned the empty default — exactly the regression "Populate ≠
+    // non-null" catches.
+    assertThat(vuln.remediationHint())
+        .as("Vulnerability.remediationHint must provide non-blank remediation guidance")
         .isNotBlank();
   }
 
@@ -550,22 +550,22 @@ public class GetVulnerabilityToolIT
         .isIn(AUTH_OR_NOT_FOUND_ERROR, ACCESS_OR_NOT_FOUND_ERROR);
   }
 
-  // ---------- Warnings (graceful degradation) ----------
+  // ---------- Notices (graceful degradation) ----------
 
   @Test
-  void getVulnerability_should_provide_non_null_warnings_list() {
-    // The warnings list is part of the response contract regardless of whether degradation
+  void getVulnerability_should_provide_non_null_notices_list() {
+    // The notices list is part of the response contract regardless of whether degradation
     // occurred. Some optional sub-fetches (recommendation, HTTP request, stack/library) are
-    // permitted to fail and are surfaced as warnings — but the list itself must always exist.
+    // permitted to fail and are surfaced as notices — but the list itself must always exist.
     var response = getVulnerabilityTool.getVulnerability(testData.vulnId, testData.appId);
 
     assertThat(response.isSuccess()).as("seeded retrieval must succeed").isTrue();
-    assertThat(response.warnings())
-        .as("warnings list is part of the response contract — must never be null")
+    assertThat(response.notices())
+        .as("notices list is part of the response contract — must never be null")
         .isNotNull();
     // Each warning, if present, must carry a non-blank message — a blank warning provides no
     // diagnostic value to the AI consumer and would represent a producer-side bug.
-    assertThat(response.warnings())
+    assertThat(response.notices())
         .as("every warning must carry a non-blank message")
         .allSatisfy(w -> assertThat(w).as("warning message").isNotBlank());
   }

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesLocalParityTest.java
@@ -39,7 +39,7 @@ class ListVulnerabilityTypesLocalParityTest {
   private static final String TEST_ORG_ID = "local-org-id-should-not-serialize";
   private static final byte[] S4C_LOCAL_STDIO_GOLDEN_JSON =
       ("{\"data\":[\"cmd-injection\",\"sql-injection\",\"xss-reflected\"],\"errors\":[],"
-              + "\"warnings\":[],\"found\":true,\"success\":true}")
+              + "\"notices\":[],\"found\":true,\"success\":true}")
           .getBytes(StandardCharsets.UTF_8);
 
   private final ObjectMapper objectMapper = new ObjectMapper();

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesLocalParityTest.java
@@ -143,7 +143,7 @@ class SearchAppVulnerabilitiesLocalParityTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.items()).isEmpty();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("API returned no trace data"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("API returned no trace data"));
   }
 
   @Test
@@ -155,7 +155,7 @@ class SearchAppVulnerabilitiesLocalParityTest {
             APP_ID, 1, 10, null, null, null, null, null, null, null, null, null);
 
     assertThat(result.isSuccess()).isTrue();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
   }
 
   @Test
@@ -178,7 +178,7 @@ class SearchAppVulnerabilitiesLocalParityTest {
         .containsExactly(
             "Access denied or resource not found. Verify credentials and that the resource ID is"
                 + " correct.");
-    assertThat(result.warnings()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
   }
 
   @Test

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesLocalParityTest.java
@@ -134,7 +134,7 @@ class SearchAppVulnerabilitiesLocalParityTest {
   }
 
   @Test
-  void searchAppVulnerabilities_should_add_warning_when_api_returns_null() throws Exception {
+  void searchAppVulnerabilities_should_add_notice_when_api_returns_null() throws Exception {
     mockSdkWithTracesResponse(TracesJsonFixture.nullTraces());
 
     var result =
@@ -147,7 +147,7 @@ class SearchAppVulnerabilitiesLocalParityTest {
   }
 
   @Test
-  void searchAppVulnerabilities_should_use_default_statuses_with_warning() throws Exception {
+  void searchAppVulnerabilities_should_use_default_statuses_with_notice() throws Exception {
     mockSdkWithTracesResponse(TracesJsonFixture.emptyTraces());
 
     var result =

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolIT.java
@@ -113,8 +113,8 @@ public class SearchAppVulnerabilitiesToolIT
   // String the API will not match against any real application.
   private static final String NONEXISTENT_APP_ID = "nonexistent-app-id-12345";
 
-  // Tool warning emitted when useLatestSession=true but the app has no recorded sessions.
-  private static final String NO_SESSIONS_WARNING = "No sessions found for this application";
+  // Tool notice emitted when useLatestSession=true but the app has no recorded sessions.
+  private static final String NO_SESSIONS_NOTICE = "No sessions found for this application";
 
   /** Container for discovered test data. */
   static class TestData {
@@ -756,9 +756,9 @@ public class SearchAppVulnerabilitiesToolIT
     assertThat(latest.errors()).as("useLatestSession=true must not surface errors").isEmpty();
     assertThat(latest.notices())
         .as(
-            "app '%s' has session metadata, so the no-sessions fallback warning must not fire",
+            "app '%s' has session metadata, so the no-sessions fallback notice must not fire",
             testData.sampleAppId)
-        .noneMatch(w -> w.contains(NO_SESSIONS_WARNING));
+        .noneMatch(w -> w.contains(NO_SESSIONS_NOTICE));
 
     // Every returned vuln must carry sessionMetadata — the parameter scopes the result set to
     // a single session, so missing sessionMetadata on any item indicates the param was silently
@@ -869,8 +869,8 @@ public class SearchAppVulnerabilitiesToolIT
   @Test
   void searchAppVulnerabilities_should_apply_default_status_filter() {
     // When no statuses param is supplied, SearchAppVulnerabilitiesParams substitutes the default
-    // (Reported, Suspicious, Confirmed) and emits a warning. This test verifies BOTH halves of
-    // that contract: the warning fires AND the filter actually narrows the result set — every
+    // (Reported, Suspicious, Confirmed) and emits a notice. This test verifies BOTH halves of
+    // that contract: the notice fires AND the filter actually narrows the result set — every
     // returned vuln must have a non-terminal status.
     var response =
         searchAppVulnerabilitiesTool.searchAppVulnerabilities(
@@ -890,11 +890,11 @@ public class SearchAppVulnerabilitiesToolIT
     assertThat(response.isSuccess()).as("default-filter query must succeed").isTrue();
     assertThat(response.errors()).as("default-filter query must not produce errors").isEmpty();
     assertThat(response.notices())
-        .as("must surface the default-status warning identifying which statuses were excluded")
+        .as("must surface the default-status notice identifying which statuses were excluded")
         .anyMatch(w -> w.contains("excluding Fixed and Remediated"));
 
     // Universal-quantifier check: any returned row must NOT have a terminal status. Vacuously
-    // true on empty (when the seeded app has only Fixed/Remediated vulns), but the warning
+    // true on empty (when the seeded app has only Fixed/Remediated vulns), but the notice
     // assertion above already proves the filter was applied. A regression that forwarded the
     // wrong status set server-side would surface here as a Fixed/Remediated row leaking through.
     assertThat(response.items())

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolIT.java
@@ -754,7 +754,7 @@ public class SearchAppVulnerabilitiesToolIT
 
     assertThat(latest.isSuccess()).as("useLatestSession=true must succeed").isTrue();
     assertThat(latest.errors()).as("useLatestSession=true must not surface errors").isEmpty();
-    assertThat(latest.warnings())
+    assertThat(latest.notices())
         .as(
             "app '%s' has session metadata, so the no-sessions fallback warning must not fire",
             testData.sampleAppId)
@@ -889,7 +889,7 @@ public class SearchAppVulnerabilitiesToolIT
 
     assertThat(response.isSuccess()).as("default-filter query must succeed").isTrue();
     assertThat(response.errors()).as("default-filter query must not produce errors").isEmpty();
-    assertThat(response.warnings())
+    assertThat(response.notices())
         .as("must surface the default-status warning identifying which statuses were excluded")
         .anyMatch(w -> w.contains("excluding Fixed and Remediated"));
 
@@ -1052,7 +1052,7 @@ public class SearchAppVulnerabilitiesToolIT
 
     assertThat(response.isSuccess()).as("far-future lastSeenAfter must succeed").isTrue();
     assertThat(response.errors()).as("far-future lastSeenAfter must not error").isEmpty();
-    assertThat(response.warnings())
+    assertThat(response.notices())
         .as("date filter must surface the lastTimeSeen advisory")
         .anyMatch(w -> w.contains("LAST ACTIVITY DATE") || w.contains("lastTimeSeen"));
     assertThat(response.items())

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesLocalParityTest.java
@@ -111,7 +111,7 @@ class SearchVulnerabilitiesLocalParityTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.items()).isEmpty();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("API returned no trace data"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("API returned no trace data"));
   }
 
   @Test
@@ -121,18 +121,18 @@ class SearchVulnerabilitiesLocalParityTest {
     var result = tool.searchVulnerabilities(1, 10, null, null, null, null, null, null, null);
 
     assertThat(result.isSuccess()).isTrue();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
   }
 
   @Test
-  void searchVulnerabilities_should_propagate_pagination_warnings() throws Exception {
+  void searchVulnerabilities_should_propagate_pagination_notices() throws Exception {
     mockSdkWithTracesResponse(TracesJsonFixture.emptyTraces());
 
     // Invalid page number
     var result = tool.searchVulnerabilities(-1, 10, null, null, null, null, null, null, null);
 
     assertThat(result.isSuccess()).isTrue();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("Invalid page number"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("Invalid page number"));
   }
 
   @Test
@@ -143,7 +143,7 @@ class SearchVulnerabilitiesLocalParityTest {
         tool.searchVulnerabilities(1, 10, null, null, null, null, "2025-01-01", null, null);
 
     assertThat(result.isSuccess()).isTrue();
-    assertThat(result.warnings()).anyMatch(w -> w.contains("LAST ACTIVITY DATE"));
+    assertThat(result.notices()).anyMatch(w -> w.contains("LAST ACTIVITY DATE"));
   }
 
   // -- Filter contract verification tests (Khorikov-compliant communication-based testing) --

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesLocalParityTest.java
@@ -104,7 +104,7 @@ class SearchVulnerabilitiesLocalParityTest {
   }
 
   @Test
-  void searchVulnerabilities_should_add_warning_when_api_returns_null() throws Exception {
+  void searchVulnerabilities_should_add_notice_when_api_returns_null() throws Exception {
     mockSdkWithTracesResponse(TracesJsonFixture.nullTraces());
 
     var result = tool.searchVulnerabilities(1, 10, null, null, null, null, null, null, null);
@@ -115,7 +115,7 @@ class SearchVulnerabilitiesLocalParityTest {
   }
 
   @Test
-  void searchVulnerabilities_should_include_default_status_warning() throws Exception {
+  void searchVulnerabilities_should_include_default_status_notice() throws Exception {
     mockSdkWithTracesResponse(TracesJsonFixture.emptyTraces());
 
     var result = tool.searchVulnerabilities(1, 10, null, null, null, null, null, null, null);
@@ -136,7 +136,7 @@ class SearchVulnerabilitiesLocalParityTest {
   }
 
   @Test
-  void searchVulnerabilities_should_include_date_warning_when_dates_specified() throws Exception {
+  void searchVulnerabilities_should_include_date_notice_when_dates_specified() throws Exception {
     mockSdkWithTracesResponse(TracesJsonFixture.emptyTraces());
 
     var result =

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolIT.java
@@ -436,7 +436,7 @@ public class SearchVulnerabilitiesToolIT
             1, 50, null, null, null, null, null, null, null);
 
     assertThat(response.isSuccess()).as("default-filter query must succeed").isTrue();
-    assertThat(response.warnings())
+    assertThat(response.notices())
         .as("must surface the default-status warning")
         .anyMatch(w -> w.contains("excluding Fixed and Remediated"));
 
@@ -514,7 +514,7 @@ public class SearchVulnerabilitiesToolIT
 
     assertThat(response.isSuccess()).as("far-future lastSeenAfter must succeed").isTrue();
     assertThat(response.errors()).as("far-future lastSeenAfter must not error").isEmpty();
-    assertThat(response.warnings())
+    assertThat(response.notices())
         .as("date filter must surface the lastTimeSeen advisory")
         .anyMatch(w -> w.contains("LAST ACTIVITY DATE") || w.contains("lastTimeSeen"));
     assertThat(response.items())

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolIT.java
@@ -427,17 +427,17 @@ public class SearchVulnerabilitiesToolIT
   @Test
   void searchVulnerabilities_should_apply_default_status_filter() {
     // When no status param is supplied, VulnerabilityFilterParams substitutes the default
-    // (Reported, Suspicious, Confirmed) and emits a warning. This test verifies BOTH halves
-    // of that contract: the warning fires AND the filter actually narrows the result set —
+    // (Reported, Suspicious, Confirmed) and emits a notice. This test verifies BOTH halves
+    // of that contract: the notice fires AND the filter actually narrows the result set —
     // every returned vuln must have a non-terminal status. A regression that emitted the
-    // warning text without applying the filter would surface here.
+    // notice text without applying the filter would surface here.
     var response =
         searchVulnerabilitiesTool.searchVulnerabilities(
             1, 50, null, null, null, null, null, null, null);
 
     assertThat(response.isSuccess()).as("default-filter query must succeed").isTrue();
     assertThat(response.notices())
-        .as("must surface the default-status warning")
+        .as("must surface the default-status notice")
         .anyMatch(w -> w.contains("excluding Fixed and Remediated"));
 
     if (response.items().isEmpty()) {

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityMapperTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityMapperTest.java
@@ -207,8 +207,8 @@ class VulnerabilityMapperTest {
     assertThat(result.vulnerableLibraries()).hasSize(1);
     assertThat(result.vulnerableLibraries().get(0)).isEqualTo(library);
     assertThat(result.httpRequest()).isEqualTo("GET /api/test");
-    assertThat(result.hint()).isNotNull();
-    assertThat(result.hint()).isNotEmpty(); // HintGenerator provides guidance
+    assertThat(result.remediationHint()).isNotNull();
+    assertThat(result.remediationHint()).isNotEmpty(); // HintGenerator provides guidance
     assertThat(result.environments()).containsExactly("PRODUCTION", "QA");
     assertThat(result.tags()).containsExactly("reviewed", "critical");
     assertThat(result.sessionMetadata()).isEmpty();

--- a/docs/adr/0001-notices-tier-and-point-of-use-teaching.md
+++ b/docs/adr/0001-notices-tier-and-point-of-use-teaching.md
@@ -9,7 +9,7 @@ To support this, the envelope's informational tier is renamed from `warnings` to
 ## Considered options
 
 - A third `notes` tier beside `errors` and `warnings`. Rejected. Agents behave identically on a warning and a note, and an earlier consolidation had already merged the informational tiers once.
-- Keeping the `warnings` name to avoid a breaking wire change. Rejected while the rename window is open. The field was nearly unused, and it is about to become the primary teaching channel, so the name will never be cheaper to fix than now.
+- Keeping the `warnings` name to avoid a breaking wire change. Rejected while the rename window was open. The field was nearly unused, and the planned point-of-use teaching would make it the primary teaching channel, so the name would never be cheaper to fix.
 - Alternative names `messages` (collides with chat message arrays in LLM contexts), `advisories` (reads as security advisories in an appsec product), `info` (log-level connotation). `notices` fits both teaching notes and degradation reports.
 
 ## Consequences

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -17,7 +17,7 @@ if ! ./gradlew spotlessApply 2>&1; then
   echo "Commit blocked: formatter failed."
   exit 1
 fi
-git diff --name-only | grep '\.java$' | xargs -r git add || true
+git diff --name-only '*.java' | xargs -r git add
 
 echo "Running tests..."
 if ! ./gradlew test 2>&1; then

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -5,7 +5,14 @@
 
 set -euo pipefail
 
-if ! git diff --cached --name-only | grep -q '\.java$'; then
+if [ "${SKIP_PRECOMMIT:-0}" = "1" ]; then
+  echo "SKIP_PRECOMMIT=1 set, skipping pre-commit checks."
+  exit 0
+fi
+
+# --quiet exits 0 when no staged .java changes exist. A grep -q pipe here can
+# exit 141 under pipefail if git diff takes a SIGPIPE, silently skipping the hook.
+if git diff --cached --quiet -- '*.java'; then
   exit 0
 fi
 
@@ -17,7 +24,7 @@ if ! ./gradlew spotlessApply 2>&1; then
   echo "Commit blocked: formatter failed."
   exit 1
 fi
-git diff --name-only '*.java' | xargs -r git add
+git diff --name-only -z -- '*.java' | xargs -r -0 git add
 
 echo "Running tests..."
 if ! ./gradlew test 2>&1; then

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -17,7 +17,7 @@ if ! ./gradlew spotlessApply 2>&1; then
   echo "Commit blocked: formatter failed."
   exit 1
 fi
-git diff --name-only | grep '\.java$' | xargs -r git add
+git diff --name-only | grep '\.java$' | xargs -r git add || true
 
 echo "Running tests..."
 if ! ./gradlew test 2>&1; then

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,14 +1,8 @@
 #!/bin/bash
 # Pre-commit hook: format, test, and check staged Java files.
 # Mirrors the checks that CI runs, catching failures before they leave the machine.
-# Skip with: SKIP_PRECOMMIT=1 git commit
 
 set -euo pipefail
-
-if [ "${SKIP_PRECOMMIT:-0}" = "1" ]; then
-  echo "SKIP_PRECOMMIT=1 set, skipping pre-commit checks."
-  exit 0
-fi
 
 # --quiet exits 0 when no staged .java changes exist. A grep -q pipe here can
 # exit 141 under pipefail if git diff takes a SIGPIPE, silently skipping the hook.


### PR DESCRIPTION
**Jira:** [AIML-942](https://contrast.atlassian.net/browse/AIML-942)

## ℹ️ _NOTE!_
_**This is a large PR, but almost entirely renames.**_

_I'm building a mechanism to reduce context in tool descriptions. Today, all guidance notes are embedded in every description, and customers are reporting token usage is too high (20k tokens, which I agree is excessive). The fix is to attach these notes dynamically as "Notices" only when specific conditions arise._

_The rename is the bulk of this diff. These messages were previously called "Warnings," which caused agents to treat them as problems when they aren't. Renaming to "Notices" fixes that. I underestimated how many files the rename would touch._

## Summary

Renames the MCP response envelope's `warnings` field to `notices` across all three response types and renames the `Vulnerability` record's `hint` field to `remediationHint`. This is the wire-format rename that MCP_STANDARDS v2 deferred behind a migration note, now shipped. Both renames change what AI agents see on the wire, aligning field names with what the data actually represents.

- Response envelope field `warnings` → `notices` on `PaginatedToolResponse`, `SingleToolResponse`, and `CursorToolResponse`
- Internal `WarningCollector` → `NoticeCollector` with method renames (`warn()` → `notice()`, etc.)
- `Vulnerability.hint` → `Vulnerability.remediationHint` for self-documenting field semantics

## Why This Change Exists

The parent PR (AIML-942 canonical description standard) introduced `notices` as the documented name for informational messages in MCP_STANDARDS v2, but kept the wire field as `warnings` with a migration note: "The wire field is named `warnings` until the AIML-942 envelope rename ships." This PR ships that rename.

The old name `warnings` primed AI agents to treat informational teaching notes as problems and waste turns "fixing" normal behavior. `notices` better reflects the intent established in ADR 0001 (notices tier and point-of-use teaching).

The `hint` → `remediationHint` rename follows the same principle from MCP_STANDARDS: "Prefer renaming a misleading field over documenting it. A rename costs zero recurring tokens." Bundled here so the wire shape breaks only once. Broader renames (`environments` → `environmentsLatestInstance`, `httpRequest` → `httpRequestRedacted`) were considered and declined because the clarity gain didn't justify the breaking change. Those facts stay as standing description clauses instead. The MCP_STANDARDS example was updated to reference the shipped `remediationHint` rename rather than the declined `httpRequestRedacted`.

## Review Guide

### 1. Wire format proof — **Focus**
Two new test files prove the wire shape changed correctly. `ResponseEnvelopeSerializationTest` serializes each response type to JSON and asserts `"notices"` is present while `"warnings"` is absent. `VulnerabilityTest` does the same for `remediationHint` vs `hint`.

- `contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/ResponseEnvelopeSerializationTest.java` (new) — serialization contract for all three envelope types
- `contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/result/VulnerabilityTest.java` (new) — serialization contract for Vulnerability record

### 2. Core rename: WarningCollector → NoticeCollector — **Focus**
The class rename and all method renames (`warn` → `notice`, `warnForEmptyResults` → `noticeForEmptyResults`, `hasEmptyResultsWarning` → `hasEmptyResultsNotice`). Behavior is unchanged.

- `contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/NoticeCollector.java` (renamed from `WarningCollector.java`)
- `contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/NoticeCollectorTest.java` (renamed from `WarningCollectorTest.java`)

### 3. Response envelope records — **Skim**
Field rename `warnings` → `notices` in the three response records and their factory methods. No logic change.

- `contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolResponse.java`
- `contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolResponse.java`
- `contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorToolResponse.java`

### 4. Base tool classes and params — **Skim**
Updating `WarningCollector` references to `NoticeCollector` in base tool pipelines, and `warnings()` to `notices()` in params.

- `contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java`
- `contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java`
- `contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java`
- `contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseToolParams.java`
- `contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/ToolParams.java`
- `contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParams.java`
- `contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParams.java`

### 5. Vulnerability record — **Skim**
Single field rename `hint` → `remediationHint`.

- `contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/Vulnerability.java`

### 6. Standards doc — **Skim**
Removes the migration note from MCP_STANDARDS.md and updates the rename example to use the shipped `remediationHint` instead of the declined `httpRequestRedacted`.

- `MCP_STANDARDS.md`

<details>
<summary>Mechanical / low-risk changes (83 files)</summary>

Tool implementations updating `WarningCollector` → `NoticeCollector` import and `doExecute` signature (13 files), `warn()` → `notice()` / `warnIf()` → `noticeIf()` call sites (5 files), validation context `warnIf` → `noticeIf` and `warnings` → `notices` (7 files), and all corresponding test files updating assertions from `warnings()` to `notices()` and `warn()` to `notice()` (58 files). No logic changes in any of these files.

</details>

## Testing

- `ResponseEnvelopeSerializationTest` proves the wire format: all three response types serialize `notices` and do not emit `warnings`
- `VulnerabilityTest` proves the `remediationHint` field serializes under the new name without a legacy `hint` key
- All existing tests updated to reference `notices()` instead of `warnings()` and `NoticeCollector` instead of `WarningCollector`

## Risks / Rollout / Follow-ups

This is a **breaking wire-format change**. Any downstream consumer parsing `warnings` from MCP tool responses must update to `notices`. The parent PR's MCP_STANDARDS v2 established `notices` as the target name and flagged the rename as pending, so consumers following the standard already expect this.

The hosted server (aiml-services) consumes contrast-mcp-core as a Maven dependency. The actual artifact-coordinate bump must wait for the breaking core release to be published. Changes were verified locally using composite build substitution.


[AIML-942]: https://contrast.atlassian.net/browse/AIML-942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
