### PR TITLE
AIML-942 Enforce per-tool description word budgets

### DIFF
--- a/MCP_STANDARDS.md
+++ b/MCP_STANDARDS.md
@@ -266,9 +266,9 @@ The MCP `instructions` string is read once near session start, far from any call
 
 ## Enforcement
 
-The standard is enforced by budget tests. Until those tests land, reviewers enforce the budgets by counting body words against the templates.
+The standard is enforced by `ToolDescriptionBudgetTest`.
 
-- **Budget checks.** A test counts body words per description against the template ceilings and the catalog-total size against a hard cap. The word count is the plain whitespace-delimited count of the description body, parameter descriptions excluded. Exceeding a ceiling fails the build unless the tool has a named allowlist entry, which is itself a reviewed artifact.
+- **Budget checks.** The test counts body words per description against the template ceilings. The word count is the plain whitespace-delimited count of the description body, parameter descriptions excluded. Exceeding a ceiling fails the build unless the tool has a named allowlist entry, which is itself a reviewed artifact.
 
 ---
 

--- a/MCP_STANDARDS.md
+++ b/MCP_STANDARDS.md
@@ -162,7 +162,7 @@ Cross-checking body against params is part of review.
 
 ### Templates and budgets
 
-Each verb shape has a fixed template. Every slot except the lead is optional. The budget is a ceiling a reviewer verifies by counting words in the body prose. `@ToolParam` text is not counted.
+Each verb shape has a fixed template. Every slot except the lead is optional. `ToolDescriptionBudgetTest` enforces the ceiling by counting words in the body prose. `@ToolParam` text is not counted.
 
 **Search and list tools, 150 words or fewer.**
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/ToolDescriptionBudgetTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/ToolDescriptionBudgetTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.ai.tool.annotation.Tool;
+
+/** Enforces the per-tool description budgets defined in {@code MCP_STANDARDS.md}. */
+class ToolDescriptionBudgetTest {
+
+  private static final String TOOL_PACKAGE = "com.contrast.labs.ai.mcp.contrast.tool";
+  private static final int SEARCH_WORD_CEILING = 150;
+  private static final int LIST_WORD_CEILING = 150;
+  private static final int GET_WORD_CEILING = 40;
+  private static final int UPDATE_WORD_CEILING = 60;
+
+  // There were 13 core tools on 2026-08-04. Additions should not change this sanity floor.
+  private static final int MINIMUM_TOOL_COUNT = 13;
+
+  private static final Map<String, AllowlistEntry> ALLOWLIST = Map.of();
+  private static final List<Method> TOOL_METHODS = ToolTestReflection.toolMethods(TOOL_PACKAGE);
+
+  static Stream<Arguments> toolMethods() {
+    return TOOL_METHODS.stream()
+        .map(method -> Arguments.of(method.getAnnotation(Tool.class).name(), method));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("toolMethods")
+  void description_should_not_exceed_its_verb_budget(String toolName, Method toolMethod) {
+    var budget = budgetFor(toolName);
+    var wordCount = wordCount(toolMethod.getAnnotation(Tool.class).description());
+    var allowlistEntry = ALLOWLIST.get(toolName);
+
+    if (allowlistEntry != null) {
+      assertThat(wordCount)
+          .as("%s is now within its base ceiling; remove the stale allowlist entry", toolName)
+          .isGreaterThan(budget.ceiling());
+      assertThat(justificationNamesSibling(toolName, allowlistEntry.justification()))
+          .as(
+              "%s allowlist justification must name the sibling tool it disambiguates against",
+              toolName)
+          .isTrue();
+    }
+
+    var effectiveCeiling =
+        allowlistEntry == null ? budget.ceiling() : allowlistEntry.grantedCeiling();
+    var ceilingSource =
+        allowlistEntry == null
+            ? budget.prefix() + " prefix"
+            : "reviewed allowlist; base " + budget.prefix() + " prefix ceiling " + budget.ceiling();
+
+    assertThat(wordCount)
+        .overridingErrorMessage(
+            "%s description is %d words, ceiling %d (%s). Cut words or add a reviewed allowlist "
+                + "entry (sibling-disambiguation overage only).",
+            toolName, wordCount, effectiveCeiling, ceilingSource)
+        .isLessThanOrEqualTo(effectiveCeiling);
+  }
+
+  @Test
+  void tool_scan_should_find_the_known_minimum_number_of_tools() {
+    assertThat(TOOL_METHODS)
+        .as("@Tool methods discovered under %s", TOOL_PACKAGE)
+        .hasSizeGreaterThanOrEqualTo(MINIMUM_TOOL_COUNT);
+  }
+
+  @Test
+  void allowlist_should_not_name_tools_missing_from_the_catalog() {
+    Set<String> toolNames =
+        TOOL_METHODS.stream()
+            .map(method -> method.getAnnotation(Tool.class).name())
+            .collect(Collectors.toSet());
+
+    assertThat(ALLOWLIST.keySet())
+        .as("Allowlist entries must name @Tool methods discovered under %s", TOOL_PACKAGE)
+        .isSubsetOf(toolNames);
+  }
+
+  private static Budget budgetFor(String toolName) {
+    if (toolName.startsWith("search_")) {
+      return new Budget(SEARCH_WORD_CEILING, "search_");
+    }
+    if (toolName.startsWith("list_")) {
+      return new Budget(LIST_WORD_CEILING, "list_");
+    }
+    if (toolName.startsWith("get_")) {
+      return new Budget(GET_WORD_CEILING, "get_");
+    }
+    if (toolName.startsWith("update_")) {
+      return new Budget(UPDATE_WORD_CEILING, "update_");
+    }
+    throw new AssertionError(
+        toolName + " uses a new verb shape that needs a ceiling decision in MCP_STANDARDS.md");
+  }
+
+  private static int wordCount(String description) {
+    // Word count is the plain whitespace-delimited token count of the @Tool description body.
+    // @ToolParam text is excluded. This matches the method pinned in MCP_STANDARDS.md Enforcement.
+    return description.trim().split("\\s+").length;
+  }
+
+  private static boolean justificationNamesSibling(String toolName, String justification) {
+    return TOOL_METHODS.stream()
+        .map(method -> method.getAnnotation(Tool.class).name())
+        .filter(candidate -> !candidate.equals(toolName))
+        .anyMatch(justification::contains);
+  }
+
+  private record Budget(int ceiling, String prefix) {}
+
+  private record AllowlistEntry(int grantedCeiling, String justification) {}
+}

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/ToolDescriptionBudgetTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/ToolDescriptionBudgetTest.java
@@ -16,6 +16,7 @@
 package com.contrast.labs.ai.mcp.contrast.tool;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -101,6 +102,36 @@ class ToolDescriptionBudgetTest {
         .isSubsetOf(toolNames);
   }
 
+  @Test
+  void wordCount_should_return_zero_when_description_is_blank() {
+    assertThat(wordCount("")).isZero();
+    assertThat(wordCount("   ")).isZero();
+    assertThat(wordCount("one")).isEqualTo(1);
+    assertThat(wordCount("one two three")).isEqualTo(3);
+  }
+
+  @Test
+  void budgetFor_should_throw_when_verb_prefix_is_unrecognized() {
+    assertThatThrownBy(() -> budgetFor("create_something"))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining("new verb shape")
+        .hasMessageContaining("ToolDescriptionBudgetTest");
+  }
+
+  @Test
+  void justificationNamesSibling_should_match_when_it_names_another_tool() {
+    assertThat(
+            justificationNamesSibling("search_attacks", "disambiguates against get_vulnerability"))
+        .isTrue();
+  }
+
+  @Test
+  void justificationNamesSibling_should_not_match_when_no_sibling_named() {
+    assertThat(
+            justificationNamesSibling("search_attacks", "generic justification without tool name"))
+        .isFalse();
+  }
+
   private static Budget budgetFor(String toolName) {
     if (toolName.startsWith("search_")) {
       return new Budget(SEARCH_WORD_CEILING, "search_");
@@ -115,13 +146,16 @@ class ToolDescriptionBudgetTest {
       return new Budget(UPDATE_WORD_CEILING, "update_");
     }
     throw new AssertionError(
-        toolName + " uses a new verb shape that needs a ceiling decision in MCP_STANDARDS.md");
+        toolName
+            + " uses a new verb shape that needs a ceiling decision in MCP_STANDARDS.md"
+            + " and a budget constant in ToolDescriptionBudgetTest");
   }
 
   private static int wordCount(String description) {
     // Word count is the plain whitespace-delimited token count of the @Tool description body.
     // @ToolParam text is excluded. This matches the method pinned in MCP_STANDARDS.md Enforcement.
-    return description.trim().split("\\s+").length;
+    var trimmed = description.trim();
+    return trimmed.isEmpty() ? 0 : trimmed.split("\\s+").length;
   }
 
   private static boolean justificationNamesSibling(String toolName, String justification) {

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/ToolTestReflection.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/ToolTestReflection.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.util.ClassUtils;
+
+/** Reflection helpers for tests that inspect the agent-visible tool contract. */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ToolTestReflection {
+
+  // Keep aligned by hand with the sibling copy at ../aiml-services/services/
+  // aiml-hosted-mcp-server/src/test/java/com/contrastsecurity/aiml/hosted/mcp/util/
+  // ToolTestReflection.java.
+  public static String toolDescription(Class<?> toolClass, String methodName) {
+    return toolMethod(toolClass, methodName).getAnnotation(Tool.class).description();
+  }
+
+  public static Method toolMethod(Class<?> toolClass, String methodName) {
+    return Arrays.stream(toolClass.getDeclaredMethods())
+        .filter(candidate -> candidate.getName().equals(methodName))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  public static List<Method> toolMethods(String basePackage) {
+    var scanner = new ClassPathScanningCandidateComponentProvider(false);
+    scanner.addIncludeFilter((metadataReader, metadataReaderFactory) -> true);
+
+    return scanner.findCandidateComponents(basePackage).stream()
+        .map(BeanDefinition::getBeanClassName)
+        .filter(Objects::nonNull)
+        .map(
+            className -> ClassUtils.resolveClassName(className, ClassUtils.getDefaultClassLoader()))
+        .flatMap(toolClass -> Arrays.stream(toolClass.getDeclaredMethods()))
+        .filter(method -> method.isAnnotationPresent(Tool.class))
+        .sorted(Comparator.comparing(method -> method.getAnnotation(Tool.class).name()))
+        .toList();
+  }
+}

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/ToolTestReflection.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/ToolTestReflection.java
@@ -41,6 +41,7 @@ public final class ToolTestReflection {
   public static Method toolMethod(Class<?> toolClass, String methodName) {
     return Arrays.stream(toolClass.getDeclaredMethods())
         .filter(candidate -> candidate.getName().equals(methodName))
+        .filter(candidate -> candidate.isAnnotationPresent(Tool.class))
         .findFirst()
         .orElseThrow();
   }


### PR DESCRIPTION
**Jira:** [AIML-942](https://contrast.atlassian.net/browse/AIML-942)

## Summary
Adds an automated build gate that fails when any `@Tool` description exceeds its per-verb word ceiling, replacing manual reviewer counting with a parameterized unit test.

- All 13 tool descriptions verified under ceiling, allowlist starts empty
- New tools are discovered automatically via classpath scan, no test maintenance needed
- MCP_STANDARDS.md updated to reference the test and remove stale future-tense language

## Why This Change Exists
MCP_STANDARDS.md defines word ceilings per verb shape (search/list 150, get 40, update 60) to keep tool descriptions cheap in agent context windows. Until now, the only enforcement was reviewers counting words by hand, which was error-prone and easy to skip. After PR #186 migrated all 13 core descriptions to fit within budgets, this PR locks the door so they stay within budgets going forward.

## Approach
A `@ParameterizedTest` discovers every `@Tool`-annotated method under the tool package via Spring's `ClassPathScanningCandidateComponentProvider`, resolves each tool's verb prefix to a ceiling, and asserts the whitespace-delimited word count of the description body stays at or below that ceiling. This means newly added tools are picked up with zero test edits.

The reflection helper (`ToolTestReflection`) was copied from the aiml-services sibling rather than published as a shared test artifact, because a shared artifact would couple every gate adjustment to a core release cycle. Each copy carries a cross-reference comment.

An empty allowlist with tripwires handles edge cases: stale entries (tool now under ceiling) fail the test, entries naming unknown tools fail, and allowlist justifications must reference a specific sibling tool (sibling-disambiguation is the only valid overage reason). An unknown verb prefix also fails, forcing a ceiling decision in MCP_STANDARDS.md before any new verb ships unbudgeted.

## What Changed
### Test infrastructure
- `ToolTestReflection.java` (new) — classpath-scanning helper that discovers `@Tool` methods by package, ported from aiml-services
- `ToolDescriptionBudgetTest.java` (new) — parameterized test with per-verb ceilings, allowlist with stale-entry and unknown-tool tripwires, and a sanity floor asserting at least 13 tools are found

### Documentation
- `MCP_STANDARDS.md` — Enforcement section now names `ToolDescriptionBudgetTest` as the enforcement mechanism, removes the "until those tests land" future-tense sentence, and removes the catalog-total cap claim (that cap was dropped as friction-without-signal)

## Testing
- `ToolDescriptionBudgetTest` runs as part of the standard `make check-test` suite
- Red-checked by temporarily pushing `get_vulnerability` over its 40-word ceiling and confirming the failure message carries tool name, count, and ceiling
- Red-checked the stale-allowlist tripwire by adding a fake entry for `get_protect_rules` (18 words, well under the 40-word get_ ceiling) and confirming it fails
- Full repo checks pass (1,066 tests, coverage floors, static analysis)


[AIML-942]: https://contrast.atlassian.net/browse/AIML-942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ