### PR TITLE
AIML-1303 Add optional totalItems to CursorToolResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ report total result count on the first page, matching the capability offset-pagi
 already have via `PaginatedToolResponse.totalItems`. The field is nullable and defaults to
 null, so existing cursor tools are unaffected.
 
-## [2.2.0]
+## [2.2.0] - 2026-08-04
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Improvements
+
+**`CursorToolResponse` now carries optional `totalItems`**: Cursor-paginated tools can
+report total result count on the first page, matching the capability offset-paginated tools
+already have via `PaginatedToolResponse.totalItems`. The field is nullable and defaults to
+null, so existing cursor tools are unaffected.
+
+## [2.2.0]
+
 ### Bug Fixes
 
 **`search_vulnerabilities` example used wrong vulnerability type name**: The tool
@@ -19,11 +28,6 @@ SDK returned a null HTTP request response, the tool threw a NullPointerException
 of returning the vulnerability with the HTTP request field omitted. Fixed.
 
 ### Improvements
-
-**`CursorToolResponse` now carries optional `totalItems`**: Cursor-paginated tools can
-report total result count on the first page, matching the capability offset-paginated tools
-already have via `PaginatedToolResponse.totalItems`. The field is nullable and defaults to
-null, so existing cursor tools are unaffected.
 
 **Response envelope field `warnings` renamed to `notices`**: The informational messages
 attached to every tool response were renamed from `warnings` to `notices` because the old

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ of returning the vulnerability with the HTTP request field omitted. Fixed.
 
 ### Improvements
 
+**`CursorToolResponse` now carries optional `totalItems`**: Cursor-paginated tools can
+report total result count on the first page, matching the capability offset-paginated tools
+already have via `PaginatedToolResponse.totalItems`. The field is nullable and defaults to
+null, so existing cursor tools are unaffected.
+
 **Response envelope field `warnings` renamed to `notices`**: The informational messages
 attached to every tool response were renamed from `warnings` to `notices` because the old
 name caused AI agents to treat normal teaching notes as problems. The `Vulnerability`

--- a/MCP_STANDARDS.md
+++ b/MCP_STANDARDS.md
@@ -310,7 +310,7 @@ com.contrast.labs.ai.mcp.contrast.tool/
 **`CursorPaginatedTool<P extends ToolParams, R>`** - For cursor/keyset-backed search/list tools:
 - Template method `executePipeline()` handles cursor pagination, validation, exceptions
 - Subclasses treat cursor values as opaque continuation tokens
-- Returns `CursorToolResponse<R>` with items, `nextCursor`, `hasMore`, errors, and notices
+- Returns `CursorToolResponse<R>` with items, `nextCursor`, `hasMore`, optional `totalItems`, errors, notices, `pageSize`, and `durationMs`
 
 ### Parameter Classes (Params Pattern)
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorExecutionResult.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorExecutionResult.java
@@ -25,9 +25,10 @@ import org.springframework.lang.Nullable;
  * @param items page items
  * @param nextCursor opaque continuation token returned by the backend, or null
  * @param hasMore true when another page can be fetched
+ * @param totalItems total count across all pages, or null when unavailable
  */
 public record CursorExecutionResult<T>(
-    List<T> items, @Nullable String nextCursor, boolean hasMore) {
+    List<T> items, @Nullable String nextCursor, boolean hasMore, @Nullable Integer totalItems) {
 
   public CursorExecutionResult {
     items = items != null ? List.copyOf(items) : List.of();
@@ -35,10 +36,15 @@ public record CursorExecutionResult<T>(
 
   public static <T> CursorExecutionResult<T> of(
       List<T> items, @Nullable String nextCursor, boolean hasMore) {
-    return new CursorExecutionResult<>(items, nextCursor, hasMore);
+    return of(items, nextCursor, hasMore, null);
+  }
+
+  public static <T> CursorExecutionResult<T> of(
+      List<T> items, @Nullable String nextCursor, boolean hasMore, @Nullable Integer totalItems) {
+    return new CursorExecutionResult<>(items, nextCursor, hasMore, totalItems);
   }
 
   public static <T> CursorExecutionResult<T> empty() {
-    return new CursorExecutionResult<>(List.of(), null, false);
+    return new CursorExecutionResult<>(List.of(), null, false, null);
   }
 }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java
@@ -143,6 +143,7 @@ public abstract class CursorPaginatedTool<P extends ToolParams, R> extends BaseT
         pagination.pageSize(),
         null,
         false,
+        null,
         List.of(errorMessage),
         collector.snapshot(),
         null);
@@ -166,6 +167,7 @@ public abstract class CursorPaginatedTool<P extends ToolParams, R> extends BaseT
         pagination.pageSize(),
         result.nextCursor(),
         result.hasMore(),
+        result.totalItems(),
         collector.snapshot(),
         duration);
   }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorToolResponse.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorToolResponse.java
@@ -27,6 +27,7 @@ import org.springframework.lang.Nullable;
  * @param pageSize page size used
  * @param nextCursor opaque continuation token, or null when absent
  * @param hasMore true when another page can be fetched
+ * @param totalItems total count across all pages, or null when unavailable
  * @param errors validation or execution errors
  * @param notices Informational notices: applied defaults, failed optional enrichments, empty-result
  *     explanations, interpretation facts
@@ -37,6 +38,7 @@ public record CursorToolResponse<T>(
     int pageSize,
     @Nullable String nextCursor,
     boolean hasMore,
+    @Nullable Integer totalItems,
     List<String> errors,
     List<String> notices,
     @Nullable Long durationMs) {
@@ -63,16 +65,28 @@ public record CursorToolResponse<T>(
       boolean hasMore,
       List<String> notices,
       @Nullable Long durationMs) {
+    return success(items, pageSize, nextCursor, hasMore, null, notices, durationMs);
+  }
+
+  public static <T> CursorToolResponse<T> success(
+      List<T> items,
+      int pageSize,
+      @Nullable String nextCursor,
+      boolean hasMore,
+      @Nullable Integer totalItems,
+      List<String> notices,
+      @Nullable Long durationMs) {
     return new CursorToolResponse<>(
-        items, pageSize, nextCursor, hasMore, List.of(), notices, durationMs);
+        items, pageSize, nextCursor, hasMore, totalItems, List.of(), notices, durationMs);
   }
 
   public static <T> CursorToolResponse<T> validationError(int pageSize, List<String> errors) {
-    return new CursorToolResponse<>(List.of(), pageSize, null, false, errors, List.of(), null);
+    return new CursorToolResponse<>(
+        List.of(), pageSize, null, false, null, errors, List.of(), null);
   }
 
   public static <T> CursorToolResponse<T> error(int pageSize, String errorMessage) {
     return new CursorToolResponse<>(
-        List.of(), pageSize, null, false, List.of(errorMessage), List.of(), null);
+        List.of(), pageSize, null, false, null, List.of(errorMessage), List.of(), null);
   }
 }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolResponse.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolResponse.java
@@ -16,6 +16,7 @@
 package com.contrast.labs.ai.mcp.contrast.tool.base;
 
 import java.util.List;
+import org.springframework.lang.Nullable;
 
 /**
  * Generic paginated response wrapper for all list-returning MCP tools. Provides consistent
@@ -39,11 +40,11 @@ public record PaginatedToolResponse<T>(
     List<T> items,
     int page,
     int pageSize,
-    Integer totalItems,
+    @Nullable Integer totalItems,
     boolean hasMorePages,
     List<String> errors,
     List<String> notices,
-    Long durationMs) {
+    @Nullable Long durationMs) {
 
   /** Compact constructor ensures non-null, immutable lists. */
   public PaginatedToolResponse {
@@ -78,10 +79,10 @@ public record PaginatedToolResponse<T>(
       List<T> items,
       int page,
       int pageSize,
-      Integer totalItems,
+      @Nullable Integer totalItems,
       boolean hasMorePages,
       List<String> notices,
-      Long durationMs) {
+      @Nullable Long durationMs) {
     return new PaginatedToolResponse<>(
         items, page, pageSize, totalItems, hasMorePages, List.of(), notices, durationMs);
   }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorExecutionResultTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorExecutionResultTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.contrast.labs.ai.mcp.contrast.tool.base;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -9,13 +24,16 @@ import org.junit.jupiter.api.Test;
 
 class CursorExecutionResultTest {
 
+  private static final int TOTAL_ITEMS = 42;
+
   @Test
   void constructor_should_substitute_an_empty_list_when_items_is_null() {
-    var result = new CursorExecutionResult<String>(null, "cursor", true);
+    var result = new CursorExecutionResult<String>(null, "cursor", true, TOTAL_ITEMS);
 
     assertThat(result.items()).isEmpty();
     assertThat(result.nextCursor()).isEqualTo("cursor");
     assertThat(result.hasMore()).isTrue();
+    assertThat(result.totalItems()).isEqualTo(TOTAL_ITEMS);
   }
 
   @Test
@@ -43,6 +61,14 @@ class CursorExecutionResultTest {
     assertThat(result.items()).containsExactly("a", "b");
     assertThat(result.nextCursor()).isEqualTo("next-token");
     assertThat(result.hasMore()).isTrue();
+    assertThat(result.totalItems()).isNull();
+  }
+
+  @Test
+  void of_should_carry_totalItems_through_when_present() {
+    var result = CursorExecutionResult.of(List.of("item"), null, false, TOTAL_ITEMS);
+
+    assertThat(result.totalItems()).isEqualTo(TOTAL_ITEMS);
   }
 
   @Test
@@ -52,5 +78,6 @@ class CursorExecutionResultTest {
     assertThat(result.items()).isEmpty();
     assertThat(result.nextCursor()).isNull();
     assertThat(result.hasMore()).isFalse();
+    assertThat(result.totalItems()).isNull();
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
@@ -139,6 +139,7 @@ class CursorPaginatedToolTest {
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors()).containsExactly("API error (HTTP 400)");
     assertThat(result.errors()).noneMatch(error -> error.contains(OPAQUE_CURSOR));
+    assertThat(result.totalItems()).isNull();
     assertThat(result.notices())
         .containsExactlyInAnyOrder("Initial notice", "Notice added before exception");
     assertThat(result.notices()).noneMatch(notice -> notice.contains(OPAQUE_CURSOR));

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
@@ -32,6 +32,7 @@ class CursorPaginatedToolTest {
       "Authentication failed or resource not found. Verify credentials and that the resource ID"
           + " is correct.";
   private static final String OPAQUE_CURSOR = "opaque.cursor/with+symbols==";
+  private static final int TOTAL_ITEMS = 42;
 
   private TestCursorTool tool;
 
@@ -77,6 +78,17 @@ class CursorPaginatedToolTest {
     assertThat(result.pageSize()).isEqualTo(25);
     assertThat(result.nextCursor()).isNull();
     assertThat(result.hasMore()).isFalse();
+  }
+
+  @Test
+  void executePipeline_should_propagate_totalItems_from_execution_result() {
+    tool.setDoExecuteHandler(
+        (pagination, params, collector) ->
+            CursorExecutionResult.of(List.of("item"), "next-token", true, TOTAL_ITEMS));
+
+    var result = tool.executePipeline(null, 25, TestParams::valid);
+
+    assertThat(result.totalItems()).isEqualTo(TOTAL_ITEMS);
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorToolResponseTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorToolResponseTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
 
 class CursorToolResponseTest {
 
+  private static final int TOTAL_ITEMS = 42;
+
   @Test
   void success_should_include_cursor_pagination_metadata_only() {
     var response =
@@ -33,10 +35,27 @@ class CursorToolResponseTest {
     assertThat(response.pageSize()).isEqualTo(50);
     assertThat(response.nextCursor()).isEqualTo("next-opaque-token");
     assertThat(response.hasMore()).isTrue();
+    assertThat(response.totalItems()).isNull();
     assertThat(response.errors()).isEmpty();
     assertThat(response.notices()).isEmpty();
     assertThat(response.durationMs()).isEqualTo(10L);
     assertThat(response.isSuccess()).isTrue();
+  }
+
+  @Test
+  void success_with_totalItems_should_include_total_in_response() {
+    var response =
+        CursorToolResponse.success(
+            List.of("item1"), 50, "next-opaque-token", true, TOTAL_ITEMS, List.of(), 10L);
+
+    assertThat(response.totalItems()).isEqualTo(TOTAL_ITEMS);
+  }
+
+  @Test
+  void success_without_totalItems_should_default_to_null() {
+    var response = CursorToolResponse.success(List.of("item1"), 50, null, false, List.of(), 10L);
+
+    assertThat(response.totalItems()).isNull();
   }
 
   @Test
@@ -47,9 +66,17 @@ class CursorToolResponseTest {
     assertThat(response.pageSize()).isEqualTo(50);
     assertThat(response.nextCursor()).isNull();
     assertThat(response.hasMore()).isFalse();
+    assertThat(response.totalItems()).isNull();
     assertThat(response.errors()).containsExactly("issueId is required");
     assertThat(response.durationMs()).isNull();
     assertThat(response.isSuccess()).isFalse();
+  }
+
+  @Test
+  void totalItems_should_be_null_for_validation_errors() {
+    var response = CursorToolResponse.validationError(50, List.of("issueId is required"));
+
+    assertThat(response.totalItems()).isNull();
   }
 
   @Test
@@ -60,8 +87,16 @@ class CursorToolResponseTest {
     assertThat(response.pageSize()).isEqualTo(25);
     assertThat(response.nextCursor()).isNull();
     assertThat(response.hasMore()).isFalse();
+    assertThat(response.totalItems()).isNull();
     assertThat(response.errors()).containsExactly("Invalid cursor");
     assertThat(response.notices()).isEmpty();
+  }
+
+  @Test
+  void totalItems_should_be_null_for_errors() {
+    var response = CursorToolResponse.error(25, "Invalid cursor");
+
+    assertThat(response.totalItems()).isNull();
   }
 
   @Test
@@ -70,14 +105,14 @@ class CursorToolResponseTest {
     mutableItems.add("item1");
 
     var response =
-        new CursorToolResponse<>(mutableItems, 50, null, false, List.of(), List.of(), null);
+        new CursorToolResponse<>(mutableItems, 50, null, false, null, List.of(), List.of(), null);
     mutableItems.add("item2");
 
     assertThat(response.items()).containsExactly("item1");
   }
 
   @Test
-  void record_components_should_exclude_total_and_random_access_page_fields() {
+  void record_components_should_include_totalItems_and_exclude_random_access_page_fields() {
     var componentNames =
         Arrays.stream(CursorToolResponse.class.getRecordComponents())
             .map(component -> component.getName())
@@ -85,7 +120,14 @@ class CursorToolResponseTest {
 
     assertThat(componentNames)
         .containsExactly(
-            "items", "pageSize", "nextCursor", "hasMore", "errors", "notices", "durationMs")
-        .doesNotContain("page", "offset", "totalPages", "totalItems", "hasMorePages");
+            "items",
+            "pageSize",
+            "nextCursor",
+            "hasMore",
+            "totalItems",
+            "errors",
+            "notices",
+            "durationMs")
+        .doesNotContain("page", "offset", "totalPages", "hasMorePages");
   }
 }


### PR DESCRIPTION
<!-- pr-tools:stacked:v1 -->
<!-- pr-tools:parent-pr=193 -->
<!-- pr-tools:parent-branch=AIML-1304-improve-ai-skills -->
<!-- pr-tools:parent-base=AIML-1303-cursor-paginated-search-standards -->
<!-- pr-tools:boundary-commit=f2e3ef2511e0f683b9275dfeaa164e361586f2eb -->
<!-- pr-tools:managed:start -->
<!-- pr-tools:managed:end -->

**Jira:** [AIML-1303](https://contrast.atlassian.net/browse/AIML-1303)

## Summary

Adds an optional `totalItems` field to the cursor-paginated response envelope so cursor-backed tools can report total result scale, matching the capability offset-paginated tools already have.

- Cursor tools can now return total count on the first page, letting agents distinguish "3 results" from "3 results on this page of 300"
- Existing cursor tools are unaffected (the field defaults to null)
- Fixes `@Nullable` annotation drift on `PaginatedToolResponse` and `MCP_STANDARDS.md` field-list drift

## Why This Change Exists

The planned CVE Shield hosted MCP tools (`search_cves`, `list_cve_issues`) wrap upstream endpoints that provide a `/count` twin, but `CursorToolResponse` had no field to carry that count. Without it, an AI agent using a cursor tool cannot tell whether a page represents the full result set or a slice, which produces confidently wrong summaries. This field also enables the no-count-tool policy for cursor tools, since page-1 `totalItems` answers the count question that would otherwise need a standalone tool.

## Approach

Added `@Nullable Integer totalItems` as a new record component to both `CursorExecutionResult` (the intermediate result from `doExecute`) and `CursorToolResponse` (the agent-facing envelope). The type matches `PaginatedToolResponse.totalItems` for cross-envelope consistency. Backward-compatible factory overloads keep the old arity and pass null. The base class (`CursorPaginatedTool`) propagates the value from execution result to response but never calls a count endpoint itself, as that is per-tool business logic.

The GOAT review (Claude, Codex, Gemini) flagged a `@Nullable` annotation inconsistency between the new fields and the existing `PaginatedToolResponse.totalItems`/`durationMs`, which accepted null but lacked the annotation. Fixed in the second commit.

## What Changed

### contrast-mcp-core (base classes)
- `CursorExecutionResult.java` -- new `@Nullable Integer totalItems` component, backward-compat `of()` overload
- `CursorToolResponse.java` -- new `@Nullable Integer totalItems` component, backward-compat `success()` overload, error/validation factories pass null
- `CursorPaginatedTool.java` -- `buildSuccessResponse` propagates `totalItems` from execution result; `handleHttpResponseException` passes null
- `PaginatedToolResponse.java` -- added `@Nullable` to `totalItems` and `durationMs` for annotation consistency

### Tests
- `CursorExecutionResultTest` -- totalItems propagation, null-default, and empty-result coverage
- `CursorToolResponseTest` -- success with/without totalItems, validation-error and error null assertions, updated component-shape test
- `CursorPaginatedToolTest` -- totalItems propagation through pipeline, null on error paths

### Documentation
- `MCP_STANDARDS.md` -- fixed CursorToolResponse description to include `totalItems`, `pageSize`, and `durationMs`
- `CHANGELOG.md` -- added entry under Improvements

## Testing

All 1,076 tests pass. Coverage floors met for both modules. Pre-push hook changed-file coverage passed.

Load-bearing tests:
- `success_with_totalItems_should_include_total_in_response` -- proves the new factory carries the value
- `success_without_totalItems_should_default_to_null` -- proves the backward-compat overload defaults to null
- `executePipeline_should_propagate_totalItems_from_execution_result` -- proves end-to-end propagation through the base class
- `record_components_should_include_totalItems_and_exclude_random_access_page_fields` -- proves the envelope shape includes totalItems but still excludes offset-pagination fields

No integration tests needed. This change adds a field to a shared record; the first integration-level coverage will come with the consuming tools (`search_cves`, `list_cve_issues`).


[AIML-1303]: https://contrast.atlassian.net/browse/AIML-1303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ