### PR TITLE
AIML-1245 Move release Docker action pins into a local composite action

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -1,0 +1,70 @@
+# This composite exists so Dependabot bumps to the action pins below edit this
+# file instead of a file under .github/workflows/. GitHub starts no
+# pull_request workflow runs for a Dependabot PR that modifies workflow files,
+# so while these pins lived in gradle-release.yml their bump PRs got no checks
+# at all and could never satisfy the required build check (PRs #196-#199,
+# AIML-1245). Bumps to this file trigger CI like any other change.
+#
+# Dependabot only scans this directory because it is listed under the
+# github-actions entry in .github/dependabot.yml. A new composite action
+# directory must be added there too, or its pins silently stop updating.
+name: Build Docker image
+description: >-
+  Set up Buildx and QEMU, resolve image tags, log in to DockerHub, and build
+  the release image locally (loaded, not pushed). The push stays in the
+  workflow because Docker Content Trust signing needs the trust key material
+  staged there first.
+
+inputs:
+  image:
+    description: Image repository, e.g. contrast/mcp-contrast
+    required: true
+  version:
+    description: Release version tagged alongside latest
+    required: true
+  dockerhub-username:
+    description: DockerHub username
+    required: true
+  dockerhub-token:
+    description: DockerHub access token
+    required: true
+
+outputs:
+  tags:
+    description: Newline-separated fully qualified image tags to push
+    value: ${{ steps.meta.outputs.tags }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Docker Buildx
+      uses: step-security/setup-buildx-action@6997872a55d77391e51b87609556578131f44402 # v4.1.0
+
+    - name: Set up QEMU
+      uses: step-security/setup-qemu-action@fe44c529aab16157fc475f4991a7f926aa9a02a2 # v4.1.0
+
+    - name: Extract metadata for Docker
+      id: meta
+      uses: step-security/metadata-action@619b5adf759ed62ddd8c6d474364da38ea264eee # v6.1.0
+      with:
+        images: ${{ inputs.image }}
+        tags: |
+          type=raw,value=${{ inputs.version }}
+          type=raw,value=latest
+
+    - name: Login to DockerHub
+      uses: step-security/docker-login-action@164e21d7e52229904128e2f946001cb88278c33d # v4.2.0
+      with:
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ inputs.dockerhub-token }}
+
+    - name: Build Docker image (without pushing)
+      uses: step-security/docker-build-push-action@9af9b5acc1751dcec2aa5375a068979fa526bc9a # v7.2.0
+      with:
+        context: .
+        push: false
+        load: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,13 @@ updates:
       default-days: 7
 
   - package-ecosystem: github-actions
-    directory: /
+    # "/" covers .github/workflows only. Local composite actions must be listed
+    # explicitly or Dependabot never sees their pins. Composites exist so pin
+    # bumps do not modify workflow files, which GitHub refuses to run
+    # pull_request checks for on Dependabot PRs (AIML-1245).
+    directories:
+      - /
+      - /.github/actions/build-docker-image
     schedule:
       interval: weekly
     open-pull-requests-limit: 10

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -262,37 +262,19 @@ jobs:
           DOCKER_CONTENT_TRUST_PKEY_ROLE: ${{ secrets.DIGICERT_PKEY_ROLE }}
         run: docker trust key load ~/.docker/trust/private/"$DOCKER_CONTENT_TRUST_KEY_FILENAME" --name "$DOCKER_CONTENT_TRUST_PKEY_ROLE"
 
-      - name: Set up Docker Buildx
-        uses: step-security/setup-buildx-action@6997872a55d77391e51b87609556578131f44402 # v4.1.0
-
-      - name: Set up QEMU
-        uses: step-security/setup-qemu-action@fe44c529aab16157fc475f4991a7f926aa9a02a2 # v4.1.0
-
-      - name: Extract metadata for Docker
-        id: meta
-        uses: step-security/metadata-action@619b5adf759ed62ddd8c6d474364da38ea264eee # v6.1.0
-        with:
-          images: contrast/mcp-contrast
-          tags: |
-            type=raw,value=${{ steps.versions.outputs.release }}
-            type=raw,value=latest
-
-      - name: Login to DockerHub
-        uses: step-security/docker-login-action@164e21d7e52229904128e2f946001cb88278c33d # v4.2.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
+      # The buildx/QEMU/metadata/login/build steps live in a local composite so
+      # Dependabot bumps to their pins edit that action.yml, not this workflow
+      # file. Dependabot PRs that modify workflow files get no pull_request
+      # runs, so pins kept here could never pass the required build check
+      # (PRs #196-#199, AIML-1245). See the comment in the action itself.
       - name: Build Docker image (without pushing)
-        uses: step-security/docker-build-push-action@9af9b5acc1751dcec2aa5375a068979fa526bc9a # v7.2.0
+        id: docker-build
+        uses: ./.github/actions/build-docker-image
         with:
-          context: .
-          push: false
-          load: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          image: contrast/mcp-contrast
+          version: ${{ steps.versions.outputs.release }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # This relies on the single-platform load above; inspect keeps the scan bound to the local image.
       # Scan the loaded image here so both formats describe the exact image that will be pushed.
@@ -321,7 +303,7 @@ jobs:
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DIGICERT_PKEY_PASSPHRASE }}
         run: |
           # The tags are newline-separated, not comma-separated
-          echo "${{ steps.meta.outputs.tags }}" | while read -r tag; do
+          echo "${{ steps.docker-build.outputs.tags }}" | while read -r tag; do
             echo "Pushing and signing $tag"
             docker push "$tag"
           done


### PR DESCRIPTION
**Jira:** [AIML-1245](https://contrast.atlassian.net/browse/AIML-1245)

## Summary
Moved the release workflow's Docker action pins into a local composite action so Dependabot bumps to those pins no longer modify workflow files, which lets their PRs run CI and flow through the auto-merge workflow.

- Bump PRs for the docker action cluster (the #196-#199 class) will now get `pull_request` runs, can pass the required `build` check, and can auto-merge unattended.
- Dependabot now scans the composite directory explicitly, so the relocated pins keep updating.

## Why This Change Exists
GitHub starts no `pull_request` workflow runs for a Dependabot PR that modifies files under `.github/workflows/`. The step-security docker pins lived in `gradle-release.yml`, so their weekly bump PRs (#196-#199) arrived with zero checks, could never satisfy the required `build` check, and sat open until a human merged them. The upstream Inc setup avoids this because its pins live in composite action files in `common-github-actions`, not in consuming repos' workflow files. This PR recreates that split locally.

## What Changed
### Release workflow
- `.github/actions/build-docker-image/action.yml` (new) holds the pinned setup-buildx, setup-qemu, metadata-action, docker-login, and docker-build-push steps. It builds and loads the image locally and exposes the resolved tags as an output. The DCT-signed push stays in the workflow because it needs the trust key material staged there.
- `.github/workflows/gradle-release.yml` replaces the five inline steps with one call to the composite. The push step now reads tags from the composite's `tags` output instead of the old `meta` step.

### Dependabot config
- `.github/dependabot.yml` switches the github-actions entry from `directory: /` to a `directories` list that adds the composite's path, because `/` only covers `.github/workflows`.

## Testing
- `actionlint` passes across all workflows, and it validates the workflow's inputs to the local action against `action.yml`.
- All three YAML files parse.
- Not exercised live. `gradle-release.yml` only runs on `workflow_dispatch` from `main`, so the composite first executes for real on the next release. The steps and pins are byte-identical to the inline versions, only relocated, and the composite resolves from the release tag's checkout, which will contain it once this merges.

## Risks / Rollout / Follow-ups
- `harden-runner` and `setup-jfrog-cli` pins stay inline in workflow files on purpose, so their bump PRs still arrive with no checks and need a manual merge. `harden-runner` must run as the first step of each job, before checkout, and a path-referenced local composite needs the checkout first.
- Open PRs #196-#199 edit workflow lines that this PR removes. After this merges, close them and let the next weekly Dependabot run raise equivalent bumps against the composite's `action.yml`.


[AIML-1245]: https://contrast.atlassian.net/browse/AIML-1245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ