### PR TITLE
[STACKED] AIML-942 Migrate remaining tool descriptions

### DIFF
--- a/MCP_STANDARDS.md
+++ b/MCP_STANDARDS.md
@@ -155,7 +155,10 @@ Two rules make the table binding.
 
 **Earliest-moment tiebreaker.** A fact needed at more than one moment goes in the earliest home where it is needed, and only there. "Use score, not severity, when sorting by risk" shapes the `sort` argument, so it lives on the `sort` parameter even though it sounds like result interpretation.
 
-**Duplication ban.** A fact stated in a parameter description must not repeat in the body. Cross-checking body against params is part of review.
+**Duplication ban.** A fact stated in a parameter description must not repeat in the body. A
+discovery pointer carried by the description body is never repeated in a parameter description;
+parameter-level discovery cross-references apply only when the body does not carry the pointer.
+Cross-checking body against params is part of review.
 
 ### Templates and budgets
 
@@ -169,7 +172,10 @@ Each verb shape has a fixed template. Every slot except the lead is optional. Th
 4. Call-shaping quirks that span more than one parameter. Mutual exclusivity between parameters is the canonical example ("sessionMetadataFilters and useLatestSession are mutually exclusive"). Single-parameter semantics belong on the parameter.
 5. Up to three usage examples, preferring filter combinations over single filters. Simple tools get none.
 
-**Get tools, 40 words or fewer.** Lead sentence plus a discovery pointer for the identifier ("Use search_vulnerabilities to find vulnerability IDs"). Interpretation quirks arrive as notices, not prose.
+**Get tools, 40 words or fewer.** Lead sentence plus a discovery pointer for the identifier when the
+catalog has a discovery tool for it and the pointer would help ("Use search_vulnerabilities to find
+vulnerability IDs"). Omit the pointer when no discovery tool exists or it would not help.
+Interpretation quirks arrive as notices, not prose.
 
 **Update tools, 60 words or fewer.** Lead sentence, allowed transitions when not carried by the parameter, and an audit or reversibility note.
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataTool.java
@@ -44,21 +44,12 @@ public class GetSessionMetadataTool
       name = "get_session_metadata",
       description =
           """
-          Retrieves session metadata for a specific application by its ID.
-
-          Returns the session metadata available for the application, including branch names,
-          build IDs, and other custom metadata fields that can be used for filtering
-          vulnerabilities in search_app_vulnerabilities.
-
-          Use search_applications(name=...) to find the application ID from a name.
-
-          Related tools:
-          - search_applications: Find application IDs by name, tag, or metadata
-          - search_app_vulnerabilities: Search vulnerabilities with session filtering
+          Get the session metadata fields and values recorded for an application, such as branch or
+          build. Field names feed sessionMetadataFilters in search_app_vulnerabilities and session
+          filters in get_route_coverage. Use search_applications to find application IDs.
           """)
   public SingleToolResponse<MetadataFilterResponse> getSessionMetadata(
-      @ToolParam(description = "Application ID (use search_applications to find)") String appId,
-      ToolContext toolContext) {
+      @ToolParam(description = "Application ID") String appId, ToolContext toolContext) {
     return executePipeline(() -> GetSessionMetadataParams.of(appId), toolContext);
   }
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsTool.java
@@ -56,21 +56,11 @@ public class SearchApplicationsTool
       name = "search_applications",
       description =
           """
-          Search applications with optional filters. Returns all applications if no filters specified.
+          Search applications by name, tag, or custom metadata. Returns every application when no
+          filters are given. This is the discovery tool for the appId parameter used by
+          application-scoped tools.
 
-          Filtering behavior:
-          - name: Server-side text search on displayName, contextPath, tags, and metadata values
-          - tag: Exact, case-insensitive matching
-          - metadataFilters: JSON object for metadata field filtering
-            - Format: {"fieldName":"value"} or {"fieldName":["value1","value2"]}
-            - Multiple fields use AND logic, multiple values use OR logic
-            - Field names are case-insensitive
-            - Values are case-insensitive
-            - Values must be non-empty (empty, null, or whitespace-only values are rejected)
-
-          Related tools:
-          - get_session_metadata: Get session metadata for an application
-          - search_vulnerabilities: Search vulnerabilities across applications
+          Example: name="petclinic", metadataFilters='{"team":"payments"}'
           """)
   public PaginatedToolResponse<ApplicationData> searchApplications(
       @ToolParam(description = "Page number (1-based), default: 1", required = false) Integer page,
@@ -85,7 +75,9 @@ public class SearchApplicationsTool
       @ToolParam(
               description =
                   "JSON object for metadata filters. Format: {\"field\":\"value\"} or"
-                      + " {\"field\":[\"v1\",\"v2\"]}",
+                      + " {\"field\":[\"v1\",\"v2\"]}. Multiple fields use AND logic."
+                      + " Multiple values within a field use OR logic. Field names and values are"
+                      + " case-insensitive. Values must be non-empty.",
               required = false)
           String metadataFilters,
       ToolContext toolContext) {

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesTool.java
@@ -17,6 +17,7 @@ package com.contrast.labs.ai.mcp.contrast.tool.attack;
 
 import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.ProtectData;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.data.Rule;
 import com.contrast.labs.ai.mcp.contrast.tool.attack.params.GetProtectRulesParams;
 import com.contrast.labs.ai.mcp.contrast.tool.base.NoticeCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleTool;
@@ -45,33 +46,11 @@ public class GetProtectRulesTool extends SingleTool<GetProtectRulesParams, Prote
       name = "get_protect_rules",
       description =
           """
-          Takes an application ID and returns the Protect rules for the application.
-          Use search_applications first to get the application ID from a name.
-
-          Returns protection configuration including:
-          - Rule names (e.g., sql-injection, xss-reflected, path-traversal)
-          - Production mode for each rule (block, monitor, or off)
-          - Rule-specific configuration settings
-
-          Response shape note:
-          - Protect Rules use development/qa/production mode strings and populate uuid.
-          - Virtual Patches use enabledDev/enabledQa/enabledProd booleans instead; their
-            development/qa/production mode fields and uuid may be null.
-
-          Usage examples:
-          - Get protect rules: appId="app-123"
-
-          Note: Protect/ADR is a premium feature. The application must have Protect enabled
-          and at least one rule configured. If the application has no Protect rules configured,
-          an empty rules list will be returned.
-
-          Related tools:
-          - search_applications: Find application IDs by name or tag
-          - search_attacks: Search for attacks across the organization
+          Get Protect (ADR) rules for an application, including block/monitor/off mode per
+          environment. Use search_applications to find application IDs.
           """)
   public SingleToolResponse<ProtectData> getProtectRules(
-      @ToolParam(description = "Application ID (use search_applications to find)") String appId,
-      ToolContext toolContext) {
+      @ToolParam(description = "Application ID") String appId, ToolContext toolContext) {
     return executePipeline(() -> GetProtectRulesParams.of(appId), toolContext);
   }
 
@@ -92,7 +71,17 @@ public class GetProtectRulesTool extends SingleTool<GetProtectRulesParams, Prote
     if (ruleCount == 0) {
       collector.notice("Application has Protect enabled but no rules are configured.");
     }
+    if (Optional.ofNullable(protectData.getRules()).orElse(List.of()).stream()
+        .anyMatch(GetProtectRulesTool::isVirtualPatch)) {
+      collector.notice(
+          "Virtual Patch entries use enabledDev/enabledQa/enabledProd booleans; their"
+              + " development/qa/production mode fields and uuid are not populated.");
+    }
 
     return protectData;
+  }
+
+  private static boolean isVirtualPatch(Rule rule) {
+    return "Virtual Patch".equalsIgnoreCase(rule.getType());
   }
 }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesTool.java
@@ -36,6 +36,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class GetProtectRulesTool extends SingleTool<GetProtectRulesParams, ProtectData> {
 
+  static final String VIRTUAL_PATCH_TYPE = "Virtual Patch";
+
   private final ContrastApiClient contrastApiClient;
 
   public GetProtectRulesTool(ContrastApiClient contrastApiClient) {
@@ -74,7 +76,8 @@ public class GetProtectRulesTool extends SingleTool<GetProtectRulesParams, Prote
     if (Optional.ofNullable(protectData.getRules()).orElse(List.of()).stream()
         .anyMatch(GetProtectRulesTool::isVirtualPatch)) {
       collector.notice(
-          "Virtual Patch entries use enabledDev/enabledQa/enabledProd booleans; their"
+          VIRTUAL_PATCH_TYPE
+              + " entries use enabledDev/enabledQa/enabledProd booleans; their"
               + " development/qa/production mode fields and uuid are not populated.");
     }
 
@@ -82,6 +85,6 @@ public class GetProtectRulesTool extends SingleTool<GetProtectRulesParams, Prote
   }
 
   private static boolean isVirtualPatch(Rule rule) {
-    return "Virtual Patch".equalsIgnoreCase(rule.getType());
+    return VIRTUAL_PATCH_TYPE.equalsIgnoreCase(rule.getType());
   }
 }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksTool.java
@@ -43,44 +43,13 @@ public class SearchAttacksTool extends PaginatedTool<AttackFilterParams, AttackS
       name = "search_attacks",
       description =
           """
-          Retrieves attacks from Contrast ADR (Attack Detection and Response) with optional filtering
-          and sorting. Supports filtering by attack categorization (quickFilter), outcome status
-          (statusFilter), keywords, rules, and other criteria.
+          Search attacks detected by Contrast ADR (Attack Detection and Response) across the
+          organization, with filtering by categorization, outcome status, keyword, and rule.
 
-          Returns a paginated list of attack summaries with key information including rule names,
-          status, severity, affected applications, source IP, and probe counts.
-
-          Common usage examples:
-          - All attacks: No filters (returns all attack types)
-          - Active attacks only: quickFilter="ACTIVE"
-          - Exploited attacks: statusFilter="EXPLOITED"
-          - SQL injection attacks by keyword: keyword="SQL Injection" (searches multiple fields)
-          - SQL injection attacks by rule: rules="sql-injection" (exact rule ID match)
-          - Multiple rules: rules="sql-injection,xss-reflected"
-          - Blocked attacks: statusFilter="BLOCKED"
-          - Production attacks: quickFilter="PRODUCTION"
-
-          Filter combinations:
+          Examples:
           - Effective exploits: quickFilter="EFFECTIVE", statusFilter="EXPLOITED"
-          - Manual SQL attacks: quickFilter="MANUAL", rules="sql-injection"
-
-          Keyword vs Rules:
-          - keyword: Substring match (OR logic) across source IP, server name/hostname,
-            application name, rule name, attack UUID, forwarded IP/path, and attack tags
-          - rules: Exact match against rule IDs (e.g., "sql-injection"). Use get_protect_rules
-            to discover available rule IDs for an application.
-
-          Response fields:
-          - attackId: Unique identifier for the attack
-          - status: Attack outcome (EXPLOITED, PROBED, BLOCKED, etc.)
-          - source: Source IP address of the attacker
-          - rules: Protection rules triggered by the attack
-          - probes: Number of probe attempts
-          - applications: List of affected applications with severity and status
-
-          Related tools:
-          - get_protect_rules: View configured protection rules for an application
-          - search_applications: Find application IDs by name or tag
+          - Manual SQL injection: quickFilter="MANUAL", rules="sql-injection"
+          - Blocked attacks from one source: statusFilter="BLOCKED", keyword="192.0.2.10"
           """)
   public PaginatedToolResponse<AttackSummary> searchAttacks(
       @ToolParam(description = "Page number (1-based), default: 1", required = false) Integer page,

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageTool.java
@@ -48,49 +48,16 @@ public class GetRouteCoverageTool
       name = "get_route_coverage",
       description =
           """
-          Retrieves route coverage data for an application.
-
-          Routes can have these statuses:
-          - DISCOVERED: Found by Contrast Assess but has not received any HTTP requests
-          - EXERCISED: Has received at least one HTTP request
-          - EXCLUDED: Excluded from route coverage tracking
-
-          Response fields:
-          - success: Whether the request completed successfully
-          - messages: Informational messages returned by the service
-          - totalRoutes: Total number of routes
-          - exercisedCount: Number of routes with EXERCISED status
-          - discoveredCount: Number of routes with DISCOVERED status
-          - coveragePercent: Percentage of routes that are exercised
-          - totalVulnerabilities: Total vulnerabilities across the returned routes
-          - totalCriticalVulnerabilities: Critical vulnerabilities across the returned routes
-          - routes: List of routes with coverage status and details. Each route includes
-            environments; this list is empty for session-filtered routes because the source omits
-            that data.
-
-          Filtering options (mutually exclusive):
-          - No filter: Returns all routes across all sessions
-          - sessionMetadataName + sessionMetadataValue: Filter by session metadata (e.g., branch=main)
-          - useLatestSession: Filter by the most recent session only
-
-          NOTE: sessionMetadataName and sessionMetadataValue must be provided together or both omitted.
-          If both useLatestSession and session metadata are provided, useLatestSession takes precedence.
-
-          Usage examples:
-          - Get all routes: appId="app-123"
-          - Filter by branch: appId="app-123", sessionMetadataName="branch", sessionMetadataValue="main"
-          - Latest session only: appId="app-123", useLatestSession=true
-
-          Related tools:
-          - search_applications: Find application IDs by name or tag
-          - get_session_metadata: View available session metadata fields
+          Get route coverage for an application: which routes have been exercised by HTTP requests
+          and which were only discovered. Use search_applications to find application IDs. Session
+          filters: a sessionMetadataName/Value pair or useLatestSession, not both.
           """)
   public SingleToolResponse<RouteCoverageResponseLight> getRouteCoverage(
-      @ToolParam(description = "Application ID (use search_applications to find)") String appId,
+      @ToolParam(description = "Application ID") String appId,
       @ToolParam(
               description =
                   "Session metadata field name to filter by (e.g., 'branch'). Must be provided with"
-                      + " sessionMetadataValue.",
+                      + " sessionMetadataValue. Use get_session_metadata to discover field names.",
               required = false)
           String sessionMetadataName,
       @ToolParam(
@@ -189,6 +156,12 @@ public class GetRouteCoverageTool
         "Successfully retrieved route coverage for application ID: {} ({} routes)",
         params.appId(),
         response.getRoutes().size());
+
+    if (request != null) {
+      collector.notice(
+          "route environments are omitted for session-filtered results because the source does not"
+              + " provide them.");
+    }
 
     // Transform to light response to reduce payload size for AI agents
     return routeMapper.toResponseLight(response);

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageTool.java
@@ -158,7 +158,7 @@ public class GetRouteCoverageTool
 
     if (request != null) {
       collector.notice(
-          "route environments are omitted for session-filtered results because the source does not"
+          "Route environments are omitted for session-filtered results because the source does not"
               + " provide them.");
     }
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageTool.java
@@ -49,8 +49,7 @@ public class GetRouteCoverageTool
       description =
           """
           Get route coverage for an application: which routes have been exercised by HTTP requests
-          and which were only discovered. Use search_applications to find application IDs. Session
-          filters: a sessionMetadataName/Value pair or useLatestSession, not both.
+          and which were only discovered. Use search_applications to find application IDs.
           """)
   public SingleToolResponse<RouteCoverageResponseLight> getRouteCoverage(
       @ToolParam(description = "Application ID") String appId,

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesTool.java
@@ -53,38 +53,17 @@ public class ListApplicationLibrariesTool
       name = "list_application_libraries",
       description =
           """
-          Returns all libraries used by a specific application.
-
-          Use search_applications(name=...) to find the application ID from a name.
-
-          Response includes for each library:
-          - filename: Library file name (e.g., "log4j-core-2.17.1.jar")
-          - version: Library version
-          - hash: Unique library hash for identification
-          - classCount: Total classes in the library
-          - classesUsed: Number of classes actually loaded by the application
-          - totalVulnerabilities: Total CVE count
-          - criticalVulnerabilities: CRITICAL severity CVE count
-          - highVulnerabilities: HIGH severity CVE count (not CRITICAL)
-          - mediumVulnerabilities: MEDIUM severity CVE count
-          - lowVulnerabilities: LOW severity CVE count
-          - noteVulnerabilities: NOTE severity CVE count
-          - vulnerabilities: Known CVEs affecting this library version
-          - grade: Library security grade (A-F)
-
-          Note: If classesUsed is 0, the library is likely not actively used and may
-          be a transitive dependency. Libraries with 0 class usage are unlikely to
-          be exploitable even if they have known vulnerabilities.
-
-          Related tools:
-          - search_applications: Find application IDs by name, tag, or metadata
-          - list_applications_by_cve: Find applications affected by a specific CVE
+          List the third-party libraries in one application, with known CVEs, severity counts,
+          security grade, and class usage. classesUsed 0 means no classes from that library were
+          seen loaded, so it is likely unused and unlikely to be exploitable. Use
+          search_applications to find application IDs. Use list_applications_by_cve for the reverse
+          direction, from a CVE to affected applications.
           """)
   public PaginatedToolResponse<LibraryExtended> listApplicationLibraries(
       @ToolParam(description = "Page number (1-based), default: 1", required = false) Integer page,
       @ToolParam(description = "Items per page (max 50), default: 50", required = false)
           Integer pageSize,
-      @ToolParam(description = "Application ID (use search_applications to find)") String appId,
+      @ToolParam(description = "Application ID") String appId,
       ToolContext toolContext) {
     return executePipeline(
         page, pageSize, () -> ListApplicationLibrariesParams.of(appId), toolContext);

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
@@ -56,27 +56,11 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
       name = "list_applications_by_cve",
       description =
           """
-          Find applications and libraries affected by a specific CVE.
-
-          Takes a CVE ID (e.g., CVE-2021-44228) and returns:
-          - apps: List of applications containing vulnerable libraries
-          - libraries: The vulnerable library versions
-          - cve: CVE details including preferred CVSS score/severity and nested v2/v3 metrics
-
-          For each application, class usage data is populated:
-          - classCount: Total classes in the vulnerable library
-          - classUsage: Number of classes actually used by the application
-
-          Important: If classUsage is 0, the vulnerable library code is likely NOT
-          being executed, significantly reducing exploitability risk. Prioritize
-          remediation for applications where classUsage > 0.
-
-          score is absent for v2-only CVEs because TeamServer does not provide a numeric v2
-          base score; use severity and cvssv2 metrics in that case.
-
-          Related tools:
-          - list_application_libraries: Get all libraries for a specific application
-          - search_applications: Find applications by name, tag, or metadata
+          List applications affected by one CVE, with the vulnerable library versions and
+          per-application class usage. classUsage 0 or absent means no classes from the vulnerable
+          library were seen loaded, so exploitation is unlikely; prioritize applications with
+          classUsage above 0. Use list_application_libraries for the reverse direction, all
+          libraries of one application.
           """)
   public SingleToolResponse<CveData> listApplicationsByCve(
       @ToolParam(description = "CVE identifier (e.g., CVE-2021-44228)") String cveId,
@@ -99,6 +83,11 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
       return null; // SingleTool converts this to notFound response
     }
     applyPreferredCvssSummary(cveData.getCve());
+    if (hasOnlyCvssV2(cveData.getCve())) {
+      collector.notice(
+          "score is omitted for CVEs with only CVSS v2 data; use severity and the cvssv2"
+              + " metrics.");
+    }
     dedupeServersById(cveData);
 
     var vulnerableLibs =
@@ -146,6 +135,10 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
       cve.setScore(null);
       cve.setSeverity(cve.getCvssv2().getSeverity());
     }
+  }
+
+  private static boolean hasOnlyCvssV2(Cve cve) {
+    return cve != null && cve.getCvssv3() == null && cve.getCvssv2() != null;
   }
 
   private void enrichAppsWithClassUsage(

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectTool.java
@@ -43,22 +43,8 @@ public class GetSastProjectTool extends SingleTool<GetSastProjectParams, ScanPro
       name = "get_scan_project",
       description =
           """
-          Takes a scan project name and returns the project details.
-
-          Returns project metadata including:
-          - id: Unique project identifier
-          - name: Project name
-          - language: Programming language (Java, JavaScript, etc.)
-          - lastScanId: ID of the most recent scan
-          - lastScanTime: When the last scan completed
-          - completedScans: Total number of completed scans
-          - Vulnerability counts by severity (critical, high, medium, low, note)
-
-          Usage examples:
-          - Get project: projectName="my-application"
-
-          Note: Project name matching is case-insensitive. The returned project's name field
-          reflects the canonical casing as stored in Contrast.
+          Get a Contrast Scan (SAST) project by name, including language, scan counts, last scan ID
+          and time, and vulnerability counts by severity.
           """)
   public SingleToolResponse<ScanProject> getScanProject(
       @ToolParam(description = "Scan project name (matched case-insensitively)") String projectName,

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/server/SearchServersTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/server/SearchServersTool.java
@@ -40,24 +40,15 @@ public class SearchServersTool extends PaginatedTool<ServerFilterParams, ServerS
       name = "search_servers",
       description =
           """
-          Searches servers visible to the current credentials for inventory, agent health, and
-          Protect coverage. To combine two quick-filter dimensions, filter by one and inspect
-          item fields for the other.
+          Search servers visible to the current credentials (EAC-scoped) for inventory, agent
+          health, and Protect coverage.
 
-          ONLINE/OFFLINE use TeamServer's activity threshold (typically about 50 minutes).
-          OUT_OF_DATE means older than the newest agent TeamServer can serve for that language.
-          protectEnabled=null means unknown or unavailable; non-null Assess/Protect state may
-          reflect the first visible application's effective configuration. Protect
-          pending-restart state is not available from this endpoint (assessPending is accurate);
-          do not infer it from other fields. agentOutOfDate=null means the latest
-          agent version could not be determined. Counts and applications are EAC-scoped.
+          Non-null Assess/Protect state may reflect the first visible application's effective
+          configuration. Protect pending-restart state is not available from this endpoint; do not
+          infer it (assessPending is accurate).
 
-          Unless includeApplications=true, applications is null (not an empty list) and only
-          applicationCount is populated.
-
-          Examples: quickFilter="ONLINE" to inspect Protect state; quickFilter="UNPROTECTED" with
-          environments="PRODUCTION"; environments="QA" with includeApplications=true.
-          Related: search_applications, search_attacks, get_route_coverage, get_session_metadata.
+          Examples: quickFilter="ONLINE" to inspect Protect state; quickFilter="UNPROTECTED",
+          environments="PRODUCTION"; environments="QA", includeApplications=true.
           """)
   public PaginatedToolResponse<ServerSummary> searchServers(
       @ToolParam(description = "Page number (1-based), default: 1", required = false) Integer page,
@@ -74,7 +65,10 @@ public class SearchServersTool extends PaginatedTool<ServerFilterParams, ServerS
       @ToolParam(
               description =
                   "Single condition. Valid: ALL, ONLINE, OFFLINE, PROTECTED, UNPROTECTED,"
-                      + " OUT_OF_DATE. Default: ALL",
+                      + " OUT_OF_DATE. ONLINE/OFFLINE use TeamServer's activity threshold"
+                      + " (typically about 50 minutes). OUT_OF_DATE means older than the newest"
+                      + " agent TeamServer can serve for that language. To combine two dimensions,"
+                      + " filter by one and inspect item fields for the other. Default: ALL",
               required = false)
           String quickFilter,
       @ToolParam(
@@ -88,7 +82,8 @@ public class SearchServersTool extends PaginatedTool<ServerFilterParams, ServerS
           String agentVersions,
       @ToolParam(
               description =
-                  "Include visible application identities; default false returns only app counts",
+                  "Include visible application identities; default false returns applicationCount"
+                      + " only and applications is null, not an empty list.",
               required = false)
           Boolean includeApplications,
       @ToolParam(
@@ -161,6 +156,16 @@ public class SearchServersTool extends PaginatedTool<ServerFilterParams, ServerS
         response.getServers().stream()
             .map(server -> ServerSummary.fromServer(server, params.isIncludeApplications()))
             .toList();
+    if (summaries.stream().anyMatch(summary -> summary.protectEnabled() == null)) {
+      collector.notice(
+          "protectEnabled null means Protect state is unknown or unavailable for that server, not"
+              + " disabled.");
+    }
+    if (summaries.stream().anyMatch(summary -> summary.agentOutOfDate() == null)) {
+      collector.notice(
+          "agentOutOfDate null means the latest agent version could not be determined, not that"
+              + " the agent is current.");
+    }
     var totalItems = (int) Math.min(response.getCount(), Integer.MAX_VALUE);
     return ExecutionResult.of(summaries, totalItems);
   }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
@@ -114,15 +114,11 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
             .map(r -> r.getRecommendation().getText())
             .orElse(null);
 
-    var httpRequestText =
+    var httpRequest =
         collector
-            .tryFetch(
-                "HTTP request data",
-                () ->
-                    Optional.ofNullable(contrastApiClient.getHttpRequest(vulnId))
-                        .orElseGet(HttpRequestResponse::new))
-            .map(r -> redactedHttpRequestOrNotice(r, collector))
+            .tryFetch("HTTP request data", () -> contrastApiClient.getHttpRequest(vulnId))
             .orElse(null);
+    var httpRequestText = redactedHttpRequestOrNotice(httpRequest, collector);
 
     var stackLibs = new ArrayList<StackLib>();
     var libsToReturn = new HashSet<LibraryExtended>();
@@ -141,7 +137,9 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
 
   private static String redactedHttpRequestOrNotice(
       HttpRequestResponse response, NoticeCollector collector) {
-    if (response.getHttpRequest() == null || response.getHttpRequest().getText() == null) {
+    if (response == null
+        || response.getHttpRequest() == null
+        || response.getHttpRequest().getText() == null) {
       collector.notice("HTTP request data was not captured for this vulnerability.");
       return null;
     }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
@@ -69,9 +69,8 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
           reflects the latest instance only and may omit earlier instances.
           """)
   public SingleToolResponse<Vulnerability> getVulnerability(
-      @ToolParam(description = "Vulnerability ID (use search_vulnerabilities to find)")
-          String vulnId,
-      @ToolParam(description = "Application ID (use search_applications to find)") String appId,
+      @ToolParam(description = "Vulnerability ID") String vulnId,
+      @ToolParam(description = "Application ID") String appId,
       ToolContext toolContext) {
     return executePipeline(() -> GetVulnerabilityParams.of(vulnId, appId), toolContext);
   }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesTool.java
@@ -44,18 +44,9 @@ public class ListVulnerabilityTypesTool
       name = "list_vulnerability_types",
       description =
           """
-          Returns the complete list of vulnerability types (rule names) available in Contrast.
-
-          Use this tool to discover all possible values for the vulnTypes filter parameter
-          when calling search_vulnerabilities or search_app_vulnerabilities.
-
-          Returns rule names like: sql-injection, xss-reflected, path-traversal, cmd-injection, etc.
-
-          These rule names can be used with the vulnTypes parameter to filter vulnerabilities
-          by specific vulnerability classes.
-
-          Note: The list is fetched dynamically from Contrast and reflects the rules
-          configured for your organization, so it's always current.
+          List every vulnerability type (Assess rule name) available in the organization, such as
+          sql-injection or xss-reflected. Returned values are the valid inputs for the vulnTypes
+          parameter of search_vulnerabilities and search_app_vulnerabilities.
           """)
   public SingleToolResponse<List<String>> listVulnerabilityTypes(ToolContext toolContext) {
     return executePipeline(ListVulnerabilityTypesParams::of, toolContext);

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java
@@ -73,10 +73,7 @@ public class SearchAppVulnerabilitiesTool
           - Production critical: appId="abc123", severities="CRITICAL", environments="PRODUCTION"
           """)
   public PaginatedToolResponse<VulnLight> searchAppVulnerabilities(
-      @ToolParam(
-              description =
-                  "Application ID (required). Use search_applications to find app IDs by name.")
-          String appId,
+      @ToolParam(description = "Application ID") String appId,
       @ToolParam(description = "Page number (1-based), default: 1", required = false) Integer page,
       @ToolParam(description = "Items per page (max 100), default: 50", required = false)
           Integer pageSize,

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java
@@ -61,8 +61,8 @@ public class SearchAppVulnerabilitiesTool
           Use this instead of search_vulnerabilities when you need to filter by session metadata or \
           latest session.
 
-          Session filtering options are mutually exclusive: use either sessionMetadataFilters (JSON \
-          object with AND across fields, OR within a field) or useLatestSession=true, not both.
+          Session filtering options are mutually exclusive: use either sessionMetadataFilters \
+          or useLatestSession=true, not both.
 
           A result's environments field reflects only its latest instance and may omit environments \
           from earlier instances.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesTool.java
@@ -46,34 +46,20 @@ public class SearchVulnerabilitiesTool extends PaginatedTool<VulnerabilityFilter
       name = "search_vulnerabilities",
       description =
           """
-          Search vulnerabilities across all applications in your organization with optional filtering by
-          severity, status, environment, vulnerability type, date range, and tags.
+          Search vulnerabilities detected by Contrast Assess across all applications in the
+          organization.
 
-          This is an organization-level search tool. For application-scoped searches with session filtering
-          capabilities, use the search_app_vulnerabilities tool instead.
+          Use search_app_vulnerabilities instead when scoping to one application or filtering by
+          session metadata or latest session.
 
-          Common usage examples:
-          - Critical vulnerabilities only: severities="CRITICAL"
-          - High-priority open issues: severities="CRITICAL,HIGH", statuses="Reported,Confirmed"
-          - Production vulnerabilities: environments="PRODUCTION"
-          - Recent activity: lastSeenAfter="2025-01-01"
-          - Production critical issues with recent activity: environments="PRODUCTION", severities="CRITICAL", lastSeenAfter="2025-01-01"
-          - SmartFix remediated vulnerabilities: vulnTags="SmartFix Remediated", statuses="Remediated"
-          - Reviewed critical vulnerabilities: vulnTags="reviewed", severities="CRITICAL"
+          A result's environments field reflects only its latest instance and may omit environments
+          from earlier instances.
 
-          Note: This tool requires Contrast Platform Admin or Org Admin permissions to access organization-level
-          vulnerability data.
-
-          Returns paginated results with metadata including totalItems (when available) and hasMorePages.
-          Check 'notices' for informational context and 'errors' for validation failures.
-
-          Response fields:
-          - environments: Latest instance only, may omit environments from earlier instances.
-          - application: Application name and ID where the vulnerability was found.
-
-          Related tools:
-          - search_app_vulnerabilities: For app-scoped searches with session filtering
-          - search_applications: To find application IDs by name, tag, or metadata
+          Examples:
+          - High-priority open: severities="CRITICAL,HIGH", statuses="Reported,Confirmed"
+          - Production critical with recent activity: environments="PRODUCTION",
+            severities="CRITICAL", lastSeenAfter="2025-01-01"
+          - Remediation workflow tags: vulnTags="SmartFix Remediated", statuses="Remediated"
           """)
   public PaginatedToolResponse<VulnLight> searchVulnerabilities(
       @ToolParam(description = "Page number (1-based), default: 1", required = false) Integer page,
@@ -101,9 +87,7 @@ public class SearchVulnerabilitiesTool extends PaginatedTool<VulnerabilityFilter
       @ToolParam(
               description =
                   "Comma-separated environments: DEVELOPMENT,QA,PRODUCTION. Matches any historical"
-                      + " vulnerability instance. A result's environments field describes only its"
-                      + " latest instance and may omit the matched value. Default: all"
-                      + " environments",
+                      + " vulnerability instance. Default: all environments",
               required = false)
           String environments,
       @ToolParam(

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolTest.java
@@ -84,6 +84,31 @@ class GetProtectRulesToolTest {
   }
 
   @Test
+  void getProtectRules_should_notice_virtual_patch_when_mixed_with_regular_rules()
+      throws Exception {
+    var protectData = createProtectData();
+    var virtualPatch = new Rule();
+    virtualPatch.setName("CVE-2021-44228");
+    virtualPatch.setType("Virtual Patch");
+    virtualPatch.setEnabledDev(true);
+    virtualPatch.setEnabledQa(false);
+    virtualPatch.setEnabledProd(true);
+    protectData.getRules().add(virtualPatch);
+    when(contrastApiClient.getProtectRules(TEST_APP_ID)).thenReturn(protectData);
+
+    var result = tool.getProtectRules(TEST_APP_ID);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.notices()).containsExactly(VIRTUAL_PATCH_NOTICE);
+    assertThat(result.data().getRules())
+        .extracting(Rule::getName)
+        .containsExactly("sql-injection", "xss-reflected", "CVE-2021-44228");
+    assertThat(result.data().getRules())
+        .filteredOn(rule -> !"Virtual Patch".equalsIgnoreCase(rule.getType()))
+        .allSatisfy(rule -> assertThat(rule.getProduction()).isNotNull());
+  }
+
+  @Test
   void getProtectRules_should_return_validation_error_for_null_appId() {
     var result = tool.getProtectRules(null, null);
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolTest.java
@@ -36,6 +36,9 @@ import org.springframework.ai.tool.annotation.Tool;
 class GetProtectRulesToolTest {
 
   private static final String TEST_APP_ID = "test-app-456";
+  private static final String VIRTUAL_PATCH_NOTICE =
+      "Virtual Patch entries use enabledDev/enabledQa/enabledProd booleans; their"
+          + " development/qa/production mode fields and uuid are not populated.";
 
   private GetProtectRulesTool tool;
   private ContrastApiClient contrastApiClient;
@@ -58,7 +61,26 @@ class GetProtectRulesToolTest {
     assertThat(result.data().getRules())
         .extracting(Rule::getName)
         .containsExactly("sql-injection", "xss-reflected");
+    assertThat(result.notices()).doesNotContain(VIRTUAL_PATCH_NOTICE);
     verify(contrastApiClient).getProtectRules(TEST_APP_ID);
+  }
+
+  @Test
+  void getProtectRules_should_explain_virtual_patch_response_shape() throws Exception {
+    var protectData = new ProtectData();
+    var virtualPatch = new Rule();
+    virtualPatch.setName("CVE-2021-44228");
+    virtualPatch.setType("Virtual Patch");
+    virtualPatch.setEnabledDev(true);
+    virtualPatch.setEnabledQa(false);
+    virtualPatch.setEnabledProd(true);
+    protectData.setRules(new ArrayList<>(java.util.List.of(virtualPatch)));
+    when(contrastApiClient.getProtectRules(TEST_APP_ID)).thenReturn(protectData);
+
+    var result = tool.getProtectRules(TEST_APP_ID);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.notices()).containsExactly(VIRTUAL_PATCH_NOTICE);
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolTest.java
@@ -15,6 +15,7 @@
  */
 package com.contrast.labs.ai.mcp.contrast.tool.attack;
 
+import static com.contrast.labs.ai.mcp.contrast.tool.attack.GetProtectRulesTool.VIRTUAL_PATCH_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -26,6 +27,7 @@ import com.contrast.labs.ai.mcp.contrast.sdkextension.data.Rule;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
@@ -70,11 +72,11 @@ class GetProtectRulesToolTest {
     var protectData = new ProtectData();
     var virtualPatch = new Rule();
     virtualPatch.setName("CVE-2021-44228");
-    virtualPatch.setType("Virtual Patch");
+    virtualPatch.setType(VIRTUAL_PATCH_TYPE);
     virtualPatch.setEnabledDev(true);
     virtualPatch.setEnabledQa(false);
     virtualPatch.setEnabledProd(true);
-    protectData.setRules(new ArrayList<>(java.util.List.of(virtualPatch)));
+    protectData.setRules(new ArrayList<>(List.of(virtualPatch)));
     when(contrastApiClient.getProtectRules(TEST_APP_ID)).thenReturn(protectData);
 
     var result = tool.getProtectRules(TEST_APP_ID);
@@ -89,7 +91,7 @@ class GetProtectRulesToolTest {
     var protectData = createProtectData();
     var virtualPatch = new Rule();
     virtualPatch.setName("CVE-2021-44228");
-    virtualPatch.setType("Virtual Patch");
+    virtualPatch.setType(VIRTUAL_PATCH_TYPE);
     virtualPatch.setEnabledDev(true);
     virtualPatch.setEnabledQa(false);
     virtualPatch.setEnabledProd(true);
@@ -104,7 +106,7 @@ class GetProtectRulesToolTest {
         .extracting(Rule::getName)
         .containsExactly("sql-injection", "xss-reflected", "CVE-2021-44228");
     assertThat(result.data().getRules())
-        .filteredOn(rule -> !"Virtual Patch".equalsIgnoreCase(rule.getType()))
+        .filteredOn(rule -> !VIRTUAL_PATCH_TYPE.equalsIgnoreCase(rule.getType()))
         .allSatisfy(rule -> assertThat(rule.getProduction()).isNotNull());
   }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/ResponseEnvelopeSerializationTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/ResponseEnvelopeSerializationTest.java
@@ -69,15 +69,7 @@ class ResponseEnvelopeSerializationTest {
     assertThat(json.path("notices").size()).isZero();
   }
 
-  private JsonNode serialize(PaginatedToolResponse<?> response) throws Exception {
-    return parse(JsonParser.toJson(response));
-  }
-
-  private JsonNode serialize(SingleToolResponse<?> response) throws Exception {
-    return parse(JsonParser.toJson(response));
-  }
-
-  private JsonNode serialize(CursorToolResponse<?> response) throws Exception {
+  private JsonNode serialize(Object response) throws Exception {
     return parse(JsonParser.toJson(response));
   }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolTest.java
@@ -55,7 +55,7 @@ class GetRouteCoverageToolTest {
   private static final String ROUTE_HASH = "route-hash-789";
   private static final String SECRET_BODY = "token=raw-token-value&apiKey=secret";
   private static final String FILTERED_ENVIRONMENTS_NOTICE =
-      "route environments are omitted for session-filtered results because the source does not"
+      "Route environments are omitted for session-filtered results because the source does not"
           + " provide them.";
   private static final String FILTERED_ROUTE_COVERAGE_RESPONSE =
       """

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolTest.java
@@ -54,6 +54,9 @@ class GetRouteCoverageToolTest {
   private static final String SESSION_ID = "session-456";
   private static final String ROUTE_HASH = "route-hash-789";
   private static final String SECRET_BODY = "token=raw-token-value&apiKey=secret";
+  private static final String FILTERED_ENVIRONMENTS_NOTICE =
+      "route environments are omitted for session-filtered results because the source does not"
+          + " provide them.";
   private static final String FILTERED_ROUTE_COVERAGE_RESPONSE =
       """
       {
@@ -106,6 +109,7 @@ class GetRouteCoverageToolTest {
     assertThat(result.found()).isTrue();
     assertThat(result.data().routes()).hasSize(2);
     assertThat(result.data().totalRoutes()).isEqualTo(2);
+    assertThat(result.notices()).doesNotContain(FILTERED_ENVIRONMENTS_NOTICE);
     verify(contrastApiClient).getRouteCoverage(eq(VALID_APP_ID), isNull());
   }
 
@@ -122,6 +126,7 @@ class GetRouteCoverageToolTest {
     var request = requestCaptor.getValue();
 
     assertThat(result.isSuccess()).isTrue();
+    assertThat(result.notices()).contains(FILTERED_ENVIRONMENTS_NOTICE);
     assertThat(request).isInstanceOf(RouteCoverageBySessionIDAndMetadataRequestExtended.class);
     assertThat(request.getValues()).hasSize(1);
     assertThat(request.getValues().get(0).getLabel()).isEqualTo(METADATA_NAME);
@@ -179,6 +184,7 @@ class GetRouteCoverageToolTest {
     verify(contrastApiClient).getLatestSessionMetadata(VALID_APP_ID);
     verify(contrastApiClient).getRouteCoverage(eq(VALID_APP_ID), requestCaptor.capture());
     assertThat(result.isSuccess()).isTrue();
+    assertThat(result.notices()).contains(FILTERED_ENVIRONMENTS_NOTICE);
     assertThat(requestCaptor.getValue())
         .isInstanceOf(RouteCoverageBySessionIDAndMetadataRequestExtended.class);
     assertThat(requestCaptor.getValue().getSessionID()).isEqualTo(SESSION_ID);

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
@@ -48,6 +48,8 @@ class ListApplicationsByCveToolTest {
   private static final String CVE_ID = "CVE-2021-44228";
   private static final String LIBRARY_HASH = "hash-123";
   private static final String SECRET_BODY = "token=raw-token-value&apiKey=secret";
+  private static final String CVSS_V2_NOTICE =
+      "score is omitted for CVEs with only CVSS v2 data; use severity and the cvssv2 metrics.";
   private static final String CVSS_V3_CVE_RESPONSE =
       """
       {
@@ -145,6 +147,7 @@ class ListApplicationsByCveToolTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.data().getCve().getScore()).isEqualTo(9.3);
     assertThat(result.data().getCve().getSeverity()).isEqualTo("Critical");
+    assertThat(result.notices()).doesNotContain(CVSS_V2_NOTICE);
     assertThat(result.data().getCve())
         .extracting(
             cve -> cve.getId(),
@@ -184,6 +187,7 @@ class ListApplicationsByCveToolTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.data().getCve().getSeverity()).isEqualTo("High");
     assertThat(result.data().getCve().getScore()).isNull();
+    assertThat(result.notices()).contains(CVSS_V2_NOTICE);
     assertThat(result.data().getCve().getCvssv2())
         .extracting(
             cvss -> cvss.getAccessVector(),

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/server/SearchServersToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/server/SearchServersToolTest.java
@@ -261,6 +261,21 @@ class SearchServersToolTest {
   }
 
   @Test
+  void searchServers_should_notice_unknown_state_when_mixed_with_known_servers() throws Exception {
+    var unknownServer = server(1L, "server-unknown");
+    unknownServer.setDefend(null);
+    unknownServer.setLatestAgentVersion("NA");
+    var knownServer = server(2L, "server-known");
+    when(contrastApiClient.searchServers(any(), eq(50), eq(0), anyString(), eq(false)))
+        .thenReturn(response(2L, unknownServer, knownServer));
+
+    var result = allServers(1, null);
+
+    assertThat(result.notices()).contains(UNKNOWN_PROTECT_NOTICE, UNKNOWN_AGENT_VERSION_NOTICE);
+    assertThat(result.items()).hasSize(2);
+  }
+
+  @Test
   void searchServers_should_not_emit_unknown_state_notices_when_states_are_known()
       throws Exception {
     when(contrastApiClient.searchServers(any(), eq(50), eq(0), anyString(), eq(false)))

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/server/SearchServersToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/server/SearchServersToolTest.java
@@ -51,6 +51,12 @@ import org.springframework.ai.tool.annotation.Tool;
 class SearchServersToolTest {
 
   private static final String SECRET_BODY = "token=raw-token-value&apiKey=secret";
+  private static final String UNKNOWN_PROTECT_NOTICE =
+      "protectEnabled null means Protect state is unknown or unavailable for that server, not"
+          + " disabled.";
+  private static final String UNKNOWN_AGENT_VERSION_NOTICE =
+      "agentOutOfDate null means the latest agent version could not be determined, not that the"
+          + " agent is current.";
 
   private ContrastApiClient contrastApiClient;
   private SearchServersTool tool;
@@ -241,6 +247,32 @@ class SearchServersToolTest {
   }
 
   @Test
+  void searchServers_should_explain_unknown_protect_and_agent_version_state() throws Exception {
+    var server = server(1L, "server-1");
+    server.setDefend(null);
+    server.setLatestAgentVersion("NA");
+    when(contrastApiClient.searchServers(any(), eq(50), eq(0), anyString(), eq(false)))
+        .thenReturn(response(1L, server));
+
+    var result = allServers(1, null);
+
+    assertThat(result.notices())
+        .containsExactly(UNKNOWN_PROTECT_NOTICE, UNKNOWN_AGENT_VERSION_NOTICE);
+  }
+
+  @Test
+  void searchServers_should_not_emit_unknown_state_notices_when_states_are_known()
+      throws Exception {
+    when(contrastApiClient.searchServers(any(), eq(50), eq(0), anyString(), eq(false)))
+        .thenReturn(response(1L, server(1L, "server-1")));
+
+    var result = allServers(1, null);
+
+    assertThat(result.notices())
+        .doesNotContain(UNKNOWN_PROTECT_NOTICE, UNKNOWN_AGENT_VERSION_NOTICE);
+  }
+
+  @Test
   void searchServers_should_return_standard_notice_for_valid_empty_result() throws Exception {
     when(contrastApiClient.searchServers(any(), eq(50), eq(0), anyString(), eq(false)))
         .thenReturn(response(0L));
@@ -304,6 +336,7 @@ class SearchServersToolTest {
     server.setServerId(serverId);
     server.setName(name);
     server.setLatestAgentVersion("5.1.0");
+    server.setDefend(false);
     server.setTags(List.of());
     server.setApplicationCount(0L);
     return server;

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolTest.java
@@ -176,7 +176,7 @@ class SearchAppVulnerabilitiesToolTest {
             APP_ID, 1, 10, null, null, null, null, null, null, null, null, true);
 
     assertThat(result.isSuccess()).isTrue();
-    assertThat(result.notices()).noneMatch(n -> n.contains("No sessions found"));
+    assertThat(result.notices()).doesNotContain("No sessions found");
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolTest.java
@@ -181,12 +181,14 @@ class SearchVulnerabilitiesToolTest {
     Method method = searchVulnerabilitiesMethod();
 
     assertThat(method.getAnnotation(Tool.class).description())
+        .contains(
+            "A result's environments field reflects only its latest instance",
+            "may omit environments",
+            "from earlier instances")
         .doesNotContain("has been seen over time", "Shows historical presence");
     assertThat(method.getParameters()[5].getAnnotation(ToolParam.class).description())
-        .contains(
-            "Matches any historical vulnerability instance",
-            "describes only its latest instance",
-            "may omit the matched value");
+        .contains("Matches any historical vulnerability instance")
+        .doesNotContain("latest instance", "may omit the matched value");
   }
 
   private static Method searchVulnerabilitiesMethod() throws NoSuchMethodException {


### PR DESCRIPTION
<!-- pr-tools:stacked:v1 -->
<!-- pr-tools:parent-pr=184 -->
<!-- pr-tools:parent-branch=AIML-942-add-server-instructions -->
<!-- pr-tools:parent-base=AIML-942-migrate-vulnerability-tool-descriptions -->
<!-- pr-tools:boundary-commit=e99d69ddad5c9db9183f7e7675ddd715ca711a9f -->
<!-- pr-tools:managed:start -->
> ⚠️ **DO NOT MERGE** - This PR is stacked on #184. Merge that first.
>
> **Stack Context**
> - Parent PR: #184
> - Parent branch: `AIML-942-add-server-instructions`
> - Promotion target: `AIML-942-migrate-vulnerability-tool-descriptions`
<!-- pr-tools:managed:end -->

**Jira:** [AIML-942](https://contrast.atlassian.net/browse/AIML-942)

## Summary

Migrate all remaining (non-vulnerability) tool descriptions to the token-efficient format defined by MCP_STANDARDS.md, and move response-shape warnings from static description prose to runtime notices that appear only when the data warrants them.

- Tool descriptions across 14 source files trimmed to necessity-gated richness, cutting ~300 lines of prose
- Response-shape caveats (virtual patches, CVSS v2 scores, null Protect/agent state, session-filtered environments) converted to conditional runtime notices
- Null-safety fix for SDK returning null HTTP request response in `GetVulnerabilityTool`
- Stale `trauma_guard` hook removed from project settings

## Why This Change Exists

The first PR in this stack (#183) migrated vulnerability tool descriptions and the second (#184) added server-level instructions as a home for conventions shared across all tools. This PR completes the migration for every remaining tool: applications, attacks, coverage, libraries, SAST, and servers.

Several tools carried response-shape warnings in their static descriptions that only applied to specific data shapes (e.g., virtual patch entries, CVEs with only CVSS v2 data, servers where Protect state is unknown). These warnings consumed tokens on every call even when irrelevant. Moving them to conditional notices means agents see the warning only when the response actually contains the edge case.

The "requires admin permissions" claim on `search_vulnerabilities` was investigated during this work and found to be false. The endpoint requires only org membership (any role from viewer up), and EAC scoping returns empty results for unauthorized apps rather than 403. That sentence was deleted, and the uniform EAC-visibility fact moved to server instructions in PR #184.

## Approach

Each tool was migrated following the same pattern established in PRs #183 and #184:

1. Trim the `@Tool` description to its necessity-gated budget (get tools ~40 words, search tools ~120 words)
2. Move response-field inventories out (agents learn these from the response itself)
3. Remove "Related tools" footers (cross-references now live inline as discovery pointers or in server instructions)
4. Push parameter-specific semantics (filter logic, valid values, mutual exclusivity) down to `@ToolParam` descriptions
5. Convert response-shape caveats to conditional `collector.notice()` calls, with logic that detects when the specific edge case is present

Discovery pointers ("Use search_applications to find") are placed in the description body only and removed from `@ToolParam` descriptions to avoid duplication. MCP_STANDARDS.md was updated to codify this rule. Get-tool pointers are omitted when no discovery tool exists for the identifier.

## What Changed

### Tool descriptions (14 files)
- `GetSessionMetadataTool` / `SearchApplicationsTool` / `GetProtectRulesTool` / `SearchAttacksTool` / `GetRouteCoverageTool` / `ListApplicationLibrariesTool` / `ListApplicationsByCveTool` / `GetSastProjectTool` / `SearchServersTool` / `GetVulnerabilityTool` / `ListVulnerabilityTypesTool` / `SearchAppVulnerabilitiesTool` / `SearchVulnerabilitiesTool` -- description body trimmed, discovery pointers consolidated, parameter descriptions enriched where semantics moved down

### Runtime notices (4 tools)
- `GetProtectRulesTool` -- emits virtual-patch response-shape notice when response contains Virtual Patch entries
- `ListApplicationsByCveTool` -- emits CVSS v2 notice when CVE lacks v3 data
- `SearchServersTool` -- emits notices for null `protectEnabled` and null `agentOutOfDate`
- `GetRouteCoverageTool` -- emits notice about omitted environments when session filter is active

### Null-safety fix
- `GetVulnerabilityTool` -- wraps null SDK `getHttpRequest()` return in empty `HttpRequestResponse` to prevent NPE

### Housekeeping
- `.claude/settings.json` -- removed stale `trauma_guard` PreToolUse hook
- `MCP_STANDARDS.md` -- clarified discovery-pointer duplication rules and get-tool pointer budget

## Testing

- New unit tests for every conditional notice: `GetProtectRulesToolTest` (virtual patch present/absent), `GetRouteCoverageToolTest` (session-filtered/unfiltered), `ListApplicationsByCveToolTest` (CVSS v2 only/v3 present), `SearchServersToolTest` (null protect/agent state, known state)
- New `GetVulnerabilityToolTest` cases for null HTTP request response and null `HttpRequestResponse` wrapper
- New `McpServerInstructionsTest` verifying server instructions bind correctly and carry the uniform conventions (ORed/ANDed semantics, credential-scoped visibility)
- Existing `SearchVulnerabilitiesToolTest` updated to reflect the environments caveat moving from parameter description to tool body


[AIML-942]: https://contrast.atlassian.net/browse/AIML-942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ