### PR TITLE
AIML-1349 Release v2.4.0 changelog and error message fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **`list_applications_by_cve` no longer returns misleading error for unrecognized CVEs**: When
 the upstream endpoint returned HTTP 500 for CVEs unknown to the SCA library data, the tool
 returned a generic "Narrow filters or reduce page size" message that made no sense for a tool
-with neither filters nor pagination. It now explains that the CVE may exist only in NorthStar
-CVE Shield data and suggests `search_cves` or `get_cve_impact` as alternatives.
+with neither filters nor pagination. It now explains that the CVE may not be recognized by the
+SCA library data and suggests verifying the CVE identifier.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-08-10
+
 ### Bug Fixes
 
 **`list_applications_by_cve` no longer returns misleading error for unrecognized CVEs**: When

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+**`list_applications_by_cve` no longer returns misleading error for unrecognized CVEs**: When
+the upstream endpoint returned HTTP 500 for CVEs unknown to the SCA library data, the tool
+returned a generic "Narrow filters or reduce page size" message that made no sense for a tool
+with neither filters nor pagination. It now explains that the CVE may exist only in NorthStar
+CVE Shield data and suggests `search_cves` or `get_cve_impact` as alternatives.
+
+### Improvements
+
+**`list_applications_by_cve` and `search_applications` explain lastSeen-zero applications**:
+When any application in the response has a `lastSeen` value of 0, the tool now emits a notice
+explaining that the application has never been observed running, typically a static or SCA-only
+upload. Previously agents misread the zero timestamp as January 1970 or missing data.
+
+**`list_applications_by_cve` notes that server status can lag live state**: The tool description
+now explains that `lastSeen` and server status reflect last-known agent reports and may not match
+current state, directing agents to `search_servers` for fresher data.
+
+**Date parameters now reject out-of-range values with actionable messages**: Tools that accept
+date filters now reject epoch timestamps outside the supported range (1970-01-01 through
+9999-12-31) and return validation errors that include the valid range bounds. Previously,
+negative or far-future timestamps were silently accepted.
+
 ## [2.3.0] - 2026-08-07
 
 ### Improvements

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,8 +196,9 @@ EOF
 
 **All MCP tool development MUST follow the standards defined in [MCP_STANDARDS.md](./MCP_STANDARDS.md).**
 
+**Read MCP_STANDARDS.md before any tool change.** This includes new tools, renamed tools, modified descriptions, error messages, notices, parameter changes, and response shape changes. The standards govern cross-server constraints (e.g., core tools must never reference hosted-only tools) that are not obvious from the code alone.
+
 When creating or modifying MCP tools:
-- Read MCP_STANDARDS.md for complete naming and design standards
 - Use `action_entity` naming convention (e.g., `search_vulnerabilities`, `get_vulnerability`)
 - Follow verb hierarchy: `search_*` (flexible filtering) > `list_*` (scoped) > `get_*` (single item)
 - Use camelCase for parameters, snake_case for tool names

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
@@ -52,9 +52,9 @@ public class ListApplicationsByCveTool extends SingleTool<ListApplicationsByCveP
 
   private static final int HTTP_INTERNAL_SERVER_ERROR = 500;
   private static final String INTERNAL_SERVER_ERROR_MESSAGE =
-      "The service returned an error. This happens for CVEs the SCA library data does not"
-          + " recognize, including CVEs that exist only in NorthStar CVE Shield data. Verify the"
-          + " CVE with search_cves or get_cve_impact, or retry later if the service is failing.";
+      "The service returned an error. This typically happens for CVEs that the SCA library data"
+          + " does not recognize. Verify the CVE identifier is correct and retry later if the"
+          + " service is failing.";
 
   private final ContrastApiClient contrastApiClient;
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
@@ -446,7 +446,7 @@ class ListApplicationsByCveToolTest {
   }
 
   @Test
-  void listApplicationsByCve_should_map_downstream_500_with_cve_shield_guidance() throws Exception {
+  void listApplicationsByCve_should_map_downstream_500_with_sca_guidance() throws Exception {
     when(contrastApiClient.getApplicationsByCve(eq(CVE_ID)))
         .thenThrow(
             new HttpResponseException(
@@ -462,10 +462,9 @@ class ListApplicationsByCveToolTest {
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors())
         .containsExactly(
-            "The service returned an error. This happens for CVEs the SCA library data does not"
-                + " recognize, including CVEs that exist only in NorthStar CVE Shield data."
-                + " Verify the CVE with search_cves or get_cve_impact, or retry later if the"
-                + " service is failing.");
+            "The service returned an error. This typically happens for CVEs that the SCA library"
+                + " data does not recognize. Verify the CVE identifier is correct and retry later"
+                + " if the service is failing.");
     assertThat(result.toString()).doesNotContain(SECRET_BODY, "/ng/org/libraries/cve");
   }
 


### PR DESCRIPTION
## Summary

- Bring `[Unreleased]` in CHANGELOG.md up to date with all user-facing changes merged since v2.3.0, stamped as v2.4.0
- Fix the `list_applications_by_cve` HTTP 500 error message, which referenced `search_cves` and `get_cve_impact`. Those tools exist only in the hosted MCP server (aiml-services). The `contrast-mcp-core` library is shared between both servers, and the stdio server has no access to hosted-only tools. An agent receiving this error from the stdio server would try to call nonexistent tools and fail. The message also referenced "NorthStar CVE Shield data," which is a hosted-server concept that does not apply to stdio users connecting to TeamServer Classic. The corrected message explains the SCA library data limitation without referencing tools or concepts that may not be available to the caller.

## Test plan

- [x] Changelog follows house style
- [x] Only user-facing changes are documented
- [x] Error message no longer references hosted-server tools
- [x] `make check-test` passes (1100 tests, 0 failures)
- [x] Changed-file coverage gate passes