### PR TITLE
AIML-1329 Override mapHttpErrorCode for 500 in ListApplicationsByCveTool

### DIFF
--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
@@ -50,6 +50,12 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveParams, CveData> {
 
+  private static final int HTTP_INTERNAL_SERVER_ERROR = 500;
+  private static final String INTERNAL_SERVER_ERROR_MESSAGE =
+      "The service returned an error. This happens for CVEs the SCA library data does not"
+          + " recognize, including CVEs that exist only in NorthStar CVE Shield data. Verify the"
+          + " CVE with search_cves or get_cve_impact, or retry later if the service is failing.";
+
   private final ContrastApiClient contrastApiClient;
 
   @Tool(
@@ -70,6 +76,14 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
 
   public SingleToolResponse<CveData> listApplicationsByCve(String cveId) {
     return listApplicationsByCve(cveId, null);
+  }
+
+  @Override
+  protected String mapHttpErrorCode(int code) {
+    if (code == HTTP_INTERNAL_SERVER_ERROR) {
+      return INTERNAL_SERVER_ERROR_MESSAGE;
+    }
+    return super.mapHttpErrorCode(code);
   }
 
   @Override

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
@@ -408,6 +408,46 @@ class ListApplicationsByCveToolTest {
   }
 
   @Test
+  void listApplicationsByCve_should_map_downstream_500_with_cve_shield_guidance() throws Exception {
+    when(contrastApiClient.getApplicationsByCve(eq(CVE_ID)))
+        .thenThrow(
+            new HttpResponseException(
+                "Internal Server Error",
+                "GET",
+                "/ng/org/libraries/cve",
+                500,
+                "Internal Server Error",
+                SECRET_BODY));
+
+    var result = tool.listApplicationsByCve(CVE_ID, null);
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors())
+        .containsExactly(
+            "The service returned an error. This happens for CVEs the SCA library data does not"
+                + " recognize, including CVEs that exist only in NorthStar CVE Shield data."
+                + " Verify the CVE with search_cves or get_cve_impact, or retry later if the"
+                + " service is failing.");
+    assertThat(result.toString()).doesNotContain(SECRET_BODY, "/ng/org/libraries/cve");
+  }
+
+  @Test
+  void listApplicationsByCve_should_map_downstream_502_with_base_message() throws Exception {
+    when(contrastApiClient.getApplicationsByCve(eq(CVE_ID)))
+        .thenThrow(
+            new HttpResponseException(
+                "Bad Gateway", "GET", "/ng/org/libraries/cve", 502, "Bad Gateway", SECRET_BODY));
+
+    var result = tool.listApplicationsByCve(CVE_ID, null);
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors())
+        .containsExactly(
+            "The service returned an error. Narrow filters or reduce page size, then retry.");
+    assertThat(result.toString()).doesNotContain(SECRET_BODY, "/ng/org/libraries/cve");
+  }
+
+  @Test
   void listApplicationsByCve_should_not_leak_exception_message_when_enrichment_fails()
       throws Exception {
     var cveData = cveData(app("Orders", APP_ID), vulnerableLibrary(LIBRARY_HASH));


### PR DESCRIPTION
## Summary

- Overrides `mapHttpErrorCode` in `ListApplicationsByCveTool` to return a CVE Shield-aware message for HTTP 500 instead of the generic "Narrow filters or reduce page size" guidance, which makes no sense for a tool with neither filters nor pagination.
- The upstream endpoint returns 500 (not 404) for CVEs unknown to the SCA library data. The new message explains this and directs the user to `search_cves` or `get_cve_impact` as alternatives.
- All other status codes (401, 403, 404, 429, 502, 503, default) delegate to `super.mapHttpErrorCode()` unchanged.

## Test plan

- [x] New test: 500 returns the CVE Shield guidance message with no response-body or path leak
- [x] New test: 502 still returns the base generic message (proves override does not widen)
- [x] `make check-test` passes (1,078 tests, checkstyle, spotless, coverage floors)
- [ ] Upstream fix tracked in TS-43426; this override remains correct after that fix since 404 already maps cleanly

## Jira

[AIML-1329](https://contrast.atlassian.net/browse/AIML-1329)

[AIML-1329]: https://contrast.atlassian.net/browse/AIML-1329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ