### PR TITLE
[STACKED] AIML-942 Add MCP server instructions with uniform conventions

### DIFF
--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/server/SearchServersTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/server/SearchServersTool.java
@@ -41,9 +41,8 @@ public class SearchServersTool extends PaginatedTool<ServerFilterParams, ServerS
       description =
           """
           Searches servers visible to the current credentials for inventory, agent health, and
-          Protect coverage. Values within a comma-separated parameter are ORed; different
-          parameters and the single-valued quickFilter are ANDed. To combine two quick-filter
-          dimensions, filter by one and inspect item fields for the other.
+          Protect coverage. To combine two quick-filter dimensions, filter by one and inspect
+          item fields for the other.
 
           ONLINE/OFFLINE use TeamServer's activity threshold (typically about 50 minutes).
           OUT_OF_DATE means older than the newest agent TeamServer can serve for that language.

--- a/contrast-mcp-stdio-app/src/main/resources/application.properties
+++ b/contrast-mcp-stdio-app/src/main/resources/application.properties
@@ -2,6 +2,10 @@ spring.application.name=mcp-contrast
 spring.main.web-application-type=none
 spring.ai.mcp.server.name=mcp-contrast
 spring.ai.mcp.server.version=@project.version@
+# Server instructions (MCP initialize result). Home for conventions uniformly true across
+# every exposed tool, per MCP_STANDARDS.md "Server Instructions" (AIML-942). Keep repo-local:
+# never name hosted-only aiml-services tools here.
+spring.ai.mcp.server.instructions=Results reflect only data visible to the configured credentials; a missing item may mean restricted access rather than absence. Values within a comma-separated filter parameter are ORed; different filter parameters are ANDed.
 
 spring.main.banner-mode=off
 logging.pattern.console=

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/McpServerInstructionsTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/McpServerInstructionsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.support.PropertiesLoaderUtils;
+
+/**
+ * Verifies the MCP server instructions configured in application.properties bind to the same {@link
+ * McpServerProperties} the Spring AI MCP server autoconfiguration consumes, so the instructions
+ * field is emitted in the initialize result (AIML-942 server-instructions channel).
+ */
+class McpServerInstructionsTest {
+
+  private McpServerProperties boundServerProperties() throws IOException {
+    var properties =
+        PropertiesLoaderUtils.loadProperties(new ClassPathResource("application.properties"));
+    var source = new MapConfigurationPropertySource(properties);
+    return new Binder(source)
+        .bind("spring.ai.mcp.server", Bindable.of(McpServerProperties.class))
+        .get();
+  }
+
+  @Test
+  void applicationProperties_should_populate_server_instructions_when_bound_to_mcp_properties()
+      throws IOException {
+    assertThat(boundServerProperties().getInstructions()).isNotBlank();
+  }
+
+  @Test
+  void instructions_should_carry_uniform_conventions_when_configured() throws IOException {
+    var instructions = boundServerProperties().getInstructions();
+
+    // The two catalog-wide conventions owned by this channel (mcp-4ubb): credential-scoped
+    // visibility and comma-separated filter semantics. Their per-tool body copies are removed
+    // in the same change, so losing either from the instructions would leave the fact homeless.
+    assertThat(instructions)
+        .contains("visible to the configured credentials")
+        .contains("ORed")
+        .contains("ANDed");
+  }
+
+  @Test
+  void instructions_should_stay_repository_local_when_configured() throws IOException {
+    var instructions = boundServerProperties().getInstructions();
+
+    // Repository boundary (MCP_STANDARDS.md): the public server must never reference
+    // hosted-only aiml-services tools, because it can be deployed without them.
+    assertThat(instructions)
+        .doesNotContain("search_issues")
+        .doesNotContain("search_incidents")
+        .doesNotContain("aiml");
+  }
+}


### PR DESCRIPTION
<!-- pr-tools:stacked:v1 -->
<!-- pr-tools:parent-pr=183 -->
<!-- pr-tools:parent-branch=AIML-942-migrate-vulnerability-tool-descriptions -->
<!-- pr-tools:parent-base=main -->
<!-- pr-tools:boundary-commit=ab0cf0e112f308bbc10a535bcfcbfd5534ba522d -->
<!-- pr-tools:managed:start -->
> ⚠️ **DO NOT MERGE** - This PR is stacked on #183. Merge that first.
>
> **Stack Context**
> - Parent PR: #183
> - Parent branch: `AIML-942-migrate-vulnerability-tool-descriptions`
> - Promotion target: `main`
<!-- pr-tools:managed:end -->

**Jira:** [AIML-942](https://contrast.atlassian.net/browse/AIML-942)

## Summary
Delivers the MCP server-instructions channel for the public server and moves the first two catalog-wide conventions into it, so per-tool descriptions stop repeating facts that are uniformly true across the tool set. Implements beads mcp-75fz (channel) and mcp-4ubb (content) in one change.

## Why This Change Exists
MCP_STANDARDS.md routes conventions that are uniformly true across the exposed tool set to server instructions, and AIML-942 explicitly calls for moving shared conventions (ANDed filters, permission scoping) to server-level instructions declared once. But this server never emitted the `instructions` field, so that home did not exist and the comma-separated filter convention squatted in the search_servers body. The description-migration plan (bead mcp-54wx) needs the channel delivered before search_servers can be cut to its word budget. Spring AI 1.1.x already supports the property, so delivery was the only missing piece.

## What Changed
### Instructions channel (mcp-75fz)
- `contrast-mcp-stdio-app/src/main/resources/application.properties` — sets `spring.ai.mcp.server.instructions`; the comment marks the channel's ownership rules (uniformly-true facts only, repo-local, never name hosted-only aiml-services tools)

### Convention content and body cut (mcp-4ubb)
- `contrast-mcp-core/.../tool/server/SearchServersTool.java` — removes the OR-within/AND-across sentence from the description body in the same change that ships its replacement (transition rule); the rest of the search_servers description migrates to budget later under mcp-54wx cohort 3

Fact ledger (one home per fact):

| Fact | Old home | New home | Rationale |
|---|---|---|---|
| Values within a comma-separated parameter are ORed; different parameters are ANDed | search_servers body | Server instructions | Uniformly true for every exposed tool with comma-separated filters (severities, statuses, environments, vulnTypes, vulnTags, logLevels, tags, applicationIds, agentVersions, rules) |
| Results reflect only data visible to the configured credentials; a missing item may mean restricted access rather than absence | unstated (implied per-tool by search_servers "EAC-scoped") | Server instructions | Uniformly true; TeamServer scopes org trace search through `EacUser` access control in `NgOrganizationTraceListingRestController` — callers with no allowed applications get empty results, not 403 |

Three-bar evidence, bar 1 (delivered) — captured `initialize` response from the built jar:

```json
{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"completions":{},"logging":{},"prompts":{"listChanged":true},"resources":{"subscribe":false,"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"mcp-contrast","version":"2.1.1-SNAPSHOT"},"instructions":"Results reflect only data visible to the configured credentials; a missing item may mean restricted access rather than absence. Values within a comma-separated filter parameter are ORed; different filter parameters are ANDed."}}
```

Bar 1 (surfaced by clients): Claude Code injects server instructions into agent context. Bar 2 (recalled): both facts are result-interpretation conventions, not mechanical call-shaping. Bar 3 (uniformly true): per the ledger rationale column.

## Testing
- `McpServerInstructionsTest` binds the real `application.properties` through Spring's `Binder` to `McpServerProperties` — the exact class the Spring AI MCP autoconfiguration consumes — and asserts the instructions are non-blank, carry both conventions, and stay repository-local (no hosted-only tool names)
- `make check-test` green on the stacked base: 1044 tests, 0 failures; coverage floors met (core 97.8% line / 89.6% branch, stdio-app 97.8% / 96.2%); changed-file coverage gate green against the parent branch
- Integration suite run twice: two stable pre-existing seed-data failures unrelated to this diff (negative `monthsOutdated` from upstream latest-version data for two doctrine PHP packages, and a missing seeded server tag), now tracked in bead mcp-by1w; one transient Varnish 503 cleared on rerun


[AIML-942]: https://contrast.atlassian.net/browse/AIML-942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ