### PR TITLE
AIML-1239 Add PIT mutation testing to contrast-mcp-core

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
 
     # Runs even when the coverage floor fails, since that is exactly when the
     # numbers and the HTML report are needed to diagnose the failure. coverageSummary
-    # only reads the reports the step above wrote, so this does not re-run the tests;
+    # only reads the reports the coverage step wrote, so this does not re-run the tests;
     # if that step failed before producing them, the table says so per module. !cancelled()
     # rather than always(), so cancelling the workflow actually stops it.
     - name: Publish coverage summary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,10 @@ jobs:
         -PjacocoChangedBase="$BASE_SHA"
         --no-daemon
 
+    - name: Run mutation testing
+      if: github.event_name == 'pull_request'
+      run: ./gradlew :contrast-mcp-core:pitest --no-daemon
+
     # Runs even when the coverage floor fails, since that is exactly when the
     # numbers and the HTML report are needed to diagnose the failure. coverageSummary
     # only reads the reports the step above wrote, so this does not re-run the tests;
@@ -70,10 +74,11 @@ jobs:
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: jacoco-coverage-reports
+        name: test-reports
         path: |
           **/build/reports/jacoco/test/html/**
           **/build/reports/jacoco/test/jacocoTestReport.xml
+          **/build/reports/pitest/**
         if-no-files-found: warn
         # Diagnostic output for a failed run, not a durable artifact.
         retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ make test-coverage                 # Unit tests plus coverage floors in one grad
 make coverage-changed              # Changed src/main/java files must meet the changed-file floor
 make coverage-changed BASE=origin/main   # Compare against a ref instead of the working tree
 make buildsrc-check                # Static analysis, tests and coverage for buildSrc
+make mutation                       # PIT mutation testing on contrast-mcp-core
 make install-hooks                 # Install the pre-push hook (backs up any hook it replaces)
 
 # Verbose output when debugging failures
@@ -69,12 +70,15 @@ make coverage VERBOSE=1
 - **Coverage**: `./gradlew jacocoTestCoverageVerification coverageSummary`
 - **Changed-file coverage**: `./gradlew jacocoChangedFileCoverageVerification -PjacocoChangedBase=origin/main`
 - **Core publication metadata**: `./gradlew :contrast-mcp-core:verifyCorePublicationMetadata`
+- **Mutation testing**: `./gradlew :contrast-mcp-core:pitest`
 - **Format code**: `./gradlew spotlessApply`
 - **Run locally**: `java -jar contrast-mcp-stdio-app/build/libs/mcp-contrast-*.jar --CONTRAST_HOST_NAME=<host> --CONTRAST_API_KEY=<key> --CONTRAST_SERVICE_KEY=<key> --CONTRAST_USERNAME=<user> --CONTRAST_ORG_ID=<org>`
 
 **Note:** `make check` auto-formats before checking — no separate `make format` step needed. `make check-test` is the standard local verification command for static analysis, unit tests, and coverage.
 
 **Coverage floors:** Per-module minimums live in `ext.coverageMinimums` in the root `build.gradle` and are enforced by `jacocoTestCoverageVerification`, which `check` depends on. Floors sit a couple of points under the measured figures on purpose, so one new uncovered branch cannot redden `main`. Raise a floor as coverage improves; never lower one to make a build pass. `verifyCoverageMinimums` fails the build if any floor drops below `ext.coverageStandardMinimum` (85%). `McpContrastApplication` is the only class excluded.
+
+**Mutation testing:** PIT runs against `contrast-mcp-core` via the `info.solidsoft.pitest` Gradle plugin. It gates on test strength (killed / (killed + survived)), not mutation score, so it measures test quality independent of JaCoCo coverage. The `testStrengthThreshold` floor lives in `contrast-mcp-core/build.gradle` and is enforced in CI on pull requests. Raise the floor as survivors get fixed, never lower it. `lombok.config` at the repo root enables `@lombok.Generated` so both PIT and JaCoCo skip Lombok-generated code.
 
 **Changed-file coverage:** `ext.changedFileCoverageMinimum` (85%) is enforced per changed `src/main/java` file by `jacocoChangedFileCoverageVerification`. Runs in CI on every pull request regardless of base branch, so stacked PRs are gated too, plus the pre-push hook (`make install-hooks`, bypass with `SKIP_COVERAGE_HOOK=1`) and `make coverage-changed`. The hook warns but still runs when dirty source, build, or resource files could change JaCoCo output; pull-request CI remains authoritative because it tests a clean checkout. Unrelated changes such as Markdown files do not warn. Set `COVERAGE_BASE_REF=origin/<parent>` on the first push of a new stacked branch. Not wired into `check`, which has no base ref to diff against. Logic lives in `buildSrc/`, which has its own checks via `make buildsrc-check`. See `scripts/git-hooks/README.md`.
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GRADLE ?= ./gradlew
 
-.PHONY: help build test test-verbose check check-verbose check-test buildsrc-check buildsrc-check-verbose coverage coverage-verbose coverage-changed coverage-changed-verbose test-coverage test-coverage-verbose install-hooks format clean verify verify-verbose
+.PHONY: help build test test-verbose check check-verbose check-test buildsrc-check buildsrc-check-verbose coverage coverage-verbose coverage-changed coverage-changed-verbose test-coverage test-coverage-verbose mutation mutation-verbose install-hooks format clean verify verify-verbose
 
 help: ## Display available make targets
 	@awk 'BEGIN {FS=":.*##"; printf "\nUsage: make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_\-]+:.*##/ {printf "  %-12s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -150,6 +150,23 @@ check-test: ## Run all checks, tests, and coverage
 	@$(MAKE) check
 	@$(MAKE) buildsrc-check
 	@$(MAKE) test-coverage
+
+## Mutation testing
+
+mutation: ## Run PIT mutation testing on contrast-mcp-core
+	@if [ -n "$$VERBOSE" ]; then \
+		$(GRADLE) :contrast-mcp-core:pitest; \
+	else \
+		$(MAKE) mutation-quiet; \
+	fi
+
+mutation-quiet:
+	@. ./hack/run_silent.sh && print_main_header "Running Mutation Tests"
+	@. ./hack/run_silent.sh && print_header "contrast-mcp-core" "PIT mutation testing"
+	@. ./hack/run_silent.sh && run_with_quiet "Mutation test strength floor met" "$(GRADLE) :contrast-mcp-core:pitest"
+
+mutation-verbose: ## Run mutation testing with verbose output
+	@VERBOSE=1 $(MAKE) mutation
 
 ## Other targets
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -106,7 +106,7 @@ test -f contrast-mcp-stdio-app/build/libs/mcp-contrast-X.Y.Z.jar
 
 Then create a GitHub release for the tag and attach `contrast-mcp-stdio-app/build/libs/mcp-contrast-X.Y.Z.jar`. Note that these manual instructions do not publish to Artifactory, sign the Docker image, generate SBOMs, or create attestations. Use the workflow whenever possible.
 
-**Coverage gate:** `check` runs `jacocoTestCoverageVerification`, so a release aborts if either module falls below its floor in `ext.coverageMinimums`. Because releases only run from `main`, and the same task and floors already gated the commit in `build.yml`, this should not fire in practice. If it does, run `make coverage` locally for the per-module numbers, or read the `jacoco-coverage-reports` artifact from that commit's build run.
+**Coverage gate:** `check` runs `jacocoTestCoverageVerification`, so a release aborts if either module falls below its floor in `ext.coverageMinimums`. Because releases only run from `main`, and the same task and floors already gated the commit in `build.yml`, this should not fire in practice. If it does, run `make coverage` locally for the per-module numbers, or read the `test-reports` artifact (JaCoCo coverage plus PIT mutation reports) from that commit's build run.
 
 ## Verify the Release
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'pl.allegro.tech.build.axion-release' version "${axionReleasePluginVersion}"
     id 'com.diffplug.spotless' version "${spotlessGradlePluginVersion}" apply false
     id 'org.springframework.boot' version "${springBootVersion}" apply false
+    id 'info.solidsoft.pitest' version "${pitestGradlePluginVersion}" apply false
 }
 
 scmVersion {

--- a/contrast-mcp-core/build.gradle
+++ b/contrast-mcp-core/build.gradle
@@ -7,6 +7,7 @@ import javax.xml.xpath.XPathFactory
 plugins {
     id 'maven-publish'
     id 'signing'
+    id 'info.solidsoft.pitest'
 }
 
 dependencies {
@@ -165,6 +166,19 @@ tasks.register('verifyCorePublicationMetadata') {
 }
 
 check.dependsOn tasks.named('verifyCorePublicationMetadata')
+
+// Mutation testing via PIT. Measured 2026-08-08 with PIT 1.25.8: 868 mutants, 792 killed,
+// test strength 94%. Floor set a few points under, matching the coverageMinimums convention.
+pitest {
+    pitestVersion = pitestCoreVersion
+    junit5PluginVersion = pitestJunit5PluginVersion
+    targetClasses = ['com.contrast.labs.ai.mcp.contrast.*']
+    targetTests = ['com.contrast.labs.ai.mcp.contrast.*']
+    testStrengthThreshold = 91
+    outputFormats = ['HTML', 'XML']
+    timestampedReports = false
+    threads = Runtime.runtime.availableProcessors()
+}
 
 String mcpCoreArtifactProperty(String name) {
     def propertiesFile = rootProject.file('gradle/contrast-mcp-core-artifact.properties')

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelper.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelper.java
@@ -99,10 +99,11 @@ public class FilterHelper {
    * @param dateStr Date string in ISO format or epoch timestamp
    * @param paramName Parameter name for error messages (e.g., "lastSeenAfter")
    * @return ParseResult with Date object and optional validation message
-   * @example parseDate("2025-01-15", "lastSeenAfter") → ParseResult(Date, null)
-   * @example parseDate("1704067200000", "lastSeenAfter") → ParseResult(Date, null)
-   * @example parseDate("invalid", "lastSeenAfter") → ParseResult(null, "Invalid date...")
-   * @example parseDate(null, "lastSeenAfter") → ParseResult(null, null)
+   * @example parseDateWithValidation("2025-01-15", "lastSeenAfter") → ParseResult(Date, null)
+   * @example parseDateWithValidation("1704067200000", "lastSeenAfter") → ParseResult(Date, null)
+   * @example parseDateWithValidation("invalid", "lastSeenAfter") → ParseResult(null, "Invalid
+   *     date...")
+   * @example parseDateWithValidation(null, "lastSeenAfter") → ParseResult(null, null)
    */
   public static ParseResult<Date> parseDateWithValidation(String dateStr, String paramName) {
     if (!StringUtils.hasText(dateStr)) {
@@ -192,14 +193,6 @@ public class FilterHelper {
   }
 
   /**
-   * Parse date string (legacy method for backward compatibility). Use parseDateWithValidation() for
-   * new code to get validation messages.
-   */
-  public static Date parseDate(String dateStr) {
-    return parseDateWithValidation(dateStr, "date").getValue();
-  }
-
-  /**
    * Parse comma-separated list and convert to case-insensitive list. Useful for status, severity,
    * and other case-insensitive filters.
    *
@@ -213,22 +206,6 @@ public class FilterHelper {
       return null;
     }
     return parsed.stream().map(String::toUpperCase).toList();
-  }
-
-  /**
-   * Parse comma-separated list and convert to lowercase list. Useful for vulnerability types and
-   * other lowercase filters.
-   *
-   * @param input Comma-separated string
-   * @return List of trimmed, lowercase strings, or null if input is null/empty
-   * @example parseCommaSeparatedLowerCase("SQL-Injection, XSS") → ["sql-injection", "xss"]
-   */
-  public static List<String> parseCommaSeparatedLowerCase(String input) {
-    List<String> parsed = parseCommaSeparated(input);
-    if (parsed == null) {
-      return null;
-    }
-    return parsed.stream().map(String::toLowerCase).toList();
   }
 
   /**

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelper.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelper.java
@@ -93,8 +93,9 @@ public class FilterHelper {
 
   /**
    * Parse date string in ISO format (YYYY-MM-DD) or epoch timestamp (milliseconds). Tries epoch
-   * timestamp first, then falls back to ISO date format. Returns validation message if format is
-   * invalid.
+   * timestamp first, then falls back to ISO date format. Epoch timestamps outside the supported
+   * range (1970-01-01 through 9999-12-31 in millis) are rejected. Returns validation message if
+   * format is invalid.
    *
    * @param dateStr Date string in ISO format or epoch timestamp
    * @param paramName Parameter name for error messages (e.g., "lastSeenAfter")
@@ -112,6 +113,9 @@ public class FilterHelper {
     try {
       // Try parsing as epoch timestamp first
       long timestamp = Long.parseLong(dateStr.trim());
+      if (!isSupportedTimestampMillis(timestamp)) {
+        return invalidDateResult(dateStr, paramName);
+      }
       return new ParseResult<>(new Date(timestamp));
     } catch (NumberFormatException e) {
       // Try ISO date format
@@ -120,15 +124,19 @@ public class FilterHelper {
         Date parsed = Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
         return new ParseResult<>(parsed);
       } catch (DateTimeParseException ex) {
-        String message =
-            String.format(
-                "Invalid %s date '%s'. Expected ISO format (YYYY-MM-DD) like '2025-01-15' or epoch"
-                    + " timestamp like '1705276800000'.",
-                paramName, sanitizeForMessage(dateStr));
-        log.warn(message);
-        return new ParseResult<>(null, message);
+        return invalidDateResult(dateStr, paramName);
       }
     }
+  }
+
+  private static ParseResult<Date> invalidDateResult(String dateStr, String paramName) {
+    String message =
+        String.format(
+            "Invalid %s date '%s'. Expected ISO format (YYYY-MM-DD) like '2025-01-15' or epoch"
+                + " timestamp between %d and %d millis like '1705276800000'.",
+            paramName, sanitizeForMessage(dateStr), MIN_EPOCH_MILLIS, MAX_EPOCH_MILLIS);
+    log.warn(message);
+    return new ParseResult<>(null, message);
   }
 
   /**

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelperTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelperTest.java
@@ -178,6 +178,45 @@ class FilterHelperTest {
         .matches("[+-]\\d{2}:\\d{2}");
   }
 
+  private static final long MIN_EPOCH_MILLIS = 0L;
+  private static final long MAX_EPOCH_MILLIS = 253402300799999L;
+  private static final long ONE_PAST_MAX_EPOCH_MILLIS = 253402300800000L;
+
+  @Test
+  void parseTimestampWithValidation_should_accept_min_epoch_boundary() {
+    var result = FilterHelper.parseTimestampWithValidation(String.valueOf(MIN_EPOCH_MILLIS), "ts");
+
+    assertThat(result.getValue()).isNotNull();
+    assertThat(result.hasValidationMessage()).isFalse();
+  }
+
+  @Test
+  void parseTimestampWithValidation_should_reject_below_min_epoch_boundary() {
+    var result = FilterHelper.parseTimestampWithValidation("-1", "ts");
+
+    assertThat(result.getValue()).isNull();
+    assertThat(result.hasValidationMessage()).isTrue();
+    assertThat(result.getValidationMessage()).contains("Invalid");
+  }
+
+  @Test
+  void parseTimestampWithValidation_should_accept_max_epoch_boundary() {
+    var result = FilterHelper.parseTimestampWithValidation(String.valueOf(MAX_EPOCH_MILLIS), "ts");
+
+    assertThat(result.getValue()).isNotNull();
+    assertThat(result.hasValidationMessage()).isFalse();
+  }
+
+  @Test
+  void parseTimestampWithValidation_should_reject_above_max_epoch_boundary() {
+    var result =
+        FilterHelper.parseTimestampWithValidation(String.valueOf(ONE_PAST_MAX_EPOCH_MILLIS), "ts");
+
+    assertThat(result.getValue()).isNull();
+    assertThat(result.hasValidationMessage()).isTrue();
+    assertThat(result.getValidationMessage()).contains("Invalid");
+  }
+
   @Test
   void testFormatTimestamp_ConsistentFormat() {
     // Given: Multiple different timestamps

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelperTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelperTest.java
@@ -22,6 +22,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import org.junit.jupiter.api.Test;
 
 /** Test suite for FilterHelper utility methods, focusing on timestamp formatting. */
@@ -45,6 +46,11 @@ class FilterHelperTest {
       LocalDateTime.of(2017, 7, 14, 2, 40)
           .toInstant(ZoneOffset.UTC)
           .toEpochMilli(); // 1500000000000L
+
+  // Must stay in sync with FilterHelper's private MIN_EPOCH_MILLIS / MAX_EPOCH_MILLIS.
+  private static final long MIN_EPOCH_MILLIS = 0L;
+  private static final long MAX_EPOCH_MILLIS = 253402300799999L;
+  private static final long ONE_PAST_MAX_EPOCH_MILLIS = 253402300800000L;
 
   @Test
   void testFormatTimestamp_ValidTimestamp() {
@@ -178,15 +184,11 @@ class FilterHelperTest {
         .matches("[+-]\\d{2}:\\d{2}");
   }
 
-  private static final long MIN_EPOCH_MILLIS = 0L;
-  private static final long MAX_EPOCH_MILLIS = 253402300799999L;
-  private static final long ONE_PAST_MAX_EPOCH_MILLIS = 253402300800000L;
-
   @Test
   void parseTimestampWithValidation_should_accept_min_epoch_boundary() {
     var result = FilterHelper.parseTimestampWithValidation(String.valueOf(MIN_EPOCH_MILLIS), "ts");
 
-    assertThat(result.getValue()).isNotNull();
+    assertThat(result.getValue()).isEqualTo(new Date(MIN_EPOCH_MILLIS));
     assertThat(result.hasValidationMessage()).isFalse();
   }
 
@@ -196,14 +198,16 @@ class FilterHelperTest {
 
     assertThat(result.getValue()).isNull();
     assertThat(result.hasValidationMessage()).isTrue();
-    assertThat(result.getValidationMessage()).contains("Invalid");
+    assertThat(result.getValidationMessage())
+        .contains("Invalid ts timestamp")
+        .contains("between " + MIN_EPOCH_MILLIS + " and " + MAX_EPOCH_MILLIS);
   }
 
   @Test
   void parseTimestampWithValidation_should_accept_max_epoch_boundary() {
     var result = FilterHelper.parseTimestampWithValidation(String.valueOf(MAX_EPOCH_MILLIS), "ts");
 
-    assertThat(result.getValue()).isNotNull();
+    assertThat(result.getValue()).isEqualTo(new Date(MAX_EPOCH_MILLIS));
     assertThat(result.hasValidationMessage()).isFalse();
   }
 
@@ -214,7 +218,48 @@ class FilterHelperTest {
 
     assertThat(result.getValue()).isNull();
     assertThat(result.hasValidationMessage()).isTrue();
-    assertThat(result.getValidationMessage()).contains("Invalid");
+    assertThat(result.getValidationMessage())
+        .contains("Invalid ts timestamp")
+        .contains("between " + MIN_EPOCH_MILLIS + " and " + MAX_EPOCH_MILLIS);
+  }
+
+  @Test
+  void parseDateWithValidation_should_accept_min_epoch_boundary() {
+    var result = FilterHelper.parseDateWithValidation(String.valueOf(MIN_EPOCH_MILLIS), "lastSeen");
+
+    assertThat(result.getValue()).isEqualTo(new Date(MIN_EPOCH_MILLIS));
+    assertThat(result.hasValidationMessage()).isFalse();
+  }
+
+  @Test
+  void parseDateWithValidation_should_reject_below_min_epoch_boundary() {
+    var result = FilterHelper.parseDateWithValidation("-1", "lastSeen");
+
+    assertThat(result.getValue()).isNull();
+    assertThat(result.hasValidationMessage()).isTrue();
+    assertThat(result.getValidationMessage())
+        .contains("Invalid lastSeen date")
+        .contains("between " + MIN_EPOCH_MILLIS + " and " + MAX_EPOCH_MILLIS);
+  }
+
+  @Test
+  void parseDateWithValidation_should_accept_max_epoch_boundary() {
+    var result = FilterHelper.parseDateWithValidation(String.valueOf(MAX_EPOCH_MILLIS), "lastSeen");
+
+    assertThat(result.getValue()).isEqualTo(new Date(MAX_EPOCH_MILLIS));
+    assertThat(result.hasValidationMessage()).isFalse();
+  }
+
+  @Test
+  void parseDateWithValidation_should_reject_above_max_epoch_boundary() {
+    var result =
+        FilterHelper.parseDateWithValidation(String.valueOf(ONE_PAST_MAX_EPOCH_MILLIS), "lastSeen");
+
+    assertThat(result.getValue()).isNull();
+    assertThat(result.hasValidationMessage()).isTrue();
+    assertThat(result.getValidationMessage())
+        .contains("Invalid lastSeen date")
+        .contains("between " + MIN_EPOCH_MILLIS + " and " + MAX_EPOCH_MILLIS);
   }
 
   @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,6 @@ jacocoVersion=0.8.15
 # Shared by module floors, changed-file coverage, and the separate buildSrc build.
 coverageStandardMinimum=0.85
 lombokVersion=1.18.38
+pitestGradlePluginVersion=1.19.0
+pitestCoreVersion=1.25.8
+pitestJunit5PluginVersion=1.2.3

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
<!-- pr-tools:stacked:v1 -->
<!-- pr-tools:parent-pr=208 -->
<!-- pr-tools:parent-branch=AIML-1331-document-lastSeen-zero-sentinel -->
<!-- pr-tools:parent-base=AIML-1329-list-applications-by-cve-error-mapping -->
<!-- pr-tools:boundary-commit=741a9dab163e723a8dcb36808a26e4bcf910a6e4 -->
<!-- pr-tools:managed:start -->
<!-- pr-tools:managed:end -->

**Jira:** [AIML-1239](https://contrast.atlassian.net/browse/AIML-1239)

## Summary
Add PIT mutation testing to contrast-mcp-core so the build catches tests that run code without verifying behavior, a class of defect that line-coverage gates cannot detect.

- Test-strength floor of 91% enforced in CI on every pull request (measured 94%)
- Lombok-generated code excluded from both PIT and JaCoCo via `@lombok.Generated`
- Two FilterHelper boundary mutants killed, two dead-code methods removed

## Why This Change Exists
In November 2025, an always-true assertion (`caughtException || true`) shipped through code review and CI. JaCoCo reported the line as covered because the test executed it. PIT would have flagged it instantly because mutating the production code under that assertion would not flip the test result. This PR wires PIT into the build so that class of problem is caught mechanically going forward.

## Approach
Gate on test strength rather than mutation score. Test strength is killed/(killed+survived), which excludes NO_COVERAGE mutants. That isolates test quality from coverage quantity and avoids double-counting what JaCoCo already enforces. The floor sits a few points under the measured figure, matching the `coverageMinimums` convention.

The Gradle plugin (`info.solidsoft.pitest` 1.19.0) is declared in the root `build.gradle` with `apply false` and applied only in `contrast-mcp-core`. All dependency versions live in `gradle.properties` and pass the 7-day soak window (pitest 1.25.9 was excluded at 4 days old).

## What Changed
### Build infrastructure
- `build.gradle` — pitest plugin declared with `apply false`
- `contrast-mcp-core/build.gradle` — plugin applied, configured with `testStrengthThreshold = 91`, dated baseline comment
- `gradle.properties` — `pitestGradlePluginVersion`, `pitestCoreVersion`, `pitestJunit5PluginVersion`
- `lombok.config` (new) — `lombok.addLombokGeneratedAnnotation = true` and `config.stopBubbling = true`

### CI and developer workflow
- `.github/workflows/build.yml` — mutation testing step on pull requests, PIT reports added to artifact upload
- `Makefile` — `make mutation` target (quiet/verbose pattern)
- `CLAUDE.md` — mutation testing documented in build commands and coverage sections

### Test fixes and dead code removal
- `FilterHelperTest.java` — four boundary tests for `isSupportedTimestampMillis` at `MIN_EPOCH_MILLIS` (0), `MAX_EPOCH_MILLIS` (253402300799999), and one past each boundary
- `FilterHelper.java` — removed `parseDate` and `parseCommaSeparatedLowerCase` (zero callers across all Contrast repos, verified via `gh search code`). Fixed javadoc `@example` references to the removed method. **This is a breaking API change** to the published `contrast-mcp-core` artifact for any external consumer that calls these methods.

## Testing
- `make check-test` passes (1080 tests, 0 failures)
- `make mutation` passes (868 mutants, 792 killed, test strength 94%)
- Gate failure verified: setting `testStrengthThreshold = 99` produces `BUILD FAILED` with `Test strength score of 94 is below threshold of 99`
- Four new boundary tests kill the two `ConditionalsBoundaryMutator` survivors on `FilterHelper.isSupportedTimestampMillis`
- Two pre-existing integration test failures on main (`SearchAttacksToolIT`, `ListApplicationLibrariesToolIT`) are data-dependent and unrelated

## Risks / Rollout / Follow-ups
- **API break:** `FilterHelper.parseDate` and `parseCommaSeparatedLowerCase` were removed from the published core module. Zero callers exist in any Contrast repo (verified org-wide), but external consumers of `contrast-mcp-core` could break.
- **Equivalent mutants:** 7 of the 52 survivors in `MetadataJsonFilterSpec` are equivalent mutants (error-path `return null` preceded by `invalidEntries.add()`). The mutation is externally unobservable through the public `get()` API. These permanently cap achievable test strength for those sites and cannot be fixed without testing private implementation details.
- **Follow-up:** PIT supports incremental analysis through history files, which could speed up a PR-scoped gate that only re-tests changed code.


[AIML-1239]: https://contrast.atlassian.net/browse/AIML-1239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ