### PR TITLE
AIML-1151 Fix wrong xss-reflected example in tool descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,7 +173,7 @@ These bugs prevented core functionality from working correctly:
 
 **Rules parameter for attack search**: Filter attacks by exact rule ID:
 - Single rule: `rules="sql-injection"`
-- Multiple rules: `rules="sql-injection,xss-reflected"`
+- Multiple rules: `rules="sql-injection,reflected-xss"`
 
 **Pagination added to consolidated tools**: The old tools returned all results in a single response with no pagination. The new consolidated tools all support pagination:
 - `search_applications` - replaces 5 non-paginated tools

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/VulnLight.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/VulnLight.java
@@ -23,7 +23,7 @@ import java.util.List;
  * vulnerability information including application correlation data.
  *
  * @param title Vulnerability title/description
- * @param type Vulnerability type/rule name (e.g., "sql-injection", "xss-reflected")
+ * @param type Vulnerability type/rule name (e.g., "sql-injection", "reflected-xss")
  * @param vulnID Unique vulnerability identifier (UUID)
  * @param severity Severity level (CRITICAL, HIGH, MEDIUM, LOW, NOTE)
  * @param appID Application UUID that owns this vulnerability

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksTool.java
@@ -92,7 +92,7 @@ public class SearchAttacksTool extends PaginatedTool<AttackFilterParams, AttackS
       @ToolParam(
               description =
                   "Comma-separated list of rule IDs to filter by (e.g.,"
-                      + " 'sql-injection,xss-reflected'). Use get_protect_rules to discover"
+                      + " 'sql-injection,reflected-xss'). Use get_protect_rules to discover"
                       + " available rule IDs for an application. This filters by exact rule match,"
                       + " unlike keyword which does substring search.",
               required = false)

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParams.java
@@ -87,7 +87,7 @@ public class AttackFilterParams extends BaseToolParams {
    * @param includeBotBlockers Include bot blocker attacks
    * @param includeIpBlacklist Include IP blacklist attacks
    * @param sort Sort field (e.g., "startTime,DESC")
-   * @param rules Comma-separated list of rule IDs (e.g., "sql-injection,xss-reflected")
+   * @param rules Comma-separated list of rule IDs (e.g., "sql-injection,reflected-xss")
    * @return AttackFilterParams with validation state
    */
   public static AttackFilterParams of(

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelper.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelper.java
@@ -74,7 +74,7 @@ public class FilterHelper {
    * Parse comma-separated string into list with robust whitespace handling. Handles edge cases like
    * extra whitespace, empty values, and null input.
    *
-   * @param input Comma-separated string (e.g., "CRITICAL, HIGH" or "sql-injection,xss-reflected")
+   * @param input Comma-separated string (e.g., "CRITICAL, HIGH" or "sql-injection,reflected-xss")
    * @return List of trimmed, non-empty strings, or null if input is null/empty
    * @example parseCommaSeparated("CRITICAL, HIGH, ") → ["CRITICAL", "HIGH"]
    * @example parseCommaSeparated("sql-injection,,xss") → ["sql-injection", "xss"]

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesTool.java
@@ -45,7 +45,7 @@ public class ListVulnerabilityTypesTool
       description =
           """
           List every vulnerability type (Assess rule name) available in the organization, such as
-          sql-injection or xss-reflected. Returned values are the valid inputs for the vulnTypes
+          sql-injection or reflected-xss. Returned values are the valid inputs for the vulnTypes
           parameter of search_vulnerabilities and search_app_vulnerabilities.
           """)
   public SingleToolResponse<List<String>> listVulnerabilityTypes(ToolContext toolContext) {

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesTool.java
@@ -80,7 +80,7 @@ public class SearchVulnerabilitiesTool extends PaginatedTool<VulnerabilityFilter
           String statuses,
       @ToolParam(
               description =
-                  "Comma-separated vulnerability types (e.g., sql-injection,xss-reflected). Use"
+                  "Comma-separated vulnerability types (e.g., sql-injection,reflected-xss). Use"
                       + " list_vulnerability_types tool for complete list. Default: all types",
               required = false)
           String vulnTypes,

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/result/AttackSummaryTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/result/AttackSummaryTest.java
@@ -205,7 +205,7 @@ class AttackSummaryTest {
     attack.setUuid("test-attack-uuid");
     attack.setStatus("PROBED");
     attack.setSource("192.168.1.100");
-    attack.setRules(List.of("sql-injection", "xss-reflected"));
+    attack.setRules(List.of("sql-injection", "reflected-xss"));
     attack.setProbes(10);
     attack.setStart_time(TEST_TIMESTAMP);
     attack.setEnd_time(TEST_TIMESTAMP + 5000);

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolTest.java
@@ -62,7 +62,7 @@ class GetProtectRulesToolTest {
     assertThat(result.found()).isTrue();
     assertThat(result.data().getRules())
         .extracting(Rule::getName)
-        .containsExactly("sql-injection", "xss-reflected");
+        .containsExactly("sql-injection", "reflected-xss");
     assertThat(result.notices()).doesNotContain(VIRTUAL_PATCH_NOTICE);
     verify(contrastApiClient).getProtectRules(TEST_APP_ID);
   }
@@ -104,7 +104,7 @@ class GetProtectRulesToolTest {
     assertThat(result.notices()).containsExactly(VIRTUAL_PATCH_NOTICE);
     assertThat(result.data().getRules())
         .extracting(Rule::getName)
-        .containsExactly("sql-injection", "xss-reflected", "CVE-2021-44228");
+        .containsExactly("sql-injection", "reflected-xss", "CVE-2021-44228");
     assertThat(result.data().getRules())
         .filteredOn(rule -> !VIRTUAL_PATCH_TYPE.equalsIgnoreCase(rule.getType()))
         .allSatisfy(rule -> assertThat(rule.getProduction()).isNotNull());
@@ -205,7 +205,7 @@ class GetProtectRulesToolTest {
     rules.add(sqlRule);
 
     var xssRule = new Rule();
-    xssRule.setName("xss-reflected");
+    xssRule.setName("reflected-xss");
     xssRule.setProduction("monitor");
     rules.add(xssRule);
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesToolTest.java
@@ -48,7 +48,7 @@ class ListVulnerabilityTypesToolTest {
     Rules.Rule rule1 = mock();
     Rules.Rule rule2 = mock();
     Rules.Rule rule3 = mock();
-    when(rule1.getName()).thenReturn("xss-reflected");
+    when(rule1.getName()).thenReturn("reflected-xss");
     when(rule2.getName()).thenReturn("sql-injection");
     when(rule3.getName()).thenReturn("cmd-injection");
 
@@ -61,7 +61,7 @@ class ListVulnerabilityTypesToolTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.found()).isTrue();
     assertThat(result.data())
-        .containsExactlyInAnyOrder("cmd-injection", "sql-injection", "xss-reflected")
+        .containsExactlyInAnyOrder("cmd-injection", "sql-injection", "reflected-xss")
         .isSortedAccordingTo(Comparator.naturalOrder());
 
     verify(contrastApiClient).getRules();

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesLocalParityTest.java
@@ -70,8 +70,8 @@ class GetProtectRulesLocalParityTest {
     assertThat(response.notices()).isEmpty();
     assertThat(response.data().getRules())
         .extracting(Rule::getName)
-        .containsExactly("sql-injection", "xss-reflected");
-    assertThat(responseJson).contains("sql-injection", "xss-reflected").doesNotContain(TEST_ORG_ID);
+        .containsExactly("sql-injection", "reflected-xss");
+    assertThat(responseJson).contains("sql-injection", "reflected-xss").doesNotContain(TEST_ORG_ID);
     verify(sdkExtension).getProtectConfig(TEST_ORG_ID, TEST_APP_ID);
   }
 
@@ -85,7 +85,7 @@ class GetProtectRulesLocalParityTest {
     rules.add(sqlRule);
 
     var xssRule = new Rule();
-    xssRule.setName("xss-reflected");
+    xssRule.setName("reflected-xss");
     xssRule.setProduction("monitor");
     rules.add(xssRule);
 

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksToolIT.java
@@ -358,12 +358,12 @@ class SearchAttacksToolIT {
   void searchAttacks_should_find_results_with_multiple_rules() {
     var response =
         searchAttacksTool.searchAttacks(
-            1, 50, null, null, null, null, null, null, null, "sql-injection,xss-reflected");
+            1, 50, null, null, null, null, null, null, null, "sql-injection,reflected-xss");
 
     assertThat(response).as("Response should not be null").isNotNull();
     assertThat(response.errors()).as("Should have no errors").isEmpty();
     assertThat(response.items())
-        .as("requires seeded attacks matching sql-injection or xss-reflected rules")
+        .as("requires seeded attacks matching sql-injection or reflected-xss rules")
         .isNotEmpty();
 
     // Every attack must have at least one rule matching one of the two requested rule families.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesLocalParityTest.java
@@ -38,7 +38,7 @@ class ListVulnerabilityTypesLocalParityTest {
 
   private static final String TEST_ORG_ID = "local-org-id-should-not-serialize";
   private static final byte[] S4C_LOCAL_STDIO_GOLDEN_JSON =
-      ("{\"data\":[\"cmd-injection\",\"sql-injection\",\"xss-reflected\"],\"errors\":[],"
+      ("{\"data\":[\"cmd-injection\",\"reflected-xss\",\"sql-injection\"],\"errors\":[],"
               + "\"notices\":[],\"found\":true,\"success\":true}")
           .getBytes(StandardCharsets.UTF_8);
 
@@ -63,7 +63,7 @@ class ListVulnerabilityTypesLocalParityTest {
     Rules.Rule rule1 = mock();
     Rules.Rule rule2 = mock();
     Rules.Rule rule3 = mock();
-    when(rule1.getName()).thenReturn("xss-reflected");
+    when(rule1.getName()).thenReturn("reflected-xss");
     when(rule2.getName()).thenReturn("sql-injection");
     when(rule3.getName()).thenReturn("cmd-injection");
 

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityMapperTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityMapperTest.java
@@ -391,7 +391,7 @@ class VulnerabilityMapperTest {
     Trace trace = mock();
 
     when(trace.getTitle()).thenReturn("XSS");
-    when(trace.getRule()).thenReturn("xss-reflected");
+    when(trace.getRule()).thenReturn("reflected-xss");
     when(trace.getUuid()).thenReturn("vuln-no-session-sdk");
     when(trace.getSeverity()).thenReturn("HIGH");
     when(trace.getStatus()).thenReturn("Confirmed");
@@ -478,7 +478,7 @@ class VulnerabilityMapperTest {
 
     when(trace.getApplication()).thenReturn(app);
     when(trace.getTitle()).thenReturn("XSS Vulnerability");
-    when(trace.getRule()).thenReturn("xss-reflected");
+    when(trace.getRule()).thenReturn("reflected-xss");
     when(trace.getUuid()).thenReturn("vuln-with-app");
     when(trace.getSeverity()).thenReturn("CRITICAL");
     when(trace.getStatus()).thenReturn("Confirmed");
@@ -499,7 +499,7 @@ class VulnerabilityMapperTest {
         .as("appName should match application name")
         .isEqualTo("My Production App");
     assertThat(result.vulnID()).isEqualTo("vuln-with-app");
-    assertThat(result.type()).isEqualTo("xss-reflected");
+    assertThat(result.type()).isEqualTo("reflected-xss");
     assertThat(result.severity()).isEqualTo("CRITICAL");
     assertThat(result.environments()).hasSize(1);
     assertThat(result.environments().get(0)).isEqualTo("PRODUCTION");


### PR DESCRIPTION
## Summary

- Fix `xss-reflected` → `reflected-xss` in tool description strings for `search_vulnerabilities`, `search_attacks`, and `list_vulnerability_types`
- Also fix matching javadoc in `AttackFilterParams`, `VulnLight`, and `FilterHelper`
- Test mock data left unchanged (those are internal names, not user-facing examples)

## Test plan

- [x] `make check-test` passes
- [ ] Run `/test-mcp-server smoke` and confirm the example in each tool description now matches a real rule name