### PR TITLE
AIML-1303 Permit cursor pagination for search_* tools when upstream is cursor-only

### DIFF
--- a/MCP_STANDARDS.md
+++ b/MCP_STANDARDS.md
@@ -34,7 +34,7 @@ Tool names (in `@Tool` annotation) use `action_entity` snake_case format.
 
 ### `search_*` - Flexible Filtering
 - Multiple optional filters
-- Paginated results
+- Paginated results: offset-paginated where the upstream supports offset paging, cursor-paginated where the upstream is cursor-only
 - Returns items matching filter combinations
 - Use when: "find all X where..."
 
@@ -113,7 +113,8 @@ Tools returning analytical data (reports, coverage, metadata) may use `get_*` ev
 | `vulnId` | Vulnerability identifier |
 | `cveId` | CVE identifier |
 | `sessionMetadataName/Value` | Session metadata |
-| `page` / `pageSize` | Pagination (1-based) |
+| `page` / `pageSize` | Offset pagination (1-based) |
+| `cursor` / `pageSize` | Cursor pagination (opaque continuation token) |
 | `useLatestSession` | Latest session flag |
 
 ### Filter Conventions
@@ -274,7 +275,7 @@ The standard is enforced by `ToolDescriptionBudgetTest`.
 
 ## Tool-per-Class Architecture
 
-All MCP tools follow a **one-class-per-tool** pattern with shared base classes. Each tool is a standalone `@Service` class that extends `PaginatedTool` for offset/page-backed search/list operations, `CursorPaginatedTool` for cursor/keyset-backed list operations, or `SingleTool` for single-item retrieval.
+All MCP tools follow a **one-class-per-tool** pattern with shared base classes. Each tool is a standalone `@Service` class that extends `PaginatedTool` for offset/page-backed search/list operations, `CursorPaginatedTool` for cursor/keyset-backed search/list operations, or `SingleTool` for single-item retrieval.
 
 ### Package Structure
 
@@ -306,7 +307,7 @@ com.contrast.labs.ai.mcp.contrast.tool/
 - Subclasses implement `doExecute()` returning item or null
 - Returns `SingleToolResponse<R>` with item, errors, notices
 
-**`CursorPaginatedTool<P extends ToolParams, R>`** - For cursor/keyset-backed list tools:
+**`CursorPaginatedTool<P extends ToolParams, R>`** - For cursor/keyset-backed search/list tools:
 - Template method `executePipeline()` handles cursor pagination, validation, exceptions
 - Subclasses treat cursor values as opaque continuation tokens
 - Returns `CursorToolResponse<R>` with items, `nextCursor`, `hasMore`, errors, and notices


### PR DESCRIPTION
**Jira:** [AIML-1303](https://contrast.atlassian.net/browse/AIML-1303)

## Summary
Amends the MCP standards so a `search_*` tool may be cursor-paginated when its upstream API only supports cursor paging. This sets up the rules that will be adhered to when implementing the new CVE Shield MCP tool which will be the first to use pure cursor-only endpoints.

- The `search_*` verb entry now states the pagination rule instead of implying offset-only paging.
- The base-class architecture text now allows `CursorPaginatedTool` for search operations, not just list operations.
- The standard parameter table gains a `cursor` / `pageSize` row alongside the existing `page` / `pageSize` row.

## Why This Change Exists
The standard treated `search_*` as offset-paginated with no exceptions, and `CursorPaginatedTool` as a list-only base class. Some upstream APIs expose only cursor paging. A search tool over such an API had no home in the docs, so a reviewer or coding agent would either flag the tool as non-conformant or "fix" it to offset paging the upstream cannot serve. This doc is the canonical generic layer for downstream standards documents, so the correction lands here first.

## What Changed
### MCP_STANDARDS.md
- `Verb Hierarchy` > `search_*`, pagination is offset-based where the upstream supports it and cursor-based where the upstream is cursor-only.
- `Parameters` > `Standard Names`, added the `cursor` / `pageSize` row and labeled the `page` / `pageSize` row as offset pagination.
- `Tool-per-Class Architecture`, `CursorPaginatedTool` now covers cursor/keyset-backed search and list operations.

## Testing
- Docs-only change, no code paths affected. The description-budget test already recognizes the `search_` prefix regardless of base class, so no test changes are needed.


[AIML-1303]: https://contrast.atlassian.net/browse/AIML-1303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ