### PR TITLE
AIML-1304 Add bead-workflow and jira-workflow skills, slim CLAUDE.md

### DIFF
--- a/.claude/skills/bead-workflow/SKILL.md
+++ b/.claude/skills/bead-workflow/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: bead-workflow
+description: Manage beads through their full lifecycle in this repository. Use when creating, updating, claiming, implementing, closing, triaging, or commenting on a bead. Covers labeling, pre-claim checks, branch requirements, stacked-branch handling, commit-before-close discipline, Jira integration, and sync. Triggers on any bead mutation, not reads.
+---
+
+# Bead Workflow
+
+Beads (`br`) is the working issue store. This skill governs every bead mutation, create, claim, implement, close, triage, and comment. For read-only commands (`br show`, `br ready`, `br list`) this skill does not need to be loaded.
+
+For Jira ticket creation, bead-to-Jira parity rules, and post-merge transitions, invoke the `jira-workflow` skill. This skill does not duplicate those rules.
+
+**Public repo note.** This repository is public. `.beads/` is gitignored and must stay that way, bead content is internal. Never commit anything under `.beads/`, and never quote internal-only detail from beads into committed files.
+
+## 1. Creating a bead
+
+```bash
+br create "Title" --type <type> --priority <0-4> --description "..." \
+  --labels "repo:mcp-contrast" [--parent <parent-id>]
+```
+
+**Required fields:**
+- `--type`: task, bug, feature, epic, chore, docs, question. Use your judgment based on context. Epics are typically parent beads with children, matching how Jira epics work.
+- `--priority`: Default to P2 (medium) unless context clearly indicates otherwise. P0/P1 for blocking issues, P3/P4 for nice-to-haves and backlog.
+
+**Repo label (`repo:<name>`):**
+Apply a `repo:` label for the repo where the code work will happen (normally `repo:mcp-contrast`). Work that spans repos can carry multiple `repo:` labels. If the target repo changes later, update the label. Figure the repo out from context, do not ask the user.
+
+**Multi-line content:** quoted heredocs prevent shell interpretation.
+
+```bash
+br create "Title" --description "$(cat << 'EOF'
+Markdown with `code`, --flags, and $(vars), all literal.
+EOF
+)"
+```
+
+For the design field, always use `scripts/br-set-design <bead-id> <file-path>` (the CLI misparses `--` in markdown).
+
+**Parent-child relationships:**
+Use `--parent <parent-id>` when creating a child bead. Child beads work on the same branch as their parent. If the parent has a Jira ticket and the user wants one for the child, follow the `jira-workflow` skill (Story under Epic when the parent ticket is an Epic, otherwise ask). Only create Jira tickets when the user explicitly requests it.
+
+**After creation:**
+Run `br sync --flush-only` to export changes locally.
+
+## 2. Pre-claim checklist
+
+Before claiming a bead for implementation, run `br show <id>` and verify:
+
+1. **No unresolved blocking dependencies.** If the bead is blocked, surface the blockers to the user. Exception, a `blocks` edge on a stacked-branch bead pointing at its base bead blocks the *merge*, not the work, see section 3.
+2. **No blocking labels.** Check for `needs-decision`, `needs-triage`, `needs-human-review`, `needs-info`, `human-security-review`, `external-approval`. If present, tell the user. `human-reviewed` is the cleared marker.
+3. **No existing assignee.** If someone else is assigned, ask the user before taking it over.
+4. **Branch requirement.** If the bead has an `external-ref` pointing to a Jira ticket, work happens on a branch named `{JIRA-KEY}-{kebab-case-description}` (e.g. `AIML-1304-improve-ai-skills`). Check the current branch:
+   - Already on the correct branch, proceed.
+   - On another feature branch, offer to use `pr-tools:create-stacked-branch` to create the `{JIRA-KEY}-...` branch stacked on the current one.
+   - On `main`, create the `{JIRA-KEY}-...` branch, or ask the user which branch to base it on if stacking is plausible.
+   - No Jira ticket, no branch naming requirement, but never commit directly to `main`.
+
+## 3. Stacked branches
+
+When the new branch is based on another PR branch rather than `main`:
+
+- Label the bead `stacked-branch`.
+- Record the merge ordering with `br dep add <new-bead> <base-bead> --type blocks`. This means the base PR must merge first, work on the stacked bead proceeds anyway.
+- `br` refuses `--claim` and status changes on a blocked bead. Set `--status in_progress --assignee <you>` *before* adding the blocks edge, or temporarily `br dep remove`, update, and re-add.
+- PRs for stacked beads are created as drafts targeting the parent branch (`pr-tools:create-pr` detects this). Apply `pr-created` but not `in-review` until the PR is promoted with `pr-tools:promote-stacked-pr`.
+
+## 4. Implementing a bead
+
+**Claim the bead:**
+```bash
+br update <id> --claim
+```
+This atomically sets the assignee and status to `in_progress`. Record the branch name in the bead so it is easy to find later.
+
+**Transition the Jira ticket.** If the bead has an `external-ref` pointing to a Jira ticket, transition it to In Progress (transition ID `21`) and assign it to the current user, per the `jira-workflow` skill.
+
+**Read the full context.** Run `br show <id>` for the bead. If it has a Jira `external-ref`, also fetch the ticket body and comments with `getJiraIssue` so both descriptions and any ticket discussion inform the work.
+
+**Do the work.** Write tests for all code changes. `make check-test` must pass, and `make verify` (integration tests) must pass before review, see CLAUDE.md Testing Requirements.
+
+**Commit and push before closing.** A bead that produced code changes must not be closed until those changes are committed and pushed. This is non-negotiable.
+
+**Open the PR.** After pushing, create the PR with `pr-tools:create-pr`. Non-stacked beads get a ready PR targeting `main`, apply `pr-created` and `in-review` to the bead and transition Jira to In Review (`41`). Stacked beads get a draft PR, apply `pr-created` only and keep Jira at In Progress.
+
+## 5. Closing a bead
+
+**Always ask the user before closing a bead.** Parent beads cannot close while children are open, and typically stay `in_progress` (with `in-review`) until the PR merges.
+
+Closing follows a strict sequence:
+
+1. **Commit and push** all related changes (if any code was written).
+2. **Add a summary comment** to the bead:
+   ```bash
+   br comments add <id> --message "Summary of changes..."
+   ```
+   Include a short paragraph on what changed and why, which files were modified, and the commit hash(es). If no code changed (resolved by discussion, decided not to proceed), say that instead.
+3. **Close the bead:**
+   ```bash
+   br close <id> --reason "Brief closure reason"
+   ```
+   The `--reason`/`-r` flag is required, a positional argument fails.
+4. **Transition the Jira ticket.** After the PR merges to `main`, transition the ticket to Ready to Deploy (`51`), per the `jira-workflow` skill. Closed (`81`) is reserved for when the code actually ships.
+5. **Sync:**
+   ```bash
+   br sync --flush-only
+   ```
+
+After a merge, run `pr-tools:after-pr-merged` to find and optionally promote dependent stacked PRs.
+
+## 6. Triage
+
+When triaging a bead (updating status, labels, priority, or assignments during review):
+
+- Set the `repo:` label if not already set or if it was wrong.
+- Apply triage labels as appropriate, `needs-decision`, `needs-info`, `ready-for-agent`, `ready-for-human`. See `docs/agents/triage-labels.md` for the vocabulary.
+- Update priority and type if the initial values were off.
+- Run `br sync --flush-only` after mutations.
+
+## 7. Jira integration
+
+This skill does not own Jira ticket creation. When Jira work is needed, invoke the `jira-workflow` skill, which handles ticket creation and all bead-to-Jira parity rules (title prefixing, external-ref, relationship mirroring). When a Jira ticket is created for a bead, the bead's title gets the `AIML-<id>: ` prefix and its `external-ref` gets the ticket key, no exceptions.

--- a/.claude/skills/jira-workflow/SKILL.md
+++ b/.claude/skills/jira-workflow/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: jira-workflow
+description: Jira ticket lifecycle for the AIML project. Covers creation, bead parity, and status transitions through the PR lifecycle. Use when creating a Jira ticket, when a PR is opened or merges for a Jira-linked branch, or when reconciling bead-to-Jira state. Triggers include "create a jira ticket", "create an AIML ticket", a bead needing an external Jira reference, or a user reporting a merged PR whose branch matches an AIML key.
+---
+
+# Jira Workflow
+
+Beads (`br`) is the working issue store for this repo and Jira is the external reference. Every Jira ticket has a matching bead, and the two are kept in sync. This skill covers ticket creation, bead parity rules, and lifecycle transitions. For the broader beads workflow see the `bead-workflow` skill and `docs/agents/issue-tracker.md`.
+
+**Public repo note.** This repository is public. Committed files may reference the AIML project, the `Contrast MCP Server` component, and the transition IDs below, all already public in this repo. Do not commit other component names, internal service or product names, or ticket content beyond what a public reader should see.
+
+## 1. Create the ticket
+
+All work on this repo files into the **AIML** Jira project with component **Contrast MCP Server**. Use the Atlassian MCP tools (load via ToolSearch if needed). Metadata and a creation example are in `references/aiml.md`.
+
+- Issue type: `Story` for features, `Task` for simple non-feature changes (refactoring, docs, bug fixes), `Epic` for large multi-ticket efforts (typically managed by Product Management).
+- Look up an assignee with `lookupJiraAccountId`, link related tickets with `createIssueLink`.
+- When starting work, assign the ticket to the current user (`atlassianUserInfo`) and transition it to In Progress (`21`).
+
+## 2. Keep a bead in parity (every time)
+
+Beads is primary. A Jira ticket should not exist without a matching bead.
+
+When a Jira ticket is created:
+
+1. Find or create the matching bead. If a bead already drove the ticket, use it. Otherwise create one per the `bead-workflow` skill, matching the Jira issue type.
+2. Prefix the bead title with the Jira key, then a colon and a space: `AIML-1304: <title>`. Do not use space-dash-space. Keep the existing title text.
+3. Set the bead `external-ref` to the Jira key, `br update <bead> --external-ref AIML-1304`.
+4. Add a bead comment with the Jira URL so the thread records the link.
+
+**Keep relationships in parity.** Mirror Jira issue links as bead dependencies and bead dependencies as Jira links:
+
+- Jira **Blocks** (A blocks B) maps to `br dep add <bead-B> <bead-A>` (B depends on A).
+- Jira parent or Epic maps to `br dep add <child-bead> <parent-bead> --type parent-child`.
+- Jira **Relates** has no hard bead dependency. Note it in a bead comment, or use parent-child if it is really hierarchy.
+
+When you add a bead dependency for work that also has Jira tickets, add the matching `createIssueLink` so both sides agree.
+
+**Child beads.** When creating a Jira ticket for a child bead whose parent has a Jira Epic, create the child as a Story under that Epic. If the parent's ticket is not an Epic, ask the user how to proceed.
+
+## 3. Status transitions
+
+Transition IDs are in `references/aiml.md`. The lifecycle for this repo:
+
+| Event | Transition |
+|-------|------------|
+| Work starts on the bead | In Progress (`21`) |
+| Ready PR opened targeting `main` | In Review (`41`) |
+| Stacked draft PR opened | stay at In Progress |
+| Stacked PR promoted to ready | In Review (`41`) |
+| PR merged to `main` | Ready to Deploy (`51`) |
+| Code released to production | Closed (`81`) |
+
+**Post-merge rule.** When a PR merges and its branch name carries a Jira key (`AIML-XXX-...`), transition that ticket to Ready to Deploy (`51`). This applies whether or not beads are involved, the trigger is the merged PR. Skip it when the PR merges into another feature branch rather than `main` (a stacked PR landing on its parent).
+
+## References
+
+- `references/aiml.md`, AIML project metadata, issue types, component, creation example, transition IDs.

--- a/.claude/skills/jira-workflow/references/aiml.md
+++ b/.claude/skills/jira-workflow/references/aiml.md
@@ -1,0 +1,40 @@
+# AIML project metadata
+
+All work on this repo files into the **AIML** Jira project. Use the Atlassian MCP tools.
+
+## Jira metadata
+
+| Field | Value |
+|-------|-------|
+| **Cloud ID** | `https://contrast.atlassian.net` (the MCP tools accept the site URL) |
+| **Project Key** | `AIML` |
+| **Component** | `Contrast MCP Server` (always, for work on this repo) |
+
+## Issue types
+
+| Type | Use for |
+|------|---------|
+| Story | User-facing features and improvements |
+| Task | Simple non-feature changes, refactoring, documentation, bug fixes |
+| Bug | Defects |
+| Epic | Large features spanning multiple tickets (typically managed by PM) |
+
+## Creating a ticket
+
+```
+cloudId: "https://contrast.atlassian.net"
+projectKey: "AIML"
+issueTypeName: "Task"   (or Story, Bug, Epic)
+summary: "Your ticket title"
+description: "markdown body"
+contentFormat: "markdown"
+additional_fields: {"components": [{"name": "Contrast MCP Server"}]}
+```
+
+To assign, look up the account ID first with `lookupJiraAccountId` (searchString = name), then pass `assignee_account_id` on the create call. For yourself, use `atlassianUserInfo`.
+
+## Workflow transitions (transitionJiraIssue)
+
+`11` To Do, `21` In Progress, `41` In Review, `51` Ready to Deploy, `61` Blocked, `71` Backlog, `81` Closed.
+
+See the main `SKILL.md` for bead-to-Jira parity rules (matching bead, title prefix, external-ref, relationship parity) and the transition-per-event table.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,70 +300,13 @@ This codebase handles sensitive vulnerability data. The README contains critical
 
 ## Beads Workflow Requirements
 
-This project uses Beads (br) for issue tracking. See the MCP resource `beads://quickstart` for usage details.
+This project uses Beads (`br`) for issue tracking. **Every bead mutation (create, claim, close, triage, comment, label) is governed by the `bead-workflow` skill** — invoke it before mutating a bead. Read-only commands (`br show`, `br ready`, `br list`) need no skill.
 
-### Bead Command Reference
-
-```bash
-# Status — set in_progress immediately when starting; close only when done
-br update <bead-id> --status in_progress
-br close <bead-id> --reason "why it's done"   # --reason/-r is REQUIRED; positional arg fails
-br reopen <bead-id>
-
-# Viewing
-br show <bead-id>
-br ready                                       # list unblocked open beads
-br list
-
-# Comments — 'br comment' does NOT exist; use 'br comments add'
-br comments add <bead-id> --message "short single-line text"
-br comments add <bead-id> -f /tmp/comment.txt  # use -f for multi-line (avoids shell interpretation)
-
-# Labels
-br label add <bead-id> -l <label>
-br label remove <bead-id> -l <label>
-
-# Dependencies
-br dep add <dependent> <prerequisite>          # dependent "blocks on" prerequisite
-br dep add <child> <parent> --type parent-child
-```
-
-**Multi-line content — quoted heredoc prevents all shell interpretation:**
-```bash
-# Comments — pipe via stdin (-f - supported)
-cat << 'EOF' | br comments add <bead-id> -f -
-## Heading
-
-With `code blocks`, **markdown**, and $(variables) — all literal.
-EOF
-
-# Description/design — capture via $() (inner heredoc is still safe with quoted delimiter)
-br create "Title" --description "$(cat << 'EOF'
-## Description with `code` and $(vars) — all literal.
-EOF
-)"
-
-# Design field — same $() pattern works
-br update <bead-id> --design "$(cat << 'EOF'
-## Design with `code` and --flags and $(vars) — all literal.
-EOF
-)"
-```
-
-### Human Review Labels
-
-- `ready-for-human` — human should inspect, decide, or run the work with agent assistance; autonomous agents should not pick it up
-- `needs-human-review` — DO NOT start work; ask human to review first
-- `human-security-review` — security review is required before agent work proceeds
-- `external-approval` — blocked on approval outside the agent workflow
-
-`human-reviewed` is the cleared marker after review; AI may proceed when no human-only label remains.
-
-When reviewing a `needs-human-review` bead, update the description if needed, then:
-```bash
-br label remove <bead-id> -l needs-human-review
-br label add <bead-id> -l human-reviewed
-```
+Quick reference (full detail in `docs/agents/issue-tracker.md`):
+- `br update <id> --claim` when starting; `br close <id> --reason "..."` only when done (`--reason` is required)
+- `br sync --flush-only` after mutations; `.beads/` is gitignored and must never be committed (public repo)
+- Human-review and triage labels: see `docs/agents/triage-labels.md`
+- Multi-line content: quoted heredocs; design field via `scripts/br-set-design`
 
 ## Helper Scripts
 
@@ -373,114 +316,17 @@ br label add <bead-id> -l human-reviewed
 
 ### Jira Issue Tracking
 
-This project is tracked in Jira under the **AIML** project. When creating Jira tickets for this codebase:
-
-**Standard Configuration:**
-- **Project**: `AIML`
-- **Component**: `Contrast MCP Server` (always use this component for work on this repository)
-- **Issue Type**:
-  - `Story` - for features and improvements
-  - `Task` - for simple non-feature changes (refactoring, documentation, bug fixes)
-  - `Epic` - for large features with many dependent tasks (typically managed by Product Management)
-
-**Access**: Use the Atlassian MCP server to read or write Jira tickets programmatically.
-
-**AIML Project Transition IDs** (use with `transitionJiraIssue`, cloudId: `https://contrast.atlassian.net`):
-- `11` → To Do
-- `21` → In Progress
-- `41` → In Review
-- `51` → Ready to Deploy
-- `61` → Blocked
-- `71` → Backlog
-- `81` → Closed
-
-**IMPORTANT**: When a jira ticket is created for a bead, you must do 2 things:
-1. Update the `external-ref` of the bead to be the jira ticket id
-2. Update the `title` of the bead to be prefixed with the jira ticket id.
+This project is tracked in Jira under the **AIML** project, component **Contrast MCP Server**. **All Jira lifecycle operations — ticket creation, bead-to-Jira parity (title prefix + `external-ref`), and status transitions — are governed by the `jira-workflow` skill.** Metadata (issue types, transition IDs, creation example) lives in `.claude/skills/jira-workflow/references/aiml.md`.
 
 ----
 
 ## AI Development Workflow
 
-This section defines the complete workflow for a Developer using AI agents working with beads and Jira tickets in this project.
+The bead and Jira lifecycle (starting work, branching, stacked branches, labels, dependencies, closing) is owned by the `bead-workflow` and `jira-workflow` skills — invoke them rather than working from memory. The sections below cover what stays in this file: build verification and testing gates, plus the user trigger phrases that map to pr-tools skills.
 
-### Workflow Overview
+**Workflow labels:** `stacked-branch` (branch based on another PR branch), `pr-created`, `in-review` (PR ready for human review, not draft). Details in the `bead-workflow` skill.
 
-**Key Labels:**
-- `stacked-branch` - Branch is based on another PR branch (not main)
-- `pr-created` - Pull request has been created
-- `in-review` - Pull request is ready for human review (not draft)
-
-**Decision Tree:**
-
-```
-Branch Creation:
-├─ Based on main → No special label
-└─ Based on another PR branch → Label with `stacked-branch`
-
-PR Creation:
-├─ Has `stacked-branch` label?
-│  └─ YES → Create DRAFT PR (Stacked PRs workflow)
-│            - Base: parent PR's branch
-│            - Labels: `pr-created` (NOT `in-review` yet)
-│            - Add warning banner + dependency context
-│
-└─ NO → Create ready PR (Moving to Review workflow)
-         - Base: main
-         - Labels: `pr-created`, `in-review`
-         - Standard PR description
-
-Promoting Stacked PR (after base PR merges):
-└─ Rebase onto main, update base branch, remove warnings
-   Add `in-review` label, mark PR ready
-```
-
-### Starting Work on a Bead
-
-**1. Determine if a feature branch is needed:**
-   - **Bead has Jira ticket**: Create a new feature branch
-     - **Ask user which branch to base it off of**
-     - Show recently updated branches (sorted by most recent commits/PRs)
-     - User may be working with stacked branches where each new branch comes off the previous PR branch
-     - Name the branch with Jira ID prefix (e.g., `AIML-224-description`)
-     - **If based on another PR branch (not main)**: Label bead with `stacked-branch`
-   - **Bead is a child of Jira-linked bead**: Use the same branch as the parent bead
-   - **Bead has no Jira association and no parent**:
-     - **Ask user if it should have a Jira ticket**
-     - Most code changes need a Jira ticket and branch before merging
-     - Code changes should generally have a Jira ticket in scope
-
-**2. Update bead status and labels:**
-   - Set bead status to `in_progress`
-   - Record the branch name in the bead (so it's easily found later)
-   - **If this is a stacked branch** (based on another PR branch):
-     - Label the bead with `stacked-branch`
-     - Create blocks dependency: `br dep add <new-bead-id> <base-bead-id> --type blocks`
-       - This represents that the base bead "blocks" the new bead from being merged
-       - Example: If AIML-230 is stacked on AIML-228, use `br dep add mcp-uuv mcp-9kr --type blocks`
-
-**3. Update Jira (if applicable):**
-   - If bead has a linked Jira ticket:
-     - Update Jira status to "In Progress" using Atlassian MCP
-     - **Assign the ticket to the current user** (the authenticated Atlassian MCP user)
-
-### Creating Related Beads
-
-**When creating new beads from a Jira-linked bead:**
-- Ask user if the new bead should be a child of the Jira-linked bead
-- If yes, establish parent-child relationship using `br dep add <child> <parent>` with `parent-child` dependency type
-- Child beads work on the same branch as their parent
-  
-### Managing Bead Dependencies
-
-**Command syntax:** `br dep add <dependent-task> <prerequisite-task>`
-
-Example: If B must be done after A completes, use `br dep add B A` (not `br dep add A B`).
-
-Verify with `br show <task-id>` - dependent tasks show "Depends on", prerequisites show "Blocks".
-
-NOTE: This is not for parent-child dependencies, these are blocks dependencies. 
-**IMPORTANT** If you are asked to add a bead as a child or with phrasing that implies a parent-child relationship, ensure you add the dependency of type parent-child. The default is a blocks type.
+**Dependency direction:** `br dep add <dependent> <prerequisite>` — if B must wait for A, `br dep add B A`. When phrasing implies hierarchy ("add as a child"), use `--type parent-child`; the default is a blocks edge.
 
 ### During Development
 
@@ -530,64 +376,36 @@ assertThat(libraries)
 - `GetRouteCoverageToolIT` — pagination + filter + edge cases
 - `GetSastProjectToolIT` — regression coverage for field mapping
 
-### Moving to Review
+### Review and merge triggers
 
-When user says "move to review" or "ready for review" for a bead WITHOUT the `stacked-branch` label:
+Each trigger phrase maps to a pr-tools skill; the `bead-workflow` and `jira-workflow` skills own the accompanying bead labels and Jira transitions.
 
-1. Apply the `pr-created` and `in-review` labels to the bead(s) on this branch
-2. Transition the linked Jira ticket to "In Review"
-3. Push the feature branch
-4. Run `/pr-tools:create-pr` — it generates the description and creates a ready-for-review PR targeting `main`
+| User says | Run | Bead / Jira effect |
+|-----------|-----|--------------------|
+| "move to review" / "ready for review" (no `stacked-branch` label) | `/pr-tools:create-pr` | `pr-created` + `in-review`; Jira → In Review |
+| "ready for stacked PR" (`stacked-branch` label) | `/pr-tools:create-pr` (draft, targets parent) | `pr-created` only; Jira stays In Progress |
+| "promote stacked PR" / "finalize stacked PR" | `/pr-tools:promote-stacked-pr` | add `in-review`; Jira → In Review |
+| PR merged to `main` | `/pr-tools:after-pr-merged` | close bead (ask first); Jira → Ready to Deploy |
 
-### Stacked PRs (Ready for Draft Review)
-
-When user says "ready for stacked PR" or creating a PR for a bead WITH the `stacked-branch` label:
-
-1. Apply the `pr-created` label to the bead(s) — do **not** add the `in-review` label yet
-2. Keep the linked Jira ticket at "In Progress"
-3. Push the branch
-4. Run `/pr-tools:create-pr` — it auto-detects the stacked context, creates a draft PR with the warning banner, and targets the parent branch
-
-The PR stays in draft until the parent merges and this branch is rebased onto `main` (use `/pr-tools:promote-stacked-pr`).
-
-### Promoting Stacked PR to Ready for Review
-
-When user says "promote stacked PR" or "finalize stacked PR" for a bead WITH the `stacked-branch` label:
-
-1. Run `/pr-tools:promote-stacked-pr` — it rebases onto main with `--onto`, force-pushes safely, retargets the PR base, updates the body, and marks it ready
-2. Add the `in-review` label to the bead and update notes with the PR URL
-3. Keep the bead `in_progress` until the PR merges
-
-### After PR is Merged to main
-
-1. Close the bead with brief description of what was done.
-2. Update Jira status to "Ready to Deploy"
-3. Handle dependent stacked PRs:
-   - Run `/pr-tools:after-pr-merged` to find and optionally promote child PRs
-
-**Rationale:**
-- "Ready to Deploy" indicates the code is merged and ready for the next release
-- "Closed" should only be used when the code is actually deployed/released to production
-- This allows tracking what code is ready to go out in the next release vs what's already deployed
-
-
-### Closing Beads
-
-**IMPORTANT**: Always ask the user before closing a bead.
-
-**Cannot close parent beads** if they still have open children. Ensure all child beads are closed first.
-
-**Parent beads** typically remain `in_progress` (with `in-review` label) until the PR review is complete and merged. Only close beads when explicitly instructed by the user.
+**Always ask the user before closing a bead.** Parent beads cannot close with open children and typically stay `in_progress` (with `in-review`) until the PR merges. Jira "Closed" is reserved for code actually released to production.
 
 ## Agent skills
 
+### Bead workflow
+
+Every bead mutation (create, claim, implement, close, triage, comment) follows the `bead-workflow` skill: pre-claim checks, stacked-branch handling, commit-before-close, sync discipline. See `.claude/skills/bead-workflow/`.
+
+### Jira workflow
+
+Jira ticket creation, bead parity, and status transitions follow the `jira-workflow` skill. See `.claude/skills/jira-workflow/`.
+
 ### Issue tracker
 
-Issues are tracked in Jira (AIML project) and Beads (`br`), not GitHub Issues. See `docs/agents/issue-tracker.md`.
+Issues are tracked in Jira (AIML project) and Beads (`br`), not GitHub Issues. Beads is the working store, Jira the external reference. See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 
-Canonical triage labels (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) for all new triage work; existing CLAUDE.md human-review labels are documented for awareness. See `docs/agents/triage-labels.md`.
+Canonical triage labels (`needs-decision`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) for all new triage work; older labels and human-review labels are documented for awareness. See `docs/agents/triage-labels.md`.
 
 ### Domain docs
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,40 +1,43 @@
-# Issue tracker: Jira + Beads
+# Issue tracker (beads + Jira)
 
-This repo tracks work in two coordinated systems, not GitHub Issues:
+Issues for this repo run on a dual model. **Beads (`br`) is the working issue store** and **Jira (the AIML project, component `Contrast MCP Server`) is the external reference**. The `gh` CLI is used for pull requests, not for issues. GitHub Issues is not the tracker for this repo.
 
-- **Jira** (project `AIML`, component `Contrast MCP Server`) — the system of record for
-  tickets that ship. Issue types: `Story` (features), `Task` (refactors/docs/bugfixes),
-  `Epic` (large multi-ticket efforts). Accessed via the Atlassian MCP server
-  (cloudId `https://contrast.atlassian.net`).
-- **Beads** (`br`) — local issue tracker for implementation work, hydrated from PRDs.
-  Beads carry the `AIML-<id>` Jira prefix in their title and an `external-ref` linking
-  back to Jira. See the `beads://quickstart` MCP resource and the Beads Workflow section
-  of CLAUDE.md for full command reference.
+When a skill says "the issue tracker", it means beads first, with Jira as the linked external ticket for anything that needs one. Most code changes need a Jira ticket and a feature branch (`AIML-<id>-<desc>`) before merging.
 
-Most code changes need a Jira ticket and a feature branch (`AIML-<id>-<desc>`) before merging.
+The **`bead-workflow`** skill governs every bead mutation and the **`jira-workflow`** skill governs ticket creation, bead-to-Jira parity, and status transitions. This doc is the quick reference.
+
+## Beads is the primary store
+
+The database lives in this repo's `.beads/`, which is **gitignored and local-only**. This is a public repository, never commit anything under `.beads/`.
+
+- **Create**: `br create "Title" --description "..." --type task --priority 2 --labels "repo:mcp-contrast"`. For multi-line content use a quoted heredoc through `$()` to keep markdown, backticks, and `$(vars)` literal. For the design field use `scripts/br-set-design <bead-id> <file>`.
+- **Start work**: `br update <bead-id> --claim` sets assignee and status atomically. Falls back to `--status in_progress --assignee <you>` when a stacked-branch blocks edge makes the bead "blocked" (see the `bead-workflow` skill).
+- **Find work**: `br ready` lists unblocked open beads. `br list` and `br show <bead-id>` for detail. `br search "keyword"` for full text.
+- **Comment**: `br comments add <bead-id> --message "..."` for one line, or `br comments add <bead-id> -f /tmp/comment.txt` for multi-line. Note `br comment` (singular) does not exist.
+- **Label**: `br label add <bead-id> -l <label>` / `br label remove <bead-id> -l <label>`. See `triage-labels.md` for the vocabulary.
+- **Dependencies**: `br dep add <dependent> <prerequisite>` for a blocks edge, `br dep add <child> <parent> --type parent-child` for hierarchy.
+- **Close**: `br close <bead-id> --reason "why it's done"`. The `--reason`/`-r` flag is required. Ask the user before closing a bead, and close child beads before their parent.
+- **Sync**: `br sync --flush-only` exports the DB to the local JSONL after mutations and before ending a session.
+
+## Jira is the external reference
+
+Significant beads get a Jira ticket in the **AIML** project (cloudId `https://contrast.atlassian.net`), issue types `Story` (features), `Task` (refactors/docs/bugfixes), `Epic` (large multi-ticket efforts). Use the Atlassian MCP tools to read and write Jira. Full metadata lives in `.claude/skills/jira-workflow/references/aiml.md`.
+
+When a Jira ticket is created for a bead, do two things.
+
+1. Set the bead's `external-ref` to the Jira ticket ID.
+2. Prefix the bead's `title` with the Jira ticket ID (for example `AIML-1304: ...`).
+
+AIML transition IDs for `transitionJiraIssue`: `11` To Do, `21` In Progress, `41` In Review, `51` Ready to Deploy, `61` Blocked, `71` Backlog, `81` Closed. The `jira-workflow` skill maps repo events (PR opened, stacked PR promoted, PR merged) onto these transitions.
 
 ## When a skill says "publish to the issue tracker"
 
-Create a Beads issue with `br create`, then (for anything that will ship) create or link a
-Jira ticket via the Atlassian MCP. When a Jira ticket is created for a bead, do two things:
-1. Set the bead's `external-ref` to the Jira ticket id.
-2. Prefix the bead's `title` with the Jira ticket id (e.g. `AIML-827: ...`).
-
-For a PRD, prefer the project PRD location (`plans/<ticket>/`) over an issue body.
+Create a bead with `br create`. If the work needs an external ticket, also create the Jira issue per the `jira-workflow` skill and link it back via `external-ref` and the title prefix. For a PRD, prefer the project PRD location (`plans/<ticket>/`) over an issue body.
 
 ## When a skill says "fetch the relevant ticket"
 
-- Bead: `br show <bead-id>`.
-- Jira: `getJiraIssue` via the Atlassian MCP (issueIdOrKey `AIML-<n>`, cloudId
-  `https://contrast.atlassian.net`).
-
-## Jira transition IDs (AIML project)
-
-`11` To Do · `21` In Progress · `41` In Review · `51` Ready to Deploy · `61` Blocked ·
-`71` Backlog · `81` Closed.
+Run `br show <bead-id>` (and `br comments` for the thread). If a Jira ID is referenced, fetch it with the Atlassian MCP `getJiraIssue` tool.
 
 ## Labels and state
 
-See `triage-labels.md` for triage roles. Beads also use workflow labels documented in
-CLAUDE.md (`stacked-branch`, `pr-created`, `in-review`) and human-review labels
-(`needs-human-review`, `human-security-review`, `external-approval`, `human-reviewed`).
+See `triage-labels.md` for triage roles and human-review labels. Beads also use workflow labels (`stacked-branch`, `pr-created`, `in-review`) documented in the `bead-workflow` skill.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,29 +1,37 @@
-# Triage Labels
+# Triage labels
 
-The skills speak in terms of five canonical triage roles. This repo uses the canonical
-strings verbatim for all new triage work.
+The skills speak in terms of five canonical triage roles. **The canonical labels are the strings to apply.** When a skill applies a triage role to a bead, use the label in the middle column with `br label add <bead-id> -l <label>`.
 
-| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
-| -------------------------- | -------------------- | ---------------------------------------- |
-| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
-| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
-| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
-| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
-| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+`triaged` is not a state role. It only means an initial analysis pass has been recorded on the bead. If that analysis concludes a maintainer still needs to choose a direction, add `needs-decision`.
 
-Apply these labels to Beads with `br label add <bead-id> -l <label>`.
+This repo also has an older bead label vocabulary. The right-hand column records which existing label carries related meaning so you can recognise it on older beads. When applying labels, use the canonical string unless you need to interoperate with older automation.
 
-## Existing repo labels (do not repurpose — awareness only)
+| Role | Canonical label to apply | Older bead label with related meaning |
+| --- | --- | --- |
+| Maintainer needs to deliberate or choose a direction | `needs-decision` | `needs-triage` |
+| Waiting on reporter for info | `needs-info` | none |
+| Fully specified, AFK-ready | `ready-for-agent` | no label, the bead simply has no human-only label and shows up in `br ready` |
+| Requires human implementation | `ready-for-human` | `ready-for-human` (exact match, keep using it) |
+| Will not be actioned | `wontfix` | none, beads are normally closed with `br close <id> --reason "..."` |
 
-CLAUDE.md already defines a separate human-review vocabulary. New triage work uses the
-canonical labels above; these pre-existing labels keep their established meanings:
+## Human-only labels that block agent work
 
-- `ready-for-human` — **note the clash**: in CLAUDE.md this means "a human should inspect/
-  decide/run the work with agent assistance; autonomous agents should NOT pick it up."
-  The canonical role above means "requires human implementation." Both keep agents from
-  auto-grabbing the issue, so the string is shared, but read the surrounding context.
-- `needs-human-review` — do not start work; ask a human to review first.
-- `human-security-review` — security review required before agent work proceeds.
-- `external-approval` — blocked on approval outside the agent workflow.
-- `human-reviewed` — cleared marker after review; AI may proceed when no human-only label remains.
-- `stacked-branch`, `pr-created`, `in-review` — branch/PR workflow state (see CLAUDE.md).
+These labels mean an autonomous agent must not pick the bead up until a human clears it.
+
+- `needs-triage` — older label for `needs-decision`; do not start, ask a maintainer to decide first
+- `needs-human-review` — do not start, ask a human to review first
+- `human-security-review` — security review required before agent work proceeds
+- `external-approval` — blocked on approval outside the agent workflow
+
+`human-reviewed` is the cleared marker. An agent may proceed once no human-only label remains. After review, swap them.
+
+```bash
+br label remove <bead-id> -l needs-human-review
+br label add <bead-id> -l human-reviewed
+```
+
+## Workflow labels (not triage)
+
+`stacked-branch`, `pr-created`, and `in-review` track branch and PR state, see the `bead-workflow` skill. Do not repurpose them.
+
+Edit this file if the vocabulary changes.


### PR DESCRIPTION
<!-- pr-tools:stacked:v1 -->
<!-- pr-tools:parent-pr=192 -->
<!-- pr-tools:parent-branch=AIML-1303-cursor-paginated-search-standards -->
<!-- pr-tools:parent-base=main -->
<!-- pr-tools:boundary-commit=87a2ad21c74a449367df693068090ceecacbc316 -->
<!-- pr-tools:managed:start -->
<!-- pr-tools:managed:end -->

**Jira:** [AIML-1304](https://contrast.atlassian.net/browse/AIML-1304)

## Summary
Ports the bead-workflow and jira-workflow agent skills from the private aiml-services repo into this public repo, and slims the duplicated workflow prose in CLAUDE.md to pointers.

- Two new skills now own the bead and Jira lifecycles, adding discipline this repo lacked, a pre-claim checklist, atomic claim, commit-before-close, and `br sync --flush-only`
- CLAUDE.md drops about 170 lines of always-loaded context
- Triage vocabulary aligns with the sibling repo's canonical labels (`needs-decision` and friends)

## Why This Change Exists
- The sibling private repo evolved its issue workflow into on-demand skills while this repo carried an older inline copy in CLAUDE.md. The two had drifted apart, this repo had no sync discipline, no atomic claim, and no pre-claim checks, even though both repos share the same bead and Jira conventions.
- This is a public repo, so the ported material needed an explicit privacy boundary, which Jira and bead metadata may appear in committed files and which must not.

## Approach
- Skills instead of CLAUDE.md prose. The lifecycle rules load when a bead or ticket mutation triggers them, not in every session.
- Public-safety filter applied throughout, name-based Jira metadata only, the site-URL cloud id instead of the UUID, and no internal service or product names, cross-repo bead notes, or private repo references.
- Kept this repo's transition semantics (In Review when the PR opens, Ready to Deploy at merge) rather than adopting the private repo's close-time transition, and expressed them as an event-to-transition table.
- Documented a workaround discovered during implementation, `br` refuses `--claim` and status changes on beads with blocks edges, so stacked-branch beads set status before adding the edge.

## What Changed
### New agent skills
- `.claude/skills/bead-workflow/SKILL.md` (new) - full bead lifecycle, creation standards, pre-claim checklist, stacked-branch handling, close sequence, triage, sync
- `.claude/skills/jira-workflow/SKILL.md` (new) - ticket creation, bead-to-Jira parity rules, event-to-transition mapping
- `.claude/skills/jira-workflow/references/aiml.md` (new) - AIML project metadata, public-safe subset only

### Agent docs
- `docs/agents/issue-tracker.md` - rewritten as the quick reference for the beads-primary model, notes that `.beads/` is gitignored and must never be committed
- `docs/agents/triage-labels.md` - canonical triage vocabulary with a mapping table for older labels

### CLAUDE.md
- Beads, Jira, and PR-lifecycle sections replaced with pointers to the skills plus a trigger-phrase table; Testing Requirements and Integration Test Standards stay put

## Testing
- Docs-only change, no code affected. The pre-push hook confirmed no changed Java files, so coverage gates do not apply.
- Audited the diff with `grep` for internal-only strings (private service and product names, the UUID cloud id, cross-repo bead references), all clean.
- Verified no remaining references to the removed CLAUDE.md sections anywhere in the repo.


[AIML-1304]: https://contrast.atlassian.net/browse/AIML-1304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ