### PR TITLE
AIML-1321 Release Contrast MCP Server v2.3.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ChrisEdwards @Contrast-Security-OSS/aiml-developers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-08-07
+
 ### Improvements
 
 **`CursorToolResponse` now carries optional `totalItems`**: Cursor-paginated tools can

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -119,6 +119,7 @@ This checklist describes an automated workflow release. For a manual recovery re
 - `contrast-mcp-core` artifact is available in Artifactory at the release version.
 - `main` has no release-version or next-snapshot commits from the workflow.
 - `./gradlew -q printVersion` on the release tag prints `X.Y.Z`.
+- GitHub release notes contain the changelog entries for this version. Copy the `[X.Y.Z]` section from `CHANGELOG.md` into the release body. This is manual for now but will be automated.
 
 ## Troubleshooting
 


### PR DESCRIPTION
**Jira:** [AIML-1321](https://contrast.atlassian.net/browse/AIML-1321)

## Summary

- Stamps the `[Unreleased]` changelog section as `[2.3.0] - 2026-08-07`
- Adds a verify step to RELEASING.md for copying changelog entries into GitHub release notes (manual for now, will be automated)
- Adds `.github/CODEOWNERS` to auto-request reviews from @ChrisEdwards and @Contrast-Security-OSS/aiml-developers on all PRs

## Test plan

- No code changes. Docs only.

[AIML-1321]: https://contrast.atlassian.net/browse/AIML-1321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ