### PR TITLE
AIML-1331 Document lastSeen=0 sentinel and status staleness in list_applications_by_cve

### DIFF
--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsTool.java
@@ -119,9 +119,28 @@ public class SearchApplicationsTool
       return ExecutionResult.empty();
     }
 
+    noticeNeverObservedApps(response.getApplications(), collector);
+
     var applications = response.getApplications().stream().map(this::toApplicationData).toList();
 
     return ExecutionResult.of(applications, response.getCount());
+  }
+
+  // TeamServer sends last_seen 0 for applications that have never reported agent activity, which
+  // renders as the 1970 Unix epoch in lastSeenAt (Jira AIML-1331).
+  private static void noticeNeverObservedApps(
+      List<Application> applications, NoticeCollector collector) {
+    var neverObserved =
+        applications.stream()
+            .filter(app -> app.getLastSeen() != null && app.getLastSeen() == 0)
+            .map(Application::getName)
+            .toList();
+    if (!neverObserved.isEmpty()) {
+      collector.notice(
+          "lastSeenAt at the 1970 Unix epoch means the application has never been observed"
+              + " running, typically a static or SCA-only upload: "
+              + String.join(", ", neverObserved));
+    }
   }
 
   /**

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
@@ -66,10 +66,8 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
           per-application class usage. classUsage 0 or absent means no classes from the vulnerable
           library were seen loaded, so exploitation is unlikely; prioritize applications with
           classUsage above 0. Use list_application_libraries for the reverse direction, all
-          libraries of one application. lastSeen of 0 means the application has never been observed
-          running, typically a static or SCA-only upload. lastSeen and server status reflect
-          last-known agent reports and can lag live state; search_servers is fresher for current
-          server state.
+          libraries of one application. lastSeen and server status reflect last-known agent
+          reports and can lag live state; search_servers is fresher for current server state.
           """)
   public SingleToolResponse<CveData> listApplicationsByCve(
       @ToolParam(description = "CVE identifier (e.g., CVE-2021-44228)") String cveId,
@@ -119,6 +117,8 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
       return cveData;
     }
 
+    noticeNeverObservedApps(apps, collector);
+
     log.debug(
         "Found {} applications vulnerable to {}, enriching with class usage data",
         apps.size(),
@@ -139,6 +139,19 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
         apps.size());
 
     return cveData;
+  }
+
+  // TeamServer sends last_seen 0 for applications that have never reported agent activity, and
+  // App.lastSeen is a primitive long, so the zero sentinel always serializes (Jira AIML-1331).
+  private static void noticeNeverObservedApps(List<App> apps, NoticeCollector collector) {
+    var neverObserved =
+        apps.stream().filter(app -> app.getLastSeen() == 0).map(App::getName).toList();
+    if (!neverObserved.isEmpty()) {
+      collector.notice(
+          "lastSeen of 0 means the application has never been observed running, typically a"
+              + " static or SCA-only upload: "
+              + String.join(", ", neverObserved));
+    }
   }
 
   private static void applyPreferredCvssSummary(Cve cve) {

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
@@ -66,7 +66,10 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
           per-application class usage. classUsage 0 or absent means no classes from the vulnerable
           library were seen loaded, so exploitation is unlikely; prioritize applications with
           classUsage above 0. Use list_application_libraries for the reverse direction, all
-          libraries of one application.
+          libraries of one application. lastSeen of 0 means the application has never been observed
+          running, typically a static or SCA-only upload. Application and server status reflect
+          last-known agent reports and can lag live status; search_servers is fresher for current
+          server state.
           """)
   public SingleToolResponse<CveData> listApplicationsByCve(
       @ToolParam(description = "CVE identifier (e.g., CVE-2021-44228)") String cveId,

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
@@ -67,8 +67,8 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
           library were seen loaded, so exploitation is unlikely; prioritize applications with
           classUsage above 0. Use list_application_libraries for the reverse direction, all
           libraries of one application. lastSeen of 0 means the application has never been observed
-          running, typically a static or SCA-only upload. Application and server status reflect
-          last-known agent reports and can lag live status; search_servers is fresher for current
+          running, typically a static or SCA-only upload. lastSeen and server status reflect
+          last-known agent reports and can lag live state; search_servers is fresher for current
           server state.
           """)
   public SingleToolResponse<CveData> listApplicationsByCve(

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolTest.java
@@ -163,6 +163,39 @@ class SearchApplicationsToolTest {
   }
 
   @Test
+  void searchApplications_should_notice_never_observed_apps_when_lastSeen_is_zero()
+      throws Exception {
+    var neverObserved = createAppWithMetadata("Static", "environment", "prod");
+    neverObserved.setLastSeen(0L);
+    var running = createAppWithMetadata("Orders", "environment", "prod");
+    when(contrastApiClient.searchApplications(isNull(), isNull(), isNull(), eq(10), eq(0)))
+        .thenReturn(createResponse(List.of(neverObserved, running), 2));
+
+    var result = tool.searchApplications(1, 10, null, null, null, null);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.notices())
+        .contains(
+            "lastSeenAt at the 1970 Unix epoch means the application has never been observed"
+                + " running, typically a static or SCA-only upload: Static");
+  }
+
+  @Test
+  void searchApplications_should_not_notice_never_observed_apps_when_lastSeen_is_populated_or_null()
+      throws Exception {
+    var running = createAppWithMetadata("Orders", "environment", "prod");
+    var neverReported = createAppWithMetadata("Legacy", "environment", "prod");
+    neverReported.setLastSeen(null);
+    when(contrastApiClient.searchApplications(isNull(), isNull(), isNull(), eq(10), eq(0)))
+        .thenReturn(createResponse(List.of(running, neverReported), 2));
+
+    var result = tool.searchApplications(1, 10, null, null, null, null);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.notices()).noneMatch(n -> n.contains("never been observed running"));
+  }
+
+  @Test
   void searchApplications_should_map_downstream_403_without_exposing_response_body()
       throws Exception {
     when(contrastApiClient.searchApplications(isNull(), isNull(), isNull(), eq(10), eq(0)))

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
@@ -50,6 +50,10 @@ class ListApplicationsByCveToolTest {
   private static final String SECRET_BODY = "token=raw-token-value&apiKey=secret";
   private static final String CVSS_V2_NOTICE =
       "score is omitted for CVEs with only CVSS v2 data; use severity and the cvssv2 metrics.";
+  private static final long LAST_SEEN_MILLIS = 1721000000000L;
+  private static final String NEVER_OBSERVED_NOTICE_PREFIX =
+      "lastSeen of 0 means the application has never been observed running, typically a static or"
+          + " SCA-only upload: ";
   private static final String CVSS_V3_CVE_RESPONSE =
       """
       {
@@ -301,6 +305,40 @@ class ListApplicationsByCveToolTest {
   }
 
   @Test
+  void listApplicationsByCve_should_notice_never_observed_apps_when_lastSeen_is_zero()
+      throws Exception {
+    var neverObserved = app("StaticUpload", "app-static");
+    neverObserved.setLastSeen(0);
+    var running = app("Orders", APP_ID);
+    var cveData = new CveData();
+    cveData.setApps(List.of(neverObserved, running));
+    cveData.setLibraries(List.of(vulnerableLibrary(LIBRARY_HASH)));
+
+    when(contrastApiClient.getApplicationsByCve(eq(CVE_ID))).thenReturn(cveData);
+    when(contrastApiClient.getAllLibraries(eq("app-static"))).thenReturn(List.of());
+    when(contrastApiClient.getAllLibraries(eq(APP_ID))).thenReturn(List.of());
+
+    var result = tool.listApplicationsByCve(CVE_ID, null);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.notices()).contains(NEVER_OBSERVED_NOTICE_PREFIX + "StaticUpload");
+  }
+
+  @Test
+  void listApplicationsByCve_should_not_notice_never_observed_apps_when_lastSeen_is_populated()
+      throws Exception {
+    var cveData = cveData(app("Orders", APP_ID), vulnerableLibrary(LIBRARY_HASH));
+
+    when(contrastApiClient.getApplicationsByCve(eq(CVE_ID))).thenReturn(cveData);
+    when(contrastApiClient.getAllLibraries(eq(APP_ID))).thenReturn(List.of());
+
+    var result = tool.listApplicationsByCve(CVE_ID, null);
+
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.notices()).noneMatch(n -> n.contains("never been observed running"));
+  }
+
+  @Test
   void listApplicationsByCve_should_dedupe_top_level_servers_by_server_id() throws Exception {
     var cveData = cveData(app("Orders", APP_ID), vulnerableLibrary(LIBRARY_HASH));
     cveData.setServers(
@@ -482,6 +520,7 @@ class ListApplicationsByCveToolTest {
     var app = new App();
     app.setName(name);
     app.setAppId(appId);
+    app.setLastSeen(LAST_SEEN_MILLIS);
     return app;
   }
 


### PR DESCRIPTION
## Summary

AI agents misread two things in the `list_applications_by_cve` response:

1. **lastSeen of 0** - Agents treat this as January 1970 or missing data. It actually means the application has never been observed running (typically a static or SCA-only upload). TeamServer sends 0 for these, and the field is a primitive long, so 0 always serializes.

2. **Server status staleness** - An agent reported "all 20 servers are OFFLINE" from this tool while `search_servers` showed one of them online. The status in this response is TeamServer's last-known state and can lag.

## What changed

**list_applications_by_cve**
- The tool now emits a notice naming the affected applications when any app in the response has `lastSeen` of 0. The notice only appears when the condition is present, following the MCP_STANDARDS.md rule that conditional quirks belong in notices, not the description body.
- The tool description now notes that `lastSeen` and server status reflect last-known agent reports and can lag live state, pointing agents to `search_servers` for fresher data.

**search_applications**
- The same lastSeen=0 sentinel exists here too, rendered even worse as a 1970 epoch date in `lastSeenAt`. The tool now emits the same conditional notice for affected applications.

Both tools already used `collector.notice()` for other conditional facts (CVSS v2 scores, empty results), so this follows the established pattern.

## Test plan

- [x] Unit tests for the new notices in both tools (positive and negative cases)
- [x] `make check-test` passes (1082 tests, 0 failures, all coverage floors met)
- [x] `make verify` passes for both changed tools (pre-existing failures in two unrelated tools are data-dependent against the live org)

Stacked on #207 (AIML-1329). Ships together in one core release plus a pin bump in aiml-services.