### PR TITLE
AIML-1285 Release stdio MCP server v2.2.0

### DIFF
--- a/.claude/skills/test-mcp-server/SKILL.md
+++ b/.claude/skills/test-mcp-server/SKILL.md
@@ -17,20 +17,25 @@ on demand only.
 
 ## Usage
 
-- `/test-mcp-server` runs the in-depth (regular) pass.
+- `/test-mcp-server` runs the in-depth (regular) pass with Sonnet testers.
 - `/test-mcp-server smoke` runs a fast pass that just checks each tool's main use case.
 - `/test-mcp-server regular <focus>` runs in-depth with a nudge, e.g. `/test-mcp-server regular focus on the server tools`.
+- `/test-mcp-server --model claude-opus-4-6` runs with Opus testers instead of Sonnet.
+- `--model <id>` can be combined with any mode, e.g. `/test-mcp-server smoke --model claude-opus-4-6`.
 
 ## What to do
 
 1. Work out the mode and focus from the arguments. Default mode is regular. If the
    first word is not `smoke` or `regular`, treat the whole argument as focus text on
    a regular run.
-2. Launch the helper in the background, since a full regular run can take several
-   minutes, and wait for the completion notification rather than polling:
+2. Launch the helper in the background so the user can keep chatting. A regular
+   run spawns one tester per tool and can take 15-20 minutes. Set
+   `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0` in the command so the background
+   output capture waits indefinitely instead of cutting off at the default
+   600-second ceiling:
 
    ```
-   bash .claude/skills/test-mcp-server/run.sh <mode> <focus>
+   CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 bash .claude/skills/test-mcp-server/run.sh <mode> <focus>
    ```
 
 3. When it finishes, read its output and show the human the report as the script

--- a/.claude/skills/test-mcp-server/SKILL.md
+++ b/.claude/skills/test-mcp-server/SKILL.md
@@ -25,9 +25,10 @@ on demand only.
 
 ## What to do
 
-1. Work out the mode and focus from the arguments. Default mode is regular. If the
-   first word is not `smoke` or `regular`, treat the whole argument as focus text on
-   a regular run.
+1. Work out the mode and focus from the arguments. If the first word is `smoke` or
+   `regular`, use it as the mode and treat the rest as focus text. If no mode was
+   provided, ask the user which mode to run (smoke or regular) before launching.
+   Always pass an explicit mode to the script.
 2. Launch the helper in the background so the user can keep chatting. A regular
    run spawns one tester per tool and can take 15-20 minutes. Set
    `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0` in the command so the background

--- a/.claude/skills/test-mcp-server/run.sh
+++ b/.claude/skills/test-mcp-server/run.sh
@@ -31,19 +31,27 @@
 set -euo pipefail
 
 # --- parse mode, model, and focus -----------------------------------------
-# Default to regular. Only consume the first word if it is an explicit mode;
-# otherwise the whole argument is focus text on a regular run.
-MODE="regular"
+# Mode (smoke or regular) must be the first positional argument.
+# The skill layer asks the user and always passes an explicit mode.
 TESTER_MODEL="sonnet"
 if [[ "${1:-}" == "smoke" || "${1:-}" == "regular" ]]; then
   MODE="$1"
   shift
+else
+  log "Usage: run.sh <smoke|regular> [--model <id>] [focus text...]"
+  log "Mode (smoke or regular) must be the first argument."
+  exit 1
 fi
 # --model <id> anywhere in remaining args overrides the tester model
 REMAINING_ARGS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --model) TESTER_MODEL="$2"; shift 2 ;;
+    --model)
+      if [[ $# -lt 2 ]]; then
+        log "--model requires a value (e.g. --model sonnet)"
+        exit 1
+      fi
+      TESTER_MODEL="$2"; shift 2 ;;
     *) REMAINING_ARGS+=("$1"); shift ;;
   esac
 done
@@ -154,7 +162,7 @@ claude -p "$ORCH_PROMPT" \
 
 # --- if the orchestrator was killed, salvage individual results ------------
 if [ "$ORCH_EXIT" -ne 0 ]; then
-  RESULT_COUNT="$(ls "$RESULTS_DIR"/*.txt 2>/dev/null | wc -l | tr -d ' ')"
+  RESULT_COUNT="$(find "$RESULTS_DIR" -maxdepth 1 -name '*.txt' | wc -l | tr -d ' ')"
   if [ "$RESULT_COUNT" -gt 0 ]; then
     echo ""
     echo "=== Orchestrator exited early (code $ORCH_EXIT). Salvaged $RESULT_COUNT tool results: ==="

--- a/.claude/skills/test-mcp-server/run.sh
+++ b/.claude/skills/test-mcp-server/run.sh
@@ -20,24 +20,34 @@
 # into a throwaway headless Claude instance, and has that instance test every
 # tool the server exposes. The report is printed to stdout for a human to read.
 #
-# Usage: run.sh [smoke|regular] [focus text...]
-#   smoke    checks each tool's main use case only
-#   regular  (default) in-depth exploratory testing; accepts an optional focus
+# Usage: run.sh [smoke|regular] [--model <id>] [focus text...]
+#   smoke              checks each tool's main use case only
+#   regular            (default) in-depth exploratory testing; accepts an optional focus
+#   --model <id>       model for tester subagents (default: sonnet)
 #
 # The tool list is never hardcoded here. The orchestrator asks the running
 # server what it exposes, so a new tool is covered with no change to this script.
 
 set -euo pipefail
 
-# --- parse mode and focus -------------------------------------------------
+# --- parse mode, model, and focus -----------------------------------------
 # Default to regular. Only consume the first word if it is an explicit mode;
 # otherwise the whole argument is focus text on a regular run.
 MODE="regular"
+TESTER_MODEL="sonnet"
 if [[ "${1:-}" == "smoke" || "${1:-}" == "regular" ]]; then
   MODE="$1"
   shift
 fi
-FOCUS="$*"
+# --model <id> anywhere in remaining args overrides the tester model
+REMAINING_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --model) TESTER_MODEL="$2"; shift 2 ;;
+    *) REMAINING_ARGS+=("$1"); shift ;;
+  esac
+done
+FOCUS="${REMAINING_ARGS[*]:-}"
 
 # --- locate repo root -----------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -81,6 +91,8 @@ fi
 # No secrets go in this file. The java subprocess inherits CONTRAST_* from the
 # environment sourced above, so credentials never touch disk.
 WORK="$(mktemp -d)"
+RESULTS_DIR="$WORK/results"
+mkdir -p "$RESULTS_DIR"
 trap 'rm -rf "$WORK"' EXIT
 MCP_CONFIG="$WORK/mcp.json"
 cat > "$MCP_CONFIG" <<EOF
@@ -95,9 +107,9 @@ cat > "$MCP_CONFIG" <<EOF
 EOF
 
 # --- the Sonnet tester persona (short and human on purpose) ---------------
-TESTER_PROMPT='You are a hands-on tester for one Contrast MCP tool. You have the Contrast tools available. Work out what your tool does from its description, then find real data to test it with by calling the other Contrast tools first (for example, search for an application, a vulnerability, or a server). Then actually call your tool and see how it behaves. Report back plainly: what you tried, what worked, anything that looked wrong or confusing, and a one-word verdict of WORKS, ISSUES, BROKEN, or INCONCLUSIVE (use INCONCLUSIVE if you could not find data to test with). Keep it short and honest. Do not spawn other agents.'
+TESTER_PROMPT="You are a hands-on tester for one Contrast MCP tool. You have the Contrast tools available. Work out what your tool does from its description, then find real data to test it with by calling the other Contrast tools first (for example, search for an application, a vulnerability, or a server). Then actually call your tool and see how it behaves. When you are done, write your full results to a file using Bash: echo your report into $RESULTS_DIR/<tool-name>.txt (use the exact tool name, e.g. search_vulnerabilities.txt). Your report must include: what you tried, what worked, anything that looked wrong or confusing, and a one-word verdict line at the end: VERDICT: WORKS, VERDICT: ISSUES, VERDICT: BROKEN, or VERDICT: INCONCLUSIVE. Keep it short and honest. Do not spawn other agents."
 AGENTS_JSON="$(cat <<EOF
-{"mcp-tool-tester": {"description": "Exploratory tester for a single Contrast MCP tool", "prompt": "$TESTER_PROMPT", "model": "sonnet"}}
+{"mcp-tool-tester": {"description": "Exploratory tester for a single Contrast MCP tool", "prompt": "$TESTER_PROMPT", "model": "$TESTER_MODEL"}}
 EOF
 )"
 
@@ -120,7 +132,7 @@ First, list every tool the contrast MCP server exposes to you. Then spawn one mc
 $DEPTH
 $FOCUS_LINE
 
-Let the subagents do the testing and find their own data. Do not test tools yourself beyond what you need to discover the tool list, and do not edit files or run shell commands.
+Let the subagents do the testing and find their own data. Do not test tools yourself beyond what you need to discover the tool list.
 
 When every tester has reported back, pull it all together into one report:
 - Start with a short overall read: is this build safe to release, and the headline problems if not.
@@ -129,12 +141,32 @@ EOF
 )"
 
 # --- run the nested instance ----------------------------------------------
-log "Launching a $MODE test. One Opus orchestrator, one Sonnet tester per tool."
+log "Launching a $MODE test. Orchestrator: opus, testers: $TESTER_MODEL."
 log "This can take several minutes for a full regular run."
 
+ORCH_EXIT=0
 claude -p "$ORCH_PROMPT" \
   --model opus \
   --mcp-config "$MCP_CONFIG" \
   --strict-mcp-config \
-  --allowedTools "mcp__contrast Task" \
-  --agents "$AGENTS_JSON"
+  --allowedTools "mcp__contrast Task Bash" \
+  --agents "$AGENTS_JSON" || ORCH_EXIT=$?
+
+# --- if the orchestrator was killed, salvage individual results ------------
+if [ "$ORCH_EXIT" -ne 0 ]; then
+  RESULT_COUNT="$(ls "$RESULTS_DIR"/*.txt 2>/dev/null | wc -l | tr -d ' ')"
+  if [ "$RESULT_COUNT" -gt 0 ]; then
+    echo ""
+    echo "=== Orchestrator exited early (code $ORCH_EXIT). Salvaged $RESULT_COUNT tool results: ==="
+    for f in "$RESULTS_DIR"/*.txt; do
+      TOOL_NAME="$(basename "$f" .txt)"
+      echo ""
+      echo "--- $TOOL_NAME ---"
+      cat "$f"
+    done
+  else
+    log "Orchestrator exited with code $ORCH_EXIT and no individual results were saved."
+  fi
+fi
+
+exit "$ORCH_EXIT"

--- a/.claude/skills/update-changelog/SKILL.md
+++ b/.claude/skills/update-changelog/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: update-changelog
+description: Bring the [Unreleased] section of CHANGELOG.md up to date before a release. Diffs the last release tag against origin/main, drafts entries PR-by-PR, audits the draft for completeness with a read-only subagent, and lands the result on a branch after the user approves. Run pre-release, before dispatching the Gradle Release workflow, or whenever a human asks for a changelog update. Optional free text is treated as guidance, e.g. classification hints.
+---
+
+# Pre-release changelog update
+
+Brings `[Unreleased]` in CHANGELOG.md up to date with every user-facing change merged
+since the last release tag, so the release ships with a finished changelog. The skill
+drafts, audits, and only then shows the human one final draft. Nothing is written to
+disk before the human approves.
+
+**When to run.** Before triggering the Gradle Release workflow (see RELEASING.md), or
+when a human explicitly asks. Not part of routine feature development.
+
+## Usage
+
+- `/update-changelog` runs the full flow.
+- `/update-changelog <guidance>` passes free-text hints, e.g.
+  `/update-changelog the SBOM work is internal, skip it`.
+
+## Ground rules
+
+- Content goes into `[Unreleased]`. Never stamp a version heading for the upcoming
+  release. Version selection belongs to the release workflow, not this skill.
+- Versions that already have a changelog section are settled. Never reopen, rewrite,
+  or re-audit them.
+- Existing `[Unreleased]` entries may be amended or expanded when they are incomplete
+  or wrong. Never delete one silently. Propose deletions in the draft and let the
+  human decide.
+- Report a suggested next version (breaking changes → major, new capabilities → minor,
+  otherwise patch). It is informational only. Do not act on it.
+- Do not create beads. This is a one-file docs change.
+
+## Step 1 — Orient and choose the branch
+
+1. `git fetch origin --tags -q`
+2. Find the newest release tag, `git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1`
+3. Find the newest version heading in CHANGELOG.md (`## [X.Y.Z]`).
+4. **Backfill check.** If release tags exist that are newer than the newest heading,
+   those releases shipped without changelog notes. Offer to backfill exactly those
+   versions in this run. A backfilled section is stamped `[X.Y.Z] - <tag date>`
+   (`git log -1 --format=%cs vX.Y.Z`). Do not scan further back than the newest
+   heading. Versions at or below it are never touched.
+5. **Ask the human where the change lands.** Use the current Jira branch, or create a
+   new branch. A new branch needs a Jira ticket, either an existing one or a new AIML
+   Task with component `Contrast MCP Server`, and follows the repo convention
+   `AIML-<ticket>-<short-description>`. This choice also determines the diff range in
+   Step 2, so ask it now.
+
+## Step 2 — Determine the range
+
+- Base range is `vLAST..origin/main`, where `vLAST` is the newest release tag.
+- **Current-branch mode.** Also include the branch's own unmerged work
+  (`git log --oneline origin/main..HEAD` and `git diff origin/main...HEAD --stat`).
+  Choosing this mode signals that the branch ships in the release, so its changes
+  are documented too.
+- **Backfill ranges.** One range per backfilled version, `vN-1..vN`.
+
+## Step 3 — Enumerate and draft
+
+For each range:
+
+1. List merged PRs, `git log --oneline --merges <range>`. Also run without `--merges`
+   to catch direct commits.
+2. For each PR, `gh pr view <N> --json title,body,labels`. Identify the Jira ticket
+   and summarize what changed. Read the diff when the PR body is thin or ambiguous.
+3. Classify every change:
+   - **USER-FACING**: new tool, tool behavior or contract change, bug fix a user would
+     notice, breaking change, security-relevant dependency change, install or docs a
+     user relies on.
+   - **INTERNAL**: test-only fixes, CI/build config, dependabot internal tooling,
+     release plumbing, refactors with no observable effect.
+4. Draft an entry for each user-facing change in the house style below. Amend an
+   existing `[Unreleased]` entry instead of duplicating it when it already covers the
+   same change but is incomplete.
+
+**House style** (match the existing file exactly):
+
+- Section order within a version: Breaking Changes, Bug Fixes, Improvements, Security,
+  Documentation. Include only non-empty sections.
+- Each entry is a short prose paragraph led by a **bold summary phrase**, wrapped at
+  roughly 100 characters.
+- No PR numbers or ticket IDs in the published text. Cite external-system defects
+  (e.g. `TS-42992`) only when the entry needs them to make sense.
+- Write for the user of the MCP server, not the developer. Name the tool and the
+  observable behavior.
+
+## Step 4 — Audit
+
+Launch one **read-only** subagent per range, in parallel when there are several, using
+the prompt template at the bottom of this file. Reproduce the full draft section text
+inline in the prompt. In current-branch mode, list the branch's own unmerged changes
+in the prompt as additional items to classify.
+
+Then verify before applying. For every MISSING or PARTIAL finding, check the claim
+against the actual PR diff (`gh pr diff <N>` or `git show`) before accepting it.
+Auditors can misattribute details, especially between merged work and similar unmerged
+work on other branches. Discard findings the diff does not support and say so.
+
+## Step 5 — Present the draft
+
+Show the human, in one message, before writing anything:
+
+- The complete proposed `[Unreleased]` section (and any backfilled sections).
+- What changed versus the current file. New entries, amended entries with the reason,
+  and any proposed deletions flagged for a decision.
+- The audit verdict per range, including anything found and rejected in verification.
+- The suggested next version, marked informational.
+
+Wait for approval. Apply requested edits and re-present if the human asks for changes.
+
+## Step 6 — Land
+
+**Current-branch mode.** Edit CHANGELOG.md in place, commit on the current branch with
+the branch's Jira ID prefix, e.g. `AIML-1285 Update changelog for upcoming release`.
+Do not push or open a PR. The change rides the branch's normal flow.
+
+**New-branch mode.** Keep the working tree untouched by using a throwaway worktree:
+
+```bash
+git worktree add -b AIML-<ticket>-update-changelog /tmp/changelog-wt origin/main
+# edit CHANGELOG.md in the worktree, then
+git -C /tmp/changelog-wt add CHANGELOG.md
+git -C /tmp/changelog-wt commit -m "AIML-<ticket> Update changelog for upcoming release"
+git -C /tmp/changelog-wt push -u origin AIML-<ticket>-update-changelog
+git worktree remove /tmp/changelog-wt
+```
+
+Then run `/pr-tools:create-pr` for the new branch. PR title follows the repo
+convention `<Jira Id> <Title>`.
+
+## Step 7 — Report
+
+Close with the suggested next version, a one-paragraph audit summary, what was added
+or amended, any deletions or backfills performed, and the PR URL or commit hash.
+
+## Audit subagent prompt template
+
+Fill in `<RANGE>`, `<REPO_PATH>`, and `<DRAFT>`. Keep the READ-ONLY framing verbatim.
+
+```text
+You are auditing a draft CHANGELOG section for completeness. READ-ONLY task: do not
+modify any files, do not commit, do not checkout branches, do not touch the working
+tree. Only use read-only git commands (git log, git show, git diff) and
+`gh pr view` / `gh pr list` / `gh pr diff`.
+
+Repo: <REPO_PATH> (an MCP server for Contrast Security)
+
+Verify that the draft below documents every USER-FACING change in the range <RANGE>,
+and that nothing user-facing was missed.
+
+STEP 1 — Enumerate everything in the range:
+- Run `git log --oneline --merges <RANGE>` to list merged PRs.
+- Also run without --merges to see direct commits.
+- For each merged PR, get its title/body with `gh pr view <N> --json title,body,labels`.
+  Identify the Jira ticket (AIML-xxx / ENTSEC-x etc.) and summarize what changed.
+
+STEP 2 — Classify each PR/change as one of:
+  (a) USER-FACING (new tool, tool behavior/contract change, bug fix a user would
+      notice, breaking change, security-relevant dependency change, install/docs a
+      user relies on)
+  (b) INTERNAL (test-only fixes, CI/build config, dependabot internal tooling,
+      release plumbing, refactors with no observable effect)
+
+STEP 3 — Cross-check against the draft reproduced below. For each USER-FACING change,
+decide: COVERED / MISSING / PARTIALLY-COVERED.
+
+--- DRAFT ---
+<DRAFT>
+--- END DRAFT ---
+
+RETURN a concise report with:
+1. A table: PR# | ticket | one-line summary | classification (user-facing/internal) |
+   changelog status (covered/missing/partial)
+2. A clear list of any USER-FACING changes that are MISSING or PARTIAL, with a
+   suggested one-line changelog entry and which section (Breaking Changes/Bug
+   Fixes/Improvements/Security/Documentation) it belongs in.
+3. A final verdict: is the draft complete, or does it need additions?
+
+Be precise and evidence-based. Quote PR titles. Do not speculate. If unsure whether
+something is user-facing, say so and explain.
+```
+
+## Notes
+
+- If CHANGELOG.md has no `[Unreleased]` heading, create one directly under the intro.
+- The audit checks a closed set, so run it only after the draft is complete for the
+  range. Re-running after human-requested edits is cheap and worth it when the edits
+  change coverage rather than wording.
+- This skill does not touch GitHub release notes. The release workflow generates
+  those, and any sync from the changelog is separate work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
-**Response notices and remediation hint renamed**: The published `contrast-mcp-core` response
-envelopes now expose `notices` instead of `warnings`, including the JSON field and the record
-component on `PaginatedToolResponse`, `SingleToolResponse`, and `CursorToolResponse`.
-`WarningCollector` is now `NoticeCollector`, `ToolParams.warnings()` is now
-`ToolParams.notices()`, and `Vulnerability.hint` is now `Vulnerability.remediationHint`.
-Java consumers must recompile and update these API references; JSON consumers must read
-`notices` and `remediationHint`.
+**Response envelope field `warnings` renamed to `notices`**: The informational messages
+attached to every tool response were renamed from `warnings` to `notices` because the old
+name caused AI agents to treat normal teaching notes as problems. The `Vulnerability`
+field `hint` was also renamed to `remediationHint` for clarity. JSON consumers must read
+`notices` and `remediationHint` instead of the old field names.
+
+### Bug Fixes
+
+**`get_vulnerability` no longer crashes on missing HTTP request data**: When the Contrast
+SDK returned a null HTTP request response, the tool threw a NullPointerException instead
+of returning the vulnerability with the HTTP request field omitted. Fixed.
+
+### Improvements
+
+**Tool descriptions rewritten to reduce token usage by ~650 tokens per session**: Every
+tool description was trimmed to a word-budget template, cutting tool description text by
+55% (1,079 to 490 words). Some parameter semantics moved from tool bodies down to
+individual parameter descriptions where agents need them at call time, bringing the net
+reduction across all agent-visible text to ~30%.
+
+**Response-shape caveats moved to conditional notices**: Several static description
+paragraphs that warned about edge-case response shapes now appear as runtime notices only
+when the response actually contains the edge case, instead of adding to the token cost of
+every call.
+
+**Server instructions deliver catalog-wide conventions**: The MCP server now emits an
+`instructions` field during initialization, teaching agents conventions that apply
+uniformly across all tools. These facts no longer repeat in individual tool descriptions,
+further reducing per-session token usage.
+
+### Documentation
+
+**Vulnerability environment filter semantics clarified**: Tool descriptions now explain
+that environment filters match any historical vulnerability instance, while the returned
+`environments` field reflects only the latest instance and may omit the environment that
+caused the match.
+
+**README documents hosted server authorization scope**: The README now explains that the
+hosted MCP server's OAuth scopes are identity-only by design, authorization is enforced
+per-request by the platform using existing RBAC, and every tool call is audited.
 
 ## [2.1.0] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+**`search_vulnerabilities` example used wrong vulnerability type name**: The tool
+description's example filter for reflected XSS used the incorrect type `xss-reflected`
+instead of `reflected-xss`, causing agents to construct queries that returned no results.
+Fixed to use the correct type name.
+
 **`get_vulnerability` no longer crashes on missing HTTP request data**: When the Contrast
 SDK returned a null HTTP request response, the tool threw a NullPointerException instead
 of returning the vulnerability with the HTTP request field omitted. Fixed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Breaking Changes
-
-**Response envelope field `warnings` renamed to `notices`**: The informational messages
-attached to every tool response were renamed from `warnings` to `notices` because the old
-name caused AI agents to treat normal teaching notes as problems. The `Vulnerability`
-field `hint` was also renamed to `remediationHint` for clarity. JSON consumers must read
-`notices` and `remediationHint` instead of the old field names.
-
 ### Bug Fixes
 
 **`get_vulnerability` no longer crashes on missing HTTP request data**: When the Contrast
@@ -22,6 +14,11 @@ SDK returned a null HTTP request response, the tool threw a NullPointerException
 of returning the vulnerability with the HTTP request field omitted. Fixed.
 
 ### Improvements
+
+**Response envelope field `warnings` renamed to `notices`**: The informational messages
+attached to every tool response were renamed from `warnings` to `notices` because the old
+name caused AI agents to treat normal teaching notes as problems. The `Vulnerability`
+field `hint` was also renamed to `remediationHint` for clarity.
 
 **Tool descriptions rewritten to reduce token usage by ~650 tokens per session**: Every
 tool description was trimmed to a word-budget template, cutting tool description text by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -601,6 +601,10 @@ Run the harness-engineering playbooks against this repo on demand via `/harness-
 
 `/test-mcp-server` runs an exploratory test of the freshly built server against the `.env.integration-test` org (in-depth by default, `smoke` for a fast pass). Run it before a release or when explicitly asked — never as part of routine feature development. See `.claude/skills/test-mcp-server/`.
 
+### Pre-release changelog update
+
+`/update-changelog` brings `[Unreleased]` in CHANGELOG.md up to date against everything merged since the last release tag, audits completeness with a read-only subagent per range, and lands the result on a branch after user approval. Run before dispatching the Gradle Release workflow or when explicitly asked. See `.claude/skills/update-changelog/`.
+
 
 
 @SECURITY.md

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,15 +23,25 @@ plain for in-depth exploratory testing. The run is read-only and prints a report
 for you to read. Treat it as a judgement aid, not an automatic gate. See
 `.claude/skills/test-mcp-server/` for details.
 
+## Pre-release Changelog Update
+
+Before you cut a release, bring `CHANGELOG.md` up to date. From a Claude Code session,
+run `/update-changelog`. It diffs the last release tag against `origin/main`, drafts
+`[Unreleased]` entries for every user-facing change, audits the draft for completeness
+with a read-only subagent, and lands the result on a branch after you approve the
+draft. Merge that change before dispatching the release so the tag contains the
+finished changelog. See `.claude/skills/update-changelog/` for details.
+
 ## Release Steps
 
 1. Ensure all desired changes are merged to `main`.
-2. Confirm CI is passing.
-3. Navigate to the [GitHub Actions](https://github.com/Contrast-Security-OSS/mcp-contrast/actions) page.
-4. Select the **Gradle Release** workflow.
-5. Click **Run workflow** and select `main`.
-6. Leave `release_version` blank for a normal patch release, or enter an explicit `X.Y.Z` version for a major, minor, or migration release.
-7. Start the run.
+2. Ensure the `[Unreleased]` section of `CHANGELOG.md` documents the release. Run `/update-changelog` if needed (see Pre-release Changelog Update).
+3. Confirm CI is passing.
+4. Navigate to the [GitHub Actions](https://github.com/Contrast-Security-OSS/mcp-contrast/actions) page.
+5. Select the **Gradle Release** workflow.
+6. Click **Run workflow** and select `main`.
+7. Leave `release_version` blank for a normal patch release, or enter an explicit `X.Y.Z` version for a major, minor, or migration release.
+8. Start the run.
 
 The first Axion-managed release must be run with `release_version=2.0.0`. After `v2.0.0` exists, leaving `release_version` blank creates the next patch release from the latest `vX.Y.Z` tag.
 


### PR DESCRIPTION
**Jira:** [AIML-1285](https://contrast.atlassian.net/browse/AIML-1285)

## Summary

Adds release tooling for the v2.2.0 release: a new `/update-changelog` skill that automates pre-release changelog authoring, hardening for the `/test-mcp-server` skill, and the finished changelog itself.

- `/update-changelog` diffs the last release tag against main, drafts entries PR-by-PR, audits with a read-only subagent, and lands the result after human approval
- `/test-mcp-server` now supports `--model` for tester selection, writes per-tool result files, and salvages partial results when the orchestrator exits early
- CHANGELOG.md documents all user-facing changes since v2.1.0

## Why This Change Exists

The changelog was previously written by hand, which was error-prone and easy to forget. The v2.1.0 release shipped without a changelog until it was backfilled after the fact. The `/update-changelog` skill automates the enumeration, classification, and auditing steps so nothing gets missed.

The `/test-mcp-server` skill had three pain points: the orchestrator sometimes gets killed mid-run (context limits or timeouts) and all individual tool results were lost, the 600-second background output capture ceiling cut off long regular runs before they finished, and there was no way to use a different model for tester subagents.

## Approach

The changelog skill follows a structured flow: orient on tags and headings, enumerate PRs in the range, classify each as user-facing or internal, draft entries in the existing house style, audit with a read-only subagent, and present the draft for human approval before writing anything. It supports both current-branch mode (changes ride the release branch) and new-branch mode (worktree-based, separate PR).

During this run, the notices/remediationHint wire rename was reclassified from Breaking Changes to Improvements. MCP server consumers (AI agents) discover response shapes dynamically, so a field rename cannot break them. This dropped the suggested version from v3.0.0 to v2.2.0. A subagent measured the actual token reduction from the AIML-942 description rewrite (55% cut in tool descriptions, ~650 fewer tokens per session), and that concrete metric was folded into the changelog entry.

For test-mcp-server, per-tool result files solve the partial-run problem: each tester writes its verdict to `$RESULTS_DIR/<tool-name>.txt`, so an early exit still produces usable output. The `--model` flag passes through to the agent definition, and `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0` removes the background capture timeout.

## What Changed

### Release tooling
- `.claude/skills/update-changelog/SKILL.md` (new) — the full skill definition with steps, ground rules, audit subagent prompt template, and house style reference
- `.claude/skills/test-mcp-server/SKILL.md` — documents `--model` flag, updates launch command with `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0`, corrects run-time estimate
- `.claude/skills/test-mcp-server/run.sh` — parses `--model` flag, creates per-tool results directory, adds early-exit salvage block, allows Bash tool for result file writes

### Changelog and docs
- `CHANGELOG.md` — full `[Unreleased]` section covering bug fixes, improvements, and documentation since v2.1.0
- `CLAUDE.md` — adds `/update-changelog` skill description to the Agent Skills section
- `RELEASING.md` — adds "Pre-release Changelog Update" section and inserts the changelog step into the release checklist

## Testing

- Both skills are internal development tooling, not shipped code. The changelog skill was exercised during this session to produce the v2.2.0 changelog (its first real run).
- The test-mcp-server changes are tested by running `/test-mcp-server` as part of the pre-release process.
- No production code changed; no unit or integration tests affected.


[AIML-1285]: https://contrast.atlassian.net/browse/AIML-1285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ