### PR TITLE
AIML-942 Migrate vulnerability tool descriptions to templates and notices

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,17 +30,6 @@
           }
         ]
       }
-    ],
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/trauma_guard.py"
-          }
-        ]
-      }
     ]
   }
 }

--- a/MCP_STANDARDS.md
+++ b/MCP_STANDARDS.md
@@ -175,6 +175,15 @@ Each verb shape has a fixed template. Every slot except the lead is optional. Th
 
 **Escape hatch.** A description may exceed its budget only when the overage is use-when/don't-use disambiguation, and the overage must name the sibling it disambiguates against. The enforcement test records the exemption in a reviewed allowlist.
 
+### Repository boundary
+
+Tool descriptions in this public repository must refer only to tools exposed by `mcp-contrast`.
+They must never name hosted-only tools from `aiml-services`, because `mcp-contrast` can be
+deployed independently and those tools may not exist. The hosted `aiml-services` catalog may refer
+to public `mcp-contrast` tools because it deliberately aggregates them. Cross-repo routing that
+would otherwise require a reverse public-to-hosted reference belongs in the hosted server's
+instructions once that channel clears its delivery gate.
+
 ### Transitional clauses
 
 Interpretation prose stays in a description until the notice, rename, or output-schema property that replaces it ships, and it moves in the same change as the code that replaces it. Transitional clauses count against the budget and are tied to the change that removes them, so shipping the replacement is how a tool reclaims its headroom.
@@ -391,6 +400,7 @@ For any other application that consumes `contrast-mcp-core`, register tools thro
 - [ ] Body follows the verb-shape template and is within budget (search/list ≤150 words, get ≤40, update ≤60), or carries a named allowlist exemption for sibling disambiguation
 - [ ] Every fact sits in its one home per the routing table, no body/param duplication
 - [ ] Prerequisite and discovery pointers inline, no "Related tools" footer
+- [ ] References only tools exposed by `mcp-contrast`, never hosted-only `aiml-services` tools
 - [ ] At most three usage examples, combinations preferred
 - [ ] No documented parameter the tool does not accept, no response-field inventory
 - [ ] Transitional clauses tagged and tied to the change that removes them

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
@@ -117,7 +117,11 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
 
     var httpRequestText =
         collector
-            .tryFetch("HTTP request data", () -> contrastApiClient.getHttpRequest(vulnId))
+            .tryFetch(
+                "HTTP request data",
+                () ->
+                    Optional.ofNullable(contrastApiClient.getHttpRequest(vulnId))
+                        .orElseGet(HttpRequestResponse::new))
             .map(r -> redactedHttpRequestOrNotice(r, collector))
             .orElse(null);
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
@@ -28,6 +28,7 @@ import com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants;
 import com.contrast.labs.ai.mcp.contrast.tool.vulnerability.params.GetVulnerabilityParams;
 import com.contrastsecurity.http.TraceFilterForm;
 import com.contrastsecurity.models.EventResource;
+import com.contrastsecurity.models.HttpRequestResponse;
 import com.contrastsecurity.models.Stacktrace;
 import java.time.Duration;
 import java.time.Instant;
@@ -52,6 +53,9 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vulnerability> {
 
+  private static final String NO_TRIGGER_EVENTS_NOTICE =
+      "Stack trace not available because no trigger events were captured for this vulnerability.";
+
   private final ContrastApiClient contrastApiClient;
   private final VulnerabilityMapper vulnerabilityMapper;
 
@@ -59,28 +63,10 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
       name = "get_vulnerability",
       description =
           """
-          Get detailed information about a specific vulnerability by ID.
-
-          Returns comprehensive vulnerability data including remediation guidance,
-          stack traces, and vulnerable library information when available.
-
-          Response fields:
-          - remediationHint: AI-generated remediation hint based on vulnerability type
-          - howToFix: Official remediation recommendation from Contrast
-          - stackTrace: Stack frames with library hash links (available when trigger events exist)
-          - vulnerableLibraries: Libraries in the stack with known CVEs
-          - httpRequest: The HTTP request that triggered the vulnerability (if captured, sensitive headers removed)
-          - environments: Latest instance only, may omit environments from earlier instances.
-
-          Usage examples:
-          - Get vulnerability details: vulnId="VULN-ABC123", appId="app-123"
-
-          Note: Some fields may be null if data wasn't captured or isn't available.
-          Notices indicate retrieval errors (transient failures where retrying may help).
-
-          Related tools:
-          - search_vulnerabilities: Find vulnerability IDs by filtering on severity, status, etc.
-          - search_applications: Find application IDs by name or tag
+          Get full vulnerability details by ID, including remediation guidance, stack traces, and \
+          vulnerable libraries. Use search_vulnerabilities or search_app_vulnerabilities to \
+          discover vulnerability IDs. httpRequest has sensitive headers removed. environments \
+          reflects the latest instance only and may omit earlier instances.
           """)
   public SingleToolResponse<Vulnerability> getVulnerability(
       @ToolParam(description = "Vulnerability ID (use search_vulnerabilities to find)")
@@ -132,8 +118,7 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
     var httpRequestText =
         collector
             .tryFetch("HTTP request data", () -> contrastApiClient.getHttpRequest(vulnId))
-            .filter(r -> r.getHttpRequest() != null)
-            .map(r -> HttpRequestRedactor.redact(r.getHttpRequest().getText()))
+            .map(r -> redactedHttpRequestOrNotice(r, collector))
             .orElse(null);
 
     var stackLibs = new ArrayList<StackLib>();
@@ -141,7 +126,7 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
 
     collector.tryRun(
         "Stack trace data",
-        () -> buildStackTraceAndLibraryData(vulnId, appId, stackLibs, libsToReturn));
+        () -> buildStackTraceAndLibraryData(vulnId, appId, stackLibs, libsToReturn, collector));
 
     return VulnerabilityContext.builder()
         .recommendation(recommendationText)
@@ -151,12 +136,26 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
         .build();
   }
 
+  private static String redactedHttpRequestOrNotice(
+      HttpRequestResponse response, NoticeCollector collector) {
+    if (response.getHttpRequest() == null || response.getHttpRequest().getText() == null) {
+      collector.notice("HTTP request data was not captured for this vulnerability.");
+      return null;
+    }
+    return HttpRequestRedactor.redact(response.getHttpRequest().getText());
+  }
+
   private void buildStackTraceAndLibraryData(
-      String vulnId, String appId, List<StackLib> stackLibs, HashSet<LibraryExtended> libsToReturn)
+      String vulnId,
+      String appId,
+      List<StackLib> stackLibs,
+      HashSet<LibraryExtended> libsToReturn,
+      NoticeCollector collector)
       throws Exception {
 
     var eventSummaryResponse = contrastApiClient.getEventSummary(vulnId);
     if (eventSummaryResponse == null || eventSummaryResponse.getEvents() == null) {
+      collector.notice(NO_TRIGGER_EVENTS_NOTICE);
       return;
     }
 
@@ -166,6 +165,7 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
             .findFirst();
 
     if (triggerEvent.isEmpty()) {
+      collector.notice(NO_TRIGGER_EVENTS_NOTICE);
       return;
     }
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java
@@ -54,28 +54,23 @@ public class SearchAppVulnerabilitiesTool
       name = "search_app_vulnerabilities",
       description =
           """
-          Application-scoped vulnerability search with all filters plus session-based filtering.
+          Application-scoped vulnerability search with session-based filtering.
 
-          Required: appId parameter. Use search_applications tool to find application IDs by name.
+          Requires appId. Use search_applications to find application IDs by name.
 
-          Session filtering (mutually exclusive - choose ONE):
-          - sessionMetadataFilters: JSON object for filtering by session metadata
-            - AND across fields: {"developer":"Ellen","commit":"100"}
-            - OR for multiple values within a field: {"developer":["Ellen","Sam"]}
-            - Combined: {"developer":["Ellen","Sam"],"branch":"main"}
-            - Values must be non-empty (empty, null, or whitespace-only values are rejected)
-          - useLatestSession=true: Filter to the most recent session only
+          Use this instead of search_vulnerabilities when you need to filter by session metadata or \
+          latest session. Use this instead of search_issues when working with Classic (TeamServer) \
+          vulnerability data rather than unified NorthStar issues.
 
-          Note: useLatestSession and sessionMetadataFilters are mutually exclusive.
-          If useLatestSession=true and no sessions exist, returns all vulnerabilities
-          for the application with a notice.
+          Session filtering options are mutually exclusive: use either sessionMetadataFilters (JSON \
+          object with AND across fields, OR within a field) or useLatestSession=true, not both.
 
-          Common usage examples:
-          - All vulns in app: appId="abc123"
+          A result's environments field reflects only its latest instance and may omit environments \
+          from earlier instances.
+
+          Examples:
           - Latest session vulns: appId="abc123", useLatestSession=true
-          - Single metadata filter: appId="abc123", sessionMetadataFilters='{"branch":"main"}'
-          - Multiple filters (AND): appId="abc123", sessionMetadataFilters='{"branch":"main","developer":"Ellen"}'
-          - Multiple values (OR): appId="abc123", sessionMetadataFilters='{"developer":["Ellen","Sam"]}'
+          - Metadata filter: appId="abc123", sessionMetadataFilters='{"branch":"main"}'
           - Production critical: appId="abc123", severities="CRITICAL", environments="PRODUCTION"
           """)
   public PaginatedToolResponse<VulnLight> searchAppVulnerabilities(
@@ -105,8 +100,7 @@ public class SearchAppVulnerabilitiesTool
       @ToolParam(
               description =
                   "Comma-separated environments: DEVELOPMENT,QA,PRODUCTION. Matches any historical"
-                      + " vulnerability instance. A result's environments field describes only its"
-                      + " latest instance and may omit the matched value",
+                      + " vulnerability instance",
               required = false)
           String environments,
       @ToolParam(
@@ -128,7 +122,7 @@ public class SearchAppVulnerabilitiesTool
                   "JSON object for session metadata filters. Format: {\"fieldName\":\"value\"} or"
                       + " {\"fieldName\":[\"val1\",\"val2\"]}. Multiple fields use AND logic."
                       + " Multiple values within a field use OR logic. Field names are"
-                      + " case-insensitive. Values are case-sensitive.",
+                      + " case-insensitive. Values are case-sensitive and must be non-empty.",
               required = false)
           String sessionMetadataFilters,
       @ToolParam(description = "Filter to latest session only", required = false)
@@ -200,8 +194,8 @@ public class SearchAppVulnerabilitiesTool
         log.debug("Using latest session ID: {}", agentSessionId);
       } else {
         collector.notice(
-            "No sessions found for this application. Returning all vulnerabilities across all"
-                + " sessions for this application.");
+            "No sessions found for this application. Results include all vulnerabilities across"
+                + " all sessions.");
         log.warn("No sessions found for application: {}", appId);
       }
     }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java
@@ -59,8 +59,7 @@ public class SearchAppVulnerabilitiesTool
           Requires appId. Use search_applications to find application IDs by name.
 
           Use this instead of search_vulnerabilities when you need to filter by session metadata or \
-          latest session. Use this instead of search_issues when working with Classic (TeamServer) \
-          vulnerability data rather than unified NorthStar issues.
+          latest session.
 
           Session filtering options are mutually exclusive: use either sessionMetadataFilters (JSON \
           object with AND across fields, OR within a field) or useLatestSession=true, not both.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/ResponseEnvelopeSerializationTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/ResponseEnvelopeSerializationTest.java
@@ -17,13 +17,12 @@ package com.contrast.labs.ai.mcp.contrast.tool.base;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.springframework.ai.util.json.JsonParser;
 
 class ResponseEnvelopeSerializationTest {
-
-  private final ObjectMapper objectMapper = new ObjectMapper();
 
   @Test
   void paginatedResponse_should_serialize_notices_without_legacy_warnings_field() throws Exception {
@@ -31,14 +30,14 @@ class ResponseEnvelopeSerializationTest {
         PaginatedToolResponse.success(
             List.of("item"), 1, 50, 1, false, List.of("Applied default"), 1L);
 
-    assertNoticesWireShape(response);
+    assertNoticesWireShape(serialize(response));
   }
 
   @Test
   void singleResponse_should_serialize_notices_without_legacy_warnings_field() throws Exception {
     var response = SingleToolResponse.success("item", List.of("Optional enrichment unavailable"));
 
-    assertNoticesWireShape(response);
+    assertNoticesWireShape(serialize(response));
   }
 
   @Test
@@ -47,27 +46,42 @@ class ResponseEnvelopeSerializationTest {
         CursorToolResponse.success(
             List.of("item"), 50, "next-cursor", true, List.of("Applied default"), 1L);
 
-    assertNoticesWireShape(response);
+    assertNoticesWireShape(serialize(response));
   }
 
   @Test
   void responseEnvelopes_should_serialize_empty_notices_arrays() throws Exception {
     assertEmptyNoticesWireShape(
-        PaginatedToolResponse.success(List.of("item"), 1, 50, 1, false, List.of(), 1L));
-    assertEmptyNoticesWireShape(SingleToolResponse.success("item", List.of()));
+        serialize(PaginatedToolResponse.success(List.of("item"), 1, 50, 1, false, List.of(), 1L)));
+    assertEmptyNoticesWireShape(serialize(SingleToolResponse.success("item", List.of())));
     assertEmptyNoticesWireShape(
-        CursorToolResponse.success(List.of("item"), 50, null, false, List.of(), 1L));
+        serialize(CursorToolResponse.success(List.of("item"), 50, null, false, List.of(), 1L)));
   }
 
-  private void assertNoticesWireShape(Object response) throws Exception {
-    var json = objectMapper.writeValueAsString(response);
-
-    assertThat(json).contains("\"notices\":[").doesNotContain("\"warnings\"");
+  private void assertNoticesWireShape(JsonNode json) {
+    assertThat(json.has("notices")).isTrue();
+    assertThat(json.path("notices").isArray()).isTrue();
+    assertThat(json.has("warnings")).isFalse();
   }
 
-  private void assertEmptyNoticesWireShape(Object response) throws Exception {
-    var json = objectMapper.writeValueAsString(response);
+  private void assertEmptyNoticesWireShape(JsonNode json) {
+    assertNoticesWireShape(json);
+    assertThat(json.path("notices").size()).isZero();
+  }
 
-    assertThat(json).contains("\"notices\":[]").doesNotContain("\"warnings\"");
+  private JsonNode serialize(PaginatedToolResponse<?> response) throws Exception {
+    return parse(JsonParser.toJson(response));
+  }
+
+  private JsonNode serialize(SingleToolResponse<?> response) throws Exception {
+    return parse(JsonParser.toJson(response));
+  }
+
+  private JsonNode serialize(CursorToolResponse<?> response) throws Exception {
+    return parse(JsonParser.toJson(response));
+  }
+
+  private JsonNode parse(String json) throws Exception {
+    return JsonParser.getObjectMapper().readTree(json);
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolTest.java
@@ -318,6 +318,44 @@ class GetVulnerabilityToolTest {
   }
 
   @Test
+  void getVulnerability_should_notice_when_http_request_text_null() throws Exception {
+    Trace trace = mock();
+    Vulnerability vulnerability = mock();
+    var httpRequest = new HttpRequest();
+    var httpResponse = new HttpRequestResponse();
+    httpResponse.setHttpRequest(httpRequest);
+
+    when(contrastApiClient.getVulnerability(eq(VALID_APP_ID), eq(VALID_VULN_ID), any()))
+        .thenReturn(trace);
+    when(contrastApiClient.getHttpRequest(VALID_VULN_ID)).thenReturn(httpResponse);
+    when(vulnerabilityMapper.toFullVulnerability(eq(trace), any(VulnerabilityContext.class)))
+        .thenReturn(vulnerability);
+
+    var result = tool.getVulnerability(VALID_VULN_ID, VALID_APP_ID);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.notices())
+        .contains("HTTP request data was not captured for this vulnerability.");
+  }
+
+  @Test
+  void getVulnerability_should_notice_when_http_request_response_null() throws Exception {
+    Trace trace = mock();
+    Vulnerability vulnerability = mock();
+    when(contrastApiClient.getVulnerability(eq(VALID_APP_ID), eq(VALID_VULN_ID), any()))
+        .thenReturn(trace);
+    when(contrastApiClient.getHttpRequest(VALID_VULN_ID)).thenReturn(null);
+    when(vulnerabilityMapper.toFullVulnerability(eq(trace), any(VulnerabilityContext.class)))
+        .thenReturn(vulnerability);
+
+    var result = tool.getVulnerability(VALID_VULN_ID, VALID_APP_ID);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.notices())
+        .contains("HTTP request data was not captured for this vulnerability.");
+  }
+
+  @Test
   void getVulnerability_should_not_notice_http_request_when_captured() throws Exception {
     Trace trace = mock();
     Vulnerability vulnerability = mock();

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolTest.java
@@ -225,14 +225,114 @@ class GetVulnerabilityToolTest {
   }
 
   @Test
-  void getVulnerability_should_document_environment_response_semantics() throws Exception {
+  void getVulnerability_should_keep_standing_clauses_and_discovery_pointer_in_description()
+      throws Exception {
     Method method =
         GetVulnerabilityTool.class.getDeclaredMethod(
             "getVulnerability", String.class, String.class, ToolContext.class);
 
     assertThat(method.getAnnotation(Tool.class).description())
-        .contains("Latest instance only", "may omit environments from earlier instances")
-        .doesNotContain("All environments where this vulnerability has been observed");
+        .contains("Use search_vulnerabilities or search_app_vulnerabilities")
+        .contains("httpRequest has sensitive headers removed")
+        .contains("environments reflects the latest instance only")
+        .doesNotContain("Response fields", "Related tools", "Usage examples");
+  }
+
+  @Test
+  void getVulnerability_should_notice_when_no_trigger_events_captured() throws Exception {
+    Trace trace = mock();
+    Vulnerability vulnerability = mock();
+    var eventSummaryResponse = new EventSummaryResponse();
+    eventSummaryResponse.setEvents(List.of());
+
+    when(contrastApiClient.getVulnerability(eq(VALID_APP_ID), eq(VALID_VULN_ID), any()))
+        .thenReturn(trace);
+    when(contrastApiClient.getEventSummary(VALID_VULN_ID)).thenReturn(eventSummaryResponse);
+    when(vulnerabilityMapper.toFullVulnerability(eq(trace), any(VulnerabilityContext.class)))
+        .thenReturn(vulnerability);
+
+    var result = tool.getVulnerability(VALID_VULN_ID, VALID_APP_ID);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.notices())
+        .contains(
+            "Stack trace not available because no trigger events were captured for this"
+                + " vulnerability.");
+  }
+
+  @Test
+  void getVulnerability_should_notice_when_event_summary_absent() throws Exception {
+    Trace trace = mock();
+    Vulnerability vulnerability = mock();
+    when(contrastApiClient.getVulnerability(eq(VALID_APP_ID), eq(VALID_VULN_ID), any()))
+        .thenReturn(trace);
+    when(contrastApiClient.getEventSummary(VALID_VULN_ID)).thenReturn(null);
+    when(vulnerabilityMapper.toFullVulnerability(eq(trace), any(VulnerabilityContext.class)))
+        .thenReturn(vulnerability);
+
+    var result = tool.getVulnerability(VALID_VULN_ID, VALID_APP_ID);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.notices())
+        .contains(
+            "Stack trace not available because no trigger events were captured for this"
+                + " vulnerability.");
+  }
+
+  @Test
+  void getVulnerability_should_not_notice_stack_trace_when_trigger_events_exist() throws Exception {
+    Trace trace = mock();
+    Vulnerability vulnerability = mock();
+    when(contrastApiClient.getVulnerability(eq(VALID_APP_ID), eq(VALID_VULN_ID), any()))
+        .thenReturn(trace);
+    when(contrastApiClient.getEventSummary(VALID_VULN_ID))
+        .thenReturn(eventSummaryResponse("com.example.Library.method"));
+    when(contrastApiClient.getAllLibraries(VALID_APP_ID)).thenReturn(List.of());
+    when(vulnerabilityMapper.toFullVulnerability(eq(trace), any(VulnerabilityContext.class)))
+        .thenReturn(vulnerability);
+
+    var result = tool.getVulnerability(VALID_VULN_ID, VALID_APP_ID);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.notices())
+        .doesNotContain(
+            "Stack trace not available because no trigger events were captured for this"
+                + " vulnerability.");
+  }
+
+  @Test
+  void getVulnerability_should_notice_when_http_request_not_captured() throws Exception {
+    Trace trace = mock();
+    Vulnerability vulnerability = mock();
+    when(contrastApiClient.getVulnerability(eq(VALID_APP_ID), eq(VALID_VULN_ID), any()))
+        .thenReturn(trace);
+    when(contrastApiClient.getHttpRequest(VALID_VULN_ID)).thenReturn(new HttpRequestResponse());
+    when(vulnerabilityMapper.toFullVulnerability(eq(trace), any(VulnerabilityContext.class)))
+        .thenReturn(vulnerability);
+
+    var result = tool.getVulnerability(VALID_VULN_ID, VALID_APP_ID);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.notices())
+        .contains("HTTP request data was not captured for this vulnerability.");
+  }
+
+  @Test
+  void getVulnerability_should_not_notice_http_request_when_captured() throws Exception {
+    Trace trace = mock();
+    Vulnerability vulnerability = mock();
+    when(contrastApiClient.getVulnerability(eq(VALID_APP_ID), eq(VALID_VULN_ID), any()))
+        .thenReturn(trace);
+    when(contrastApiClient.getHttpRequest(VALID_VULN_ID))
+        .thenReturn(httpRequestResponse("GET /orders HTTP/1.1"));
+    when(vulnerabilityMapper.toFullVulnerability(eq(trace), any(VulnerabilityContext.class)))
+        .thenReturn(vulnerability);
+
+    var result = tool.getVulnerability(VALID_VULN_ID, VALID_APP_ID);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.notices())
+        .doesNotContain("HTTP request data was not captured for this vulnerability.");
   }
 
   private static RecommendationResponse recommendationResponse(String text) {

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolTest.java
@@ -153,7 +153,30 @@ class SearchAppVulnerabilitiesToolTest {
 
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.notices())
-        .anyMatch(w -> w.contains("No sessions found for this application"));
+        .contains(
+            "No sessions found for this application. Results include all vulnerabilities across"
+                + " all sessions.");
+  }
+
+  @Test
+  void searchAppVulnerabilities_should_not_notice_session_fallback_when_session_found()
+      throws Exception {
+    var latestSession = new SessionMetadataResponse();
+    var agentSession = new AgentSession();
+    agentSession.setAgentSessionId("session-123");
+    latestSession.setAgentSession(agentSession);
+    var traces = emptyTraces();
+    when(contrastApiClient.getLatestSessionMetadata(APP_ID)).thenReturn(latestSession);
+    when(contrastApiClient.searchAppVulnerabilities(
+            eq(APP_ID), any(TraceFilterBody.class), eq(10), eq(0), any()))
+        .thenReturn(traces);
+
+    var result =
+        tool.searchAppVulnerabilities(
+            APP_ID, 1, 10, null, null, null, null, null, null, null, null, true);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.notices()).noneMatch(n -> n.contains("No sessions found"));
   }
 
   @Test
@@ -204,15 +227,29 @@ class SearchAppVulnerabilitiesToolTest {
   }
 
   @Test
-  void searchAppVulnerabilities_should_document_environment_filter_and_response_semantics()
+  void searchAppVulnerabilities_should_split_environment_semantics_between_param_and_body()
       throws Exception {
     Method method = searchAppVulnerabilitiesMethod();
 
     assertThat(method.getParameters()[6].getAnnotation(ToolParam.class).description())
+        .contains("Matches any historical vulnerability instance")
+        .doesNotContain("latest instance");
+    assertThat(method.getAnnotation(Tool.class).description())
         .contains(
-            "Matches any historical vulnerability instance",
-            "describes only its latest instance",
-            "may omit the matched value");
+            "environments field reflects only its latest instance",
+            "may omit environments from earlier instances");
+  }
+
+  @Test
+  void searchAppVulnerabilities_should_disambiguate_siblings_without_restating_param_facts()
+      throws Exception {
+    Method method = searchAppVulnerabilitiesMethod();
+
+    assertThat(method.getAnnotation(Tool.class).description())
+        .contains("Use this instead of search_vulnerabilities")
+        .contains("Use this instead of search_issues")
+        .contains("mutually exclusive")
+        .doesNotContain("All vulns in app", "Values must be non-empty");
   }
 
   private static Method searchAppVulnerabilitiesMethod() throws NoSuchMethodException {

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolTest.java
@@ -241,15 +241,15 @@ class SearchAppVulnerabilitiesToolTest {
   }
 
   @Test
-  void searchAppVulnerabilities_should_disambiguate_siblings_without_restating_param_facts()
+  void searchAppVulnerabilities_should_disambiguate_public_siblings_without_hosted_references()
       throws Exception {
     Method method = searchAppVulnerabilitiesMethod();
 
     assertThat(method.getAnnotation(Tool.class).description())
         .contains("Use this instead of search_vulnerabilities")
-        .contains("Use this instead of search_issues")
         .contains("mutually exclusive")
-        .doesNotContain("All vulns in app", "Values must be non-empty");
+        .doesNotContain(
+            "search_issues", "NorthStar", "All vulns in app", "Values must be non-empty");
   }
 
   private static Method searchAppVulnerabilitiesMethod() throws NoSuchMethodException {


### PR DESCRIPTION
**Jira:** [AIML-942](https://contrast.atlassian.net/browse/AIML-942)

## Summary
Migrates `search_app_vulnerabilities` and `get_vulnerability` to the AIML-942 verb-shape description templates (bead mcp-ayi0.2), the two mcp-contrast tools with pre-written targets from the validation exercise. Interpretation prose moves onto point-of-use notices in the same change, and the two facts whose renames were declined become standing single body clauses.

- Body word counts: `search_app_vulnerabilities` **106 / 150**, `get_vulnerability` **38 / 40** (plain whitespace-delimited count of the `@Tool` description body, `@ToolParam` text excluded)

## Why This Change Exists
Descriptions ship in `tools/list` for every session. Both tools carried multi-section descriptions that restated `@ToolParam` facts, inventoried response fields, and listed six-plus examples. The v2 standard (MCP_STANDARDS.md) is structural: every fact gets one home chosen by when the agent needs it, conditional quirks become notices emitted only when the condition occurs, and interpretation prose may leave a description only in the same PR as the code that replaces it.

## Approach
Fact ledgers were built for both tools (see below), following `docs/research/AIML-942-template-validation.md` in aiml-services. Two decisions recorded on the bead shaped the result. First, the `environments` and `httpRequest` renames were declined (2026-07-30), so the latest-instance and redaction facts stay as standing single body clauses, the fallback home, not tagged transitional since no rename is planned. Second, the `environments` response-side fact moved from the `environments` param into the `search_app_vulnerabilities` body, and the param keeps only the filter-side fact, satisfying the duplication ban while teaching the response semantics to agents that never touch that filter.

## What Changed
### contrast-mcp-core
- `tool/vulnerability/SearchAppVulnerabilitiesTool.java` — description rewritten to the search template with cross-catalog disambiguation in both directions (vs `search_vulnerabilities` and vs the hosted `search_issues`), examples cut from six to three. The latest-session fallback notice is reworded to the affirmative form: "No sessions found for this application. Results include all vulnerabilities across all sessions." The `environments` param keeps only the filter-matching fact; "Values must be non-empty" moved onto the `sessionMetadataFilters` param.
- `tool/vulnerability/GetVulnerabilityTool.java` — description rewritten to the get template (lead + discovery pointer + two standing clauses). Two new conditional notices: "Stack trace not available because no trigger events were captured for this vulnerability." when the event summary holds no trigger event, and "HTTP request data was not captured for this vulnerability." when the fetch succeeds but no request was captured. Retrieval failures keep the existing degradation notices from `tryFetch`/`tryRun`.
- Test updates in both tool test classes, detailed under Testing.

## Fact ledgers

<details>
<summary>search_app_vulnerabilities (10 entries)</summary>

| # | Fact (old description) | Classification | Destination |
|---|---|---|---|
| 1 | Lead sentence (app-scoped search, session filtering) | Selection | Body, retained (simplified) |
| 2 | appId required; use search_applications to find IDs | Selection (prerequisite) | Body, retained; also on `appId` param as call-time discovery help |
| 3 | sessionMetadataFilters JSON format, AND across fields, OR within a field | Call-construction | Already on `sessionMetadataFilters` param; body keeps only a compressed mention inside the mutual-exclusivity quirk |
| 4 | Values must be non-empty | Call-construction | Moved onto `sessionMetadataFilters` param; body copy deleted |
| 5 | useLatestSession filters to most recent session | Call-construction | Already on `useLatestSession` param; body copy deleted |
| 6 | useLatestSession and sessionMetadataFilters mutually exclusive | Call-construction (spans two params) | Body, retained |
| 7 | No-sessions fallback returns all vulnerabilities with a notice | Interpretation (conditional) | Notice (already emitted in code); wording aligned to the affirmative rule, body copy deleted |
| 8 | Six usage examples | Selection | Cut to three; dropped the trivial appId-only example and the two JSON-shape examples already carried by the param format |
| 9 | environments response field shows latest instance only, may omit matched value | Interpretation (always-true) | Standing body clause (rename `environmentsLatestInstance` declined 2026-07-30); removed from the `environments` param under the duplication ban |
| 10 | NEW: cross-catalog disambiguation (vs search_vulnerabilities, vs search_issues NorthStar/Classic) | Selection (use-when) | Body, added; the hosted search_issues side names this tool back in the sibling aiml-services PR |

</details>

<details>
<summary>get_vulnerability (10 entries)</summary>

| # | Fact (old description) | Classification | Destination |
|---|---|---|---|
| 1 | Lead + enrichments (remediation guidance, stack traces, vulnerable libraries) | Selection | Body, merged into one lead sentence |
| 2 | remediationHint is an AI-generated remediation hint | Interpretation (always-true) | Cut; the `hint` → `remediationHint` rename (mcp-ayi0.1, PR #179) made the name self-describing |
| 3 | howToFix / vulnerableLibraries meanings | Interpretation (always-true) | Cut, field names self-describing |
| 4 | stackTrace available when trigger events exist | Interpretation (conditional) | **New notice**, emitted when no trigger events were captured |
| 5 | httpRequest present only if captured | Interpretation (conditional) | **New notice**, emitted when the fetch succeeds but nothing was captured |
| 6 | httpRequest has sensitive headers removed | Interpretation (always-true) | Standing body clause (rename `httpRequestRedacted` declined 2026-07-30) |
| 7 | environments shows latest instance only | Interpretation (always-true) | Standing body clause (rename declined 2026-07-30) |
| 8 | Usage example (vulnId + appId) | Selection | Cut; get tools take IDs, the discovery pointer suffices |
| 9 | "Some fields may be null" and "notices indicate retrieval errors" | Uniform convention | Cut; catalog-wide facts, three-bar candidates for server instructions (bead mcp-ayi0.4) |
| 10 | Related tools footer (search_vulnerabilities, search_applications) | Selection (related tools) | Cut; discovery pointer retained inline, search_applications pointer already on the `appId` param |

Notice mechanics: `NoticeCollector.tryFetch` treats a null client return as absent without a notice, so the not-captured notice fires only when the response object is present but carries no HTTP request text. Fetch failures keep the established "not available (retrieval error)" degradation suffix.

</details>

## Testing
- `SearchAppVulnerabilitiesToolTest`: exact-wording assertion for the reworded fallback notice, a negative test proving the notice stays silent when a session exists, and two description tests, one pinning the param/body split for the environments semantics and one pinning sibling disambiguation without param restatement.
- `GetVulnerabilityToolTest`: notices tested in both directions for both conditions (no trigger events, event summary absent, trigger events present; HTTP request not captured vs captured), plus a description test for the standing clauses and discovery pointer.
- `make check-test` green: full suite, coverage floors met (contrast-mcp-core 97.8% line / 89.6% branch).
- Budgets verified manually per the pinned method; the mcp-ayi0.3.2 budget gate lands after the migration.


[AIML-942]: https://contrast.atlassian.net/browse/AIML-942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## PR 179 Review Follow-up
PR #179's four remaining review comments were revalidated against this stack-tip branch and handled here so the base PR remains unchanged.

- Commit `1e1eab4` updates `ResponseEnvelopeSerializationTest` to serialize through Spring AI's production `JsonParser`, parse the result as `JsonNode`, assert semantic field presence and empty-array shape, and use typed overloads for all three response envelopes.
- The positional `VulnerabilityTest` concern required no code change: record-component additions change constructor arity, and moving `remediationHint` would fail the exact-value assertion.
- Notice null/blank normalization was deferred because it is a pre-existing semantic consistency change rather than part of the rename/description stack. Follow-up: [AIML-1266](https://contrast.atlassian.net/browse/AIML-1266), local bead `mcp-77hk`.
- Verification: focused serialization test, full unit-test tasks, Spotless, Checkstyle, and the pre-push changed-file coverage gate all pass.
