### PR TITLE
AIML-1352 Document vulnerability status filters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,7 @@ When creating or modifying MCP tools:
 **Testing:**
 - Simplified `mock()`: `ClassName mock = mock()` not `mock(ClassName.class)` — when `mock(X.class)` appears as a method argument (not an assignment), extract to a typed local first: `Foo x = mock(); when(x.method())...`
 - AssertJ fluent: `assertThat(x).isEqualTo(y)` not `assertEquals(y, x)`
+- **Share contract text with tests:** Define exact descriptions, notices, errors, and other long contract text once in a production constant, then reference that constant from both production code and tests. Never duplicate or reconstruct the full text in test expectations.
 - Naming: `methodName_should_expectedBehavior_when_condition()` — body must verify the behavior the name promises. If assertions don't match the name, strengthen the assertions. Do **not** delete or weaken the name.
 - Example: `getVulnerability_should_return_data_when_valid_id()`
 - **Anonymous builders**: Use `AnonymousXxxBuilder` pattern for complex mocks (see `AnonymousApplicationBuilder.java`)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,17 @@
+# Contrast MCP Server
+
+Glossary for the mcp-contrast repository. Tool contracts, docs, and code must use these terms consistently.
+
+## Language
+
+**Vulnerability status**:
+One of seven canonical filter values on the legacy TeamServer vulnerability model. The values are Reported, Suspicious, Confirmed, NotAProblem, Remediated, Fixed, and AutoRemediated. `ValidationConstants.VALID_VULN_STATUSES_CSV` is the source of truth for documentation and validation.
+_Avoid_: Issue Status, trace status
+
+**Issue Status**:
+The NorthStar status vocabulary on Issue entities. The values are REPORTED, CONFIRMED, REMEDIATED, NOT_A_PROBLEM, and FIXED. Suspicious and AutoRemediated exist only as Vulnerability statuses, never as Issue Statuses.
+_Avoid_: using this term for legacy Vulnerability statuses
+
+**Status display label**:
+The human-readable status text TeamServer returns on vulnerability records, for example "Remediated - Auto-Verified" for a vulnerability in the AutoRemediated status. Filters take canonical Vulnerability statuses. Results may carry display labels that differ from the filter value.
+_Avoid_: treating a display label as a valid filter value

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,7 +5,7 @@ Glossary for the mcp-contrast repository. Tool contracts, docs, and code must us
 ## Language
 
 **Vulnerability status**:
-One of seven canonical filter values on the legacy TeamServer vulnerability model. The values are Reported, Suspicious, Confirmed, NotAProblem, Remediated, Fixed, and AutoRemediated. `ValidationConstants.VALID_VULN_STATUSES_CSV` is the source of truth for documentation and validation.
+One of seven canonical filter values on the legacy TeamServer vulnerability model. The values are Reported, Suspicious, Confirmed, NotAProblem, Remediated, Fixed, and AutoRemediated. `ValidationConstants.VALID_VULN_STATUSES_CSV` is the source of truth for documentation and validation. AutoRemediated means the remediation was automatically verified as fixed, not that the vulnerability was auto-remediated. SmartFix performs actual auto-remediation, which is a different concept.
 _Avoid_: Issue Status, trace status
 
 **Issue Status**:

--- a/REPO-CONTEXT.md
+++ b/REPO-CONTEXT.md
@@ -1,7 +1,12 @@
 # Repo context
 
 ## Definitions
-<!-- Common terms specific to this repo/team -->
+
+Domain terms live in [CONTEXT.md](./CONTEXT.md). Read it before touching tool contracts. It covers the Vulnerability status vocabulary, the distinct Issue Status vocabulary, and status display labels.
+
+## Design docs
+
+Planning design docs are saved in the bead's design field via `scripts/br-set-design <bead-id> <file>`. They are not committed to the repo.
 
 ## Architecture
 <!-- High-level architecture notes -->

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ValidationConstants.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ValidationConstants.java
@@ -84,7 +84,7 @@ public final class ValidationConstants {
       "The statuses filter uses canonical values; result statuses may use TeamServer display labels"
           + " such as \""
           + AUTO_REMEDIATED_VULN_STATUS_DISPLAY_LABEL
-          + "\".";
+          + "\". AutoRemediated means automatically verified as fixed, not auto-remediated.";
 
   /** Default vulnerability statuses (actionable only). */
   public static final List<String> DEFAULT_VULN_STATUSES =

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ValidationConstants.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ValidationConstants.java
@@ -39,20 +39,56 @@ public final class ValidationConstants {
   /** Minimum page number (1-indexed). */
   public static final int MIN_PAGE = 1;
 
+  /** Canonical filter value for vulnerabilities marked not a problem. */
+  public static final String NOT_A_PROBLEM_VULN_STATUS = "NotAProblem";
+
+  /** Canonical filter value for vulnerabilities automatically remediated by TeamServer. */
+  public static final String AUTO_REMEDIATED_VULN_STATUS = "AutoRemediated";
+
+  /** TeamServer display label returned for the not-a-problem vulnerability status. */
+  public static final String NOT_A_PROBLEM_VULN_STATUS_DISPLAY_LABEL = "Not a Problem";
+
+  /** TeamServer display label returned for the automatically remediated vulnerability status. */
+  public static final String AUTO_REMEDIATED_VULN_STATUS_DISPLAY_LABEL =
+      "Remediated - Auto-Verified";
+
+  /** Canonical vulnerability status values, formatted for tool parameter descriptions. */
+  public static final String VALID_VULN_STATUSES_CSV =
+      "Reported,Suspicious,Confirmed,"
+          + NOT_A_PROBLEM_VULN_STATUS
+          + ",Remediated,Fixed,"
+          + AUTO_REMEDIATED_VULN_STATUS;
+
   /** Valid vulnerability status values. */
   public static final Set<String> VALID_VULN_STATUSES =
-      Set.of(
-          "Reported",
-          "Suspicious",
-          "Confirmed",
-          "NotAProblem",
-          "Remediated",
-          "Fixed",
-          "AutoRemediated");
+      Set.copyOf(List.of(VALID_VULN_STATUSES_CSV.split(",")));
 
-  /** Default vulnerability statuses (actionable only, excludes Fixed/Remediated). */
+  /** Default vulnerability status values, formatted for tool parameter descriptions. */
+  public static final String DEFAULT_VULN_STATUSES_CSV = "Reported,Suspicious,Confirmed";
+
+  /** Description shared by vulnerability status tool parameters and their contract tests. */
+  public static final String VULN_STATUSES_PARAM_DESCRIPTION =
+      "Comma-separated vulnerability statuses: "
+          + VALID_VULN_STATUSES_CSV
+          + ". Default: "
+          + DEFAULT_VULN_STATUSES_CSV
+          + " (actionable only)";
+
+  /** Notice emitted when a vulnerability search applies the default status filter. */
+  public static final String DEFAULT_VULN_STATUSES_NOTICE =
+      "Showing actionable vulnerabilities only. To see all vulnerability statuses, specify the "
+          + "statuses parameter explicitly.";
+
+  /** Standing result semantics shared by vulnerability search tool descriptions and tests. */
+  public static final String VULN_STATUS_RESULT_SEMANTICS =
+      "The statuses filter uses canonical values; result statuses may use TeamServer display labels"
+          + " such as \""
+          + AUTO_REMEDIATED_VULN_STATUS_DISPLAY_LABEL
+          + "\".";
+
+  /** Default vulnerability statuses (actionable only). */
   public static final List<String> DEFAULT_VULN_STATUSES =
-      List.of("Reported", "Suspicious", "Confirmed");
+      List.of(DEFAULT_VULN_STATUSES_CSV.split(","));
 
   private ValidationConstants() {}
 }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java
@@ -15,6 +15,9 @@
  */
 package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.VULN_STATUSES_PARAM_DESCRIPTION;
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.VULN_STATUS_RESULT_SEMANTICS;
+
 import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
 import com.contrast.labs.ai.mcp.contrast.result.VulnLight;
 import com.contrast.labs.ai.mcp.contrast.tool.base.ExecutionResult;
@@ -66,12 +69,15 @@ public class SearchAppVulnerabilitiesTool
 
           A result's environments field reflects only its latest instance and may omit environments \
           from earlier instances.
+          """
+              + VULN_STATUS_RESULT_SEMANTICS
+              + """
 
-          Examples:
-          - Latest session vulns: appId="abc123", useLatestSession=true
-          - Metadata filter: appId="abc123", sessionMetadataFilters='{"branch":"main"}'
-          - Production critical: appId="abc123", severities="CRITICAL", environments="PRODUCTION"
-          """)
+              Examples:
+              - Latest session vulns: appId="abc123", useLatestSession=true
+              - Metadata filter: appId="abc123", sessionMetadataFilters='{"branch":"main"}'
+              - Production critical: appId="abc123", severities="CRITICAL", environments="PRODUCTION"
+              """)
   public PaginatedToolResponse<VulnLight> searchAppVulnerabilities(
       @ToolParam(description = "Application ID") String appId,
       @ToolParam(description = "Page number (1-based), default: 1", required = false) Integer page,
@@ -81,12 +87,7 @@ public class SearchAppVulnerabilitiesTool
               description = "Comma-separated severities: CRITICAL,HIGH,MEDIUM,LOW,NOTE",
               required = false)
           String severities,
-      @ToolParam(
-              description =
-                  "Comma-separated statuses: Reported,Suspicious,Confirmed,Remediated,Fixed."
-                      + " Default: Reported,Suspicious,Confirmed",
-              required = false)
-          String statuses,
+      @ToolParam(description = VULN_STATUSES_PARAM_DESCRIPTION, required = false) String statuses,
       @ToolParam(
               description =
                   "Comma-separated vulnerability types. Use list_vulnerability_types for complete"

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesTool.java
@@ -15,6 +15,9 @@
  */
 package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.VULN_STATUSES_PARAM_DESCRIPTION;
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.VULN_STATUS_RESULT_SEMANTICS;
+
 import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
 import com.contrast.labs.ai.mcp.contrast.result.VulnLight;
 import com.contrast.labs.ai.mcp.contrast.tool.base.ExecutionResult;
@@ -54,13 +57,16 @@ public class SearchVulnerabilitiesTool extends PaginatedTool<VulnerabilityFilter
 
           A result's environments field reflects only its latest instance and may omit environments
           from earlier instances.
+          """
+              + VULN_STATUS_RESULT_SEMANTICS
+              + """
 
-          Examples:
-          - High-priority open: severities="CRITICAL,HIGH", statuses="Reported,Confirmed"
-          - Production critical with recent activity: environments="PRODUCTION",
-            severities="CRITICAL", lastSeenAfter="2025-01-01"
-          - Remediation workflow tags: vulnTags="SmartFix Remediated", statuses="Remediated"
-          """)
+              Examples:
+              - High-priority open: severities="CRITICAL,HIGH", statuses="Reported,Confirmed"
+              - Production critical with recent activity: environments="PRODUCTION",
+                severities="CRITICAL", lastSeenAfter="2025-01-01"
+              - Remediation workflow tags: vulnTags="SmartFix Remediated", statuses="Remediated"
+              """)
   public PaginatedToolResponse<VulnLight> searchVulnerabilities(
       @ToolParam(description = "Page number (1-based), default: 1", required = false) Integer page,
       @ToolParam(description = "Items per page (max 100), default: 50", required = false)
@@ -71,13 +77,7 @@ public class SearchVulnerabilitiesTool extends PaginatedTool<VulnerabilityFilter
                       + " severities",
               required = false)
           String severities,
-      @ToolParam(
-              description =
-                  "Comma-separated statuses: Reported,Suspicious,Confirmed,Remediated,Fixed."
-                      + " Default: Reported,Suspicious,Confirmed (excludes Fixed and Remediated to"
-                      + " focus on actionable items)",
-              required = false)
-          String statuses,
+      @ToolParam(description = VULN_STATUSES_PARAM_DESCRIPTION, required = false) String statuses,
       @ToolParam(
               description =
                   "Comma-separated vulnerability types (e.g., sql-injection,reflected-xss). Use"

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParams.java
@@ -66,7 +66,8 @@ public class SearchAppVulnerabilitiesParams extends BaseToolParams {
    *
    * @param appIdParam Application ID (required)
    * @param severitiesParam Comma-separated severities (CRITICAL,HIGH,MEDIUM,LOW,NOTE)
-   * @param statusesParam Comma-separated statuses (Reported,Suspicious,Confirmed,Remediated,Fixed)
+   * @param statusesParam Canonical comma-separated vulnerability statuses; see {@link
+   *     ValidationConstants#VALID_VULN_STATUSES}
    * @param vulnTypesParam Comma-separated vulnerability types
    * @param environmentsParam Comma-separated environments (DEVELOPMENT,QA,PRODUCTION); matches
    *     historical vulnerability instances
@@ -105,8 +106,7 @@ public class SearchAppVulnerabilitiesParams extends BaseToolParams {
             .allowedValues(ValidationConstants.VALID_VULN_STATUSES)
             .defaultTo(
                 ValidationConstants.DEFAULT_VULN_STATUSES,
-                "Showing actionable vulnerabilities only (excluding Fixed and Remediated). "
-                    + "To see all statuses, specify statuses parameter explicitly.")
+                ValidationConstants.DEFAULT_VULN_STATUSES_NOTICE)
             .get();
 
     params.vulnTypes = ctx.stringListParam(vulnTypesParam, "vulnTypes").get();

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParams.java
@@ -59,8 +59,8 @@ public class VulnerabilityFilterParams extends BaseToolParams {
    * Parse and validate vulnerability filter parameters using fluent API.
    *
    * @param severitiesParam Comma-separated severities (CRITICAL,HIGH,MEDIUM,LOW,NOTE)
-   * @param statusesParam Comma-separated statuses
-   *     (Reported,Suspicious,Confirmed,NotAProblem,Remediated,Fixed,AutoRemediated)
+   * @param statusesParam Canonical comma-separated vulnerability statuses; see {@link
+   *     ValidationConstants#VALID_VULN_STATUSES}
    * @param vulnTypesParam Comma-separated vulnerability types
    * @param environmentsParam Comma-separated environments (DEVELOPMENT,QA,PRODUCTION); matches
    *     historical vulnerability instances
@@ -89,8 +89,7 @@ public class VulnerabilityFilterParams extends BaseToolParams {
             .allowedValues(ValidationConstants.VALID_VULN_STATUSES)
             .defaultTo(
                 ValidationConstants.DEFAULT_VULN_STATUSES,
-                "Showing actionable vulnerabilities only (excluding Fixed and Remediated). "
-                    + "To see all statuses, specify statuses parameter explicitly.")
+                ValidationConstants.DEFAULT_VULN_STATUSES_NOTICE)
             .get();
 
     params.vulnTypes = ctx.stringListParam(vulnTypesParam, "vulnTypes").get();

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ValidationConstantsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ValidationConstantsTest.java
@@ -36,10 +36,20 @@ class ValidationConstantsTest {
             "Reported",
             "Suspicious",
             "Confirmed",
-            "NotAProblem",
+            ValidationConstants.NOT_A_PROBLEM_VULN_STATUS,
             "Remediated",
             "Fixed",
-            "AutoRemediated");
+            ValidationConstants.AUTO_REMEDIATED_VULN_STATUS);
+  }
+
+  @Test
+  void vulnerability_status_collections_should_match_documentation_csv_constants() {
+    assertThat(ValidationConstants.VALID_VULN_STATUSES)
+        .containsExactlyInAnyOrder(ValidationConstants.VALID_VULN_STATUSES_CSV.split(","));
+    assertThat(ValidationConstants.DEFAULT_VULN_STATUSES)
+        .containsExactly(ValidationConstants.DEFAULT_VULN_STATUSES_CSV.split(","));
+    assertThat(ValidationConstants.VALID_VULN_STATUSES)
+        .containsAll(ValidationConstants.DEFAULT_VULN_STATUSES);
   }
 
   @Test
@@ -47,9 +57,13 @@ class ValidationConstantsTest {
     assertThat(ValidationConstants.DEFAULT_VULN_STATUSES)
         .containsExactly("Reported", "Suspicious", "Confirmed");
 
-    // Should not contain resolved statuses
+    // Actionable defaults omit terminal statuses.
     assertThat(ValidationConstants.DEFAULT_VULN_STATUSES)
-        .doesNotContain("Fixed", "Remediated", "NotAProblem", "AutoRemediated");
+        .doesNotContain(
+            "Fixed",
+            "Remediated",
+            ValidationConstants.NOT_A_PROBLEM_VULN_STATUS,
+            ValidationConstants.AUTO_REMEDIATED_VULN_STATUS);
   }
 
   @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolTest.java
@@ -15,6 +15,8 @@
  */
 package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.VULN_STATUSES_PARAM_DESCRIPTION;
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.VULN_STATUS_RESULT_SEMANTICS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -250,6 +252,17 @@ class SearchAppVulnerabilitiesToolTest {
         .contains("mutually exclusive")
         .doesNotContain(
             "search_issues", "NorthStar", "All vulns in app", "Values must be non-empty");
+  }
+
+  @Test
+  void searchAppVulnerabilities_should_document_canonical_statuses_and_display_labels()
+      throws Exception {
+    Method method = searchAppVulnerabilitiesMethod();
+
+    assertThat(method.getParameters()[4].getAnnotation(ToolParam.class).description())
+        .isEqualTo(VULN_STATUSES_PARAM_DESCRIPTION);
+    assertThat(method.getAnnotation(Tool.class).description())
+        .contains(VULN_STATUS_RESULT_SEMANTICS);
   }
 
   private static Method searchAppVulnerabilitiesMethod() throws NoSuchMethodException {

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolTest.java
@@ -15,6 +15,8 @@
  */
 package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.VULN_STATUSES_PARAM_DESCRIPTION;
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.VULN_STATUS_RESULT_SEMANTICS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -189,6 +191,17 @@ class SearchVulnerabilitiesToolTest {
     assertThat(method.getParameters()[5].getAnnotation(ToolParam.class).description())
         .contains("Matches any historical vulnerability instance")
         .doesNotContain("latest instance", "may omit the matched value");
+  }
+
+  @Test
+  void searchVulnerabilities_should_document_canonical_statuses_and_display_labels()
+      throws Exception {
+    Method method = searchVulnerabilitiesMethod();
+
+    assertThat(method.getParameters()[3].getAnnotation(ToolParam.class).description())
+        .isEqualTo(VULN_STATUSES_PARAM_DESCRIPTION);
+    assertThat(method.getAnnotation(Tool.class).description())
+        .contains(VULN_STATUS_RESULT_SEMANTICS);
   }
 
   private static Method searchVulnerabilitiesMethod() throws NoSuchMethodException {

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParamsTest.java
@@ -15,10 +15,13 @@
  */
 package com.contrast.labs.ai.mcp.contrast.tool.vulnerability.params;
 
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.AUTO_REMEDIATED_VULN_STATUS;
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.NOT_A_PROBLEM_VULN_STATUS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrast.labs.ai.mcp.contrast.sdkextension.ExtendedTraceFilterBody;
 import com.contrast.labs.ai.mcp.contrast.tool.validation.UnresolvedMetadataFilter;
+import com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants;
 import com.contrastsecurity.http.RuleSeverity;
 import com.contrastsecurity.http.ServerEnvironment;
 import com.contrastsecurity.models.TraceTimestampField;
@@ -103,7 +106,7 @@ class SearchAppVulnerabilitiesParamsTest {
 
     assertThat(params.isValid()).isTrue();
     assertThat(params.getStatuses()).containsExactly("Reported", "Suspicious", "Confirmed");
-    assertThat(params.notices()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+    assertThat(params.notices()).containsExactly(ValidationConstants.DEFAULT_VULN_STATUSES_NOTICE);
   }
 
   @Test
@@ -117,6 +120,30 @@ class SearchAppVulnerabilitiesParamsTest {
   }
 
   @Test
+  void toTraceFilterBody_should_map_newly_documented_statuses() {
+    var params =
+        SearchAppVulnerabilitiesParams.of(
+            VALID_APP_ID,
+            null,
+            NOT_A_PROBLEM_VULN_STATUS + "," + AUTO_REMEDIATED_VULN_STATUS,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    var body = params.toTraceFilterBody();
+
+    assertThat(params.isValid()).isTrue();
+    assertThat(params.getStatuses())
+        .containsExactly(NOT_A_PROBLEM_VULN_STATUS, AUTO_REMEDIATED_VULN_STATUS);
+    assertThat(body.getStatus())
+        .containsExactlyInAnyOrder(NOT_A_PROBLEM_VULN_STATUS, AUTO_REMEDIATED_VULN_STATUS);
+  }
+
+  @Test
   void of_should_reject_invalid_status() {
     var params =
         SearchAppVulnerabilitiesParams.of(
@@ -124,7 +151,12 @@ class SearchAppVulnerabilitiesParamsTest {
 
     assertThat(params.isValid()).isFalse();
     assertThat(params.errors())
-        .anyMatch(e -> e.contains("Invalid statuses") && e.contains("Invalid"));
+        .singleElement()
+        .satisfies(
+            error ->
+                assertThat(error)
+                    .startsWith("Invalid statuses: 'Invalid'. Valid values:")
+                    .contains(ValidationConstants.VALID_VULN_STATUSES_CSV.split(",")));
   }
 
   // -- Environment tests --

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParamsTest.java
@@ -15,9 +15,12 @@
  */
 package com.contrast.labs.ai.mcp.contrast.tool.vulnerability.params;
 
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.AUTO_REMEDIATED_VULN_STATUS;
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.NOT_A_PROBLEM_VULN_STATUS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrast.labs.ai.mcp.contrast.sdkextension.ExtendedTraceFilterBody;
+import com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants;
 import com.contrastsecurity.http.RuleSeverity;
 import com.contrastsecurity.http.ServerEnvironment;
 import com.contrastsecurity.models.TraceTimestampField;
@@ -70,7 +73,12 @@ class VulnerabilityFilterParamsTest {
 
     assertThat(params.isValid()).isFalse();
     assertThat(params.errors())
-        .anyMatch(e -> e.contains("Invalid statuses") && e.contains("Invalid"));
+        .singleElement()
+        .satisfies(
+            error ->
+                assertThat(error)
+                    .startsWith("Invalid statuses: 'Invalid'. Valid values:")
+                    .contains(ValidationConstants.VALID_VULN_STATUSES_CSV.split(",")));
   }
 
   @Test
@@ -79,7 +87,28 @@ class VulnerabilityFilterParamsTest {
 
     assertThat(params.isValid()).isTrue();
     assertThat(params.getStatuses()).containsExactly("Reported", "Suspicious", "Confirmed");
-    assertThat(params.notices()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+    assertThat(params.notices()).containsExactly(ValidationConstants.DEFAULT_VULN_STATUSES_NOTICE);
+  }
+
+  @Test
+  void toTraceFilterBody_should_map_newly_documented_statuses() {
+    var params =
+        VulnerabilityFilterParams.of(
+            null,
+            NOT_A_PROBLEM_VULN_STATUS + "," + AUTO_REMEDIATED_VULN_STATUS,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    var body = params.toTraceFilterBody();
+
+    assertThat(params.isValid()).isTrue();
+    assertThat(params.getStatuses())
+        .containsExactly(NOT_A_PROBLEM_VULN_STATUS, AUTO_REMEDIATED_VULN_STATUS);
+    assertThat(body.getStatus())
+        .containsExactlyInAnyOrder(NOT_A_PROBLEM_VULN_STATUS, AUTO_REMEDIATED_VULN_STATUS);
   }
 
   @Test

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesLocalParityTest.java
@@ -15,6 +15,7 @@
  */
 package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.DEFAULT_VULN_STATUSES_NOTICE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -155,7 +156,7 @@ class SearchAppVulnerabilitiesLocalParityTest {
             APP_ID, 1, 10, null, null, null, null, null, null, null, null, null);
 
     assertThat(result.isSuccess()).isTrue();
-    assertThat(result.notices()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+    assertThat(result.notices()).contains(DEFAULT_VULN_STATUSES_NOTICE);
   }
 
   @Test
@@ -178,7 +179,7 @@ class SearchAppVulnerabilitiesLocalParityTest {
         .containsExactly(
             "Access denied or resource not found. Verify credentials and that the resource ID is"
                 + " correct.");
-    assertThat(result.notices()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+    assertThat(result.notices()).contains(DEFAULT_VULN_STATUSES_NOTICE);
   }
 
   @Test

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolIT.java
@@ -15,6 +15,12 @@
  */
 package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.AUTO_REMEDIATED_VULN_STATUS;
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.AUTO_REMEDIATED_VULN_STATUS_DISPLAY_LABEL;
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.DEFAULT_VULN_STATUSES_NOTICE;
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.NOT_A_PROBLEM_VULN_STATUS;
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.NOT_A_PROBLEM_VULN_STATUS_DISPLAY_LABEL;
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.VALID_VULN_STATUSES_CSV;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrast.labs.ai.mcp.contrast.config.IntegrationTestConfig;
@@ -83,17 +89,18 @@ public class SearchAppVulnerabilitiesToolIT
   // RuleSeverity in the SDK. Tests compare case-insensitively to insulate from label drift.
   private static final Set<String> CRITICAL_HIGH_LABELS = Set.of("critical", "high");
 
-  // Default-status filter excludes these terminal statuses. The API returns capitalized labels
-  // for non-default statuses ("Fixed", "Remediated"); the auto-remediated flow has been observed
-  // both as "AutoRemediated" and "Auto-Remediated" depending on TeamServer version, so the
-  // assertion compares case-insensitively against both spellings.
+  // TeamServer returns display labels rather than canonical filter values for NotAProblem and
+  // AutoRemediated. Keep the default-filter assertion aligned with those returned values.
   private static final Set<String> DEFAULT_STATUS_FILTER_EXCLUDES =
-      Set.of("fixed", "remediated", "autoremediated", "auto-remediated", "notaproblem");
+      Set.of(
+          "fixed",
+          "remediated",
+          AUTO_REMEDIATED_VULN_STATUS_DISPLAY_LABEL.toLowerCase(Locale.ROOT),
+          NOT_A_PROBLEM_VULN_STATUS_DISPLAY_LABEL.toLowerCase(Locale.ROOT));
 
   // Full status set — used to bypass the default-status filter when looking for tagged
   // vulnerabilities (which are commonly on Remediated/Fixed traces).
-  private static final String ALL_STATUSES =
-      "Reported,Suspicious,Confirmed,NotAProblem,Remediated,Fixed,AutoRemediated";
+  private static final String ALL_STATUSES = VALID_VULN_STATUSES_CSV;
 
   // Cap pages walked when searching for a tag-bearing app — bounds discovery cost on large orgs.
   private static final int TAG_DISCOVERY_PAGES = 5;
@@ -867,6 +874,62 @@ public class SearchAppVulnerabilitiesToolIT
   }
 
   @Test
+  void
+      searchAppVulnerabilities_should_return_not_a_problem_display_label_when_filter_is_canonical() {
+    assertCanonicalStatusFilter(NOT_A_PROBLEM_VULN_STATUS, NOT_A_PROBLEM_VULN_STATUS_DISPLAY_LABEL);
+  }
+
+  @Test
+  void
+      searchAppVulnerabilities_should_return_auto_remediated_display_label_when_filter_is_canonical() {
+    assertCanonicalStatusFilter(
+        AUTO_REMEDIATED_VULN_STATUS, AUTO_REMEDIATED_VULN_STATUS_DISPLAY_LABEL);
+  }
+
+  private void assertCanonicalStatusFilter(String canonicalStatus, String expectedDisplayLabel) {
+    var orgResponse =
+        searchVulnerabilitiesTool.searchVulnerabilities(
+            1, VULN_DISCOVERY_PAGE_SIZE, null, canonicalStatus, null, null, null, null, null);
+    assertThat(orgResponse.isSuccess()).as("org-wide status probe must succeed").isTrue();
+    assertThat(orgResponse.errors()).as("org-wide status probe must not produce errors").isEmpty();
+    assertThat(orgResponse.items())
+        .as(
+            "requires seeded vulnerabilities with canonical status '%s' — see"
+                + " INTEGRATION_TESTS.md",
+            canonicalStatus)
+        .isNotEmpty();
+
+    var appId = orgResponse.items().get(0).appID();
+    assertThat(appId).as("seeded vulnerability must identify its application").isNotBlank();
+
+    var appResponse =
+        searchAppVulnerabilitiesTool.searchAppVulnerabilities(
+            appId,
+            1,
+            VULN_SAMPLE_PAGE_SIZE,
+            null,
+            canonicalStatus,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    assertThat(appResponse.isSuccess()).as("status-filtered query must succeed").isTrue();
+    assertThat(appResponse.errors()).as("status filter must not produce errors").isEmpty();
+    assertThat(appResponse.items())
+        .as("application must return the seeded canonical status '%s'", canonicalStatus)
+        .isNotEmpty()
+        .allSatisfy(
+            vulnerability ->
+                assertThat(vulnerability.status())
+                    .as("%s.status", vulnerability.vulnID())
+                    .isEqualTo(expectedDisplayLabel));
+  }
+
+  @Test
   void searchAppVulnerabilities_should_apply_default_status_filter() {
     // When no statuses param is supplied, SearchAppVulnerabilitiesParams substitutes the default
     // (Reported, Suspicious, Confirmed) and emits a notice. This test verifies BOTH halves of
@@ -890,8 +953,8 @@ public class SearchAppVulnerabilitiesToolIT
     assertThat(response.isSuccess()).as("default-filter query must succeed").isTrue();
     assertThat(response.errors()).as("default-filter query must not produce errors").isEmpty();
     assertThat(response.notices())
-        .as("must surface the default-status notice identifying which statuses were excluded")
-        .anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+        .as("must surface the default-status notice identifying the actionable default")
+        .contains(DEFAULT_VULN_STATUSES_NOTICE);
 
     // Universal-quantifier check: any returned row must NOT have a terminal status. Vacuously
     // true on empty (when the seeded app has only Fixed/Remediated vulns), but the notice

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesLocalParityTest.java
@@ -15,6 +15,7 @@
  */
 package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.DEFAULT_VULN_STATUSES_NOTICE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -121,7 +122,7 @@ class SearchVulnerabilitiesLocalParityTest {
     var result = tool.searchVulnerabilities(1, 10, null, null, null, null, null, null, null);
 
     assertThat(result.isSuccess()).isTrue();
-    assertThat(result.notices()).anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+    assertThat(result.notices()).contains(DEFAULT_VULN_STATUSES_NOTICE);
   }
 
   @Test

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolIT.java
@@ -15,6 +15,12 @@
  */
 package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.AUTO_REMEDIATED_VULN_STATUS;
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.AUTO_REMEDIATED_VULN_STATUS_DISPLAY_LABEL;
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.DEFAULT_VULN_STATUSES_NOTICE;
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.NOT_A_PROBLEM_VULN_STATUS;
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.NOT_A_PROBLEM_VULN_STATUS_DISPLAY_LABEL;
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.VALID_VULN_STATUSES_CSV;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrast.labs.ai.mcp.contrast.config.IntegrationTestConfig;
@@ -70,12 +76,14 @@ public class SearchVulnerabilitiesToolIT
   private static final int PAGINATION_PROBE_SIZE = 2;
   private static final int MIN_VULNS_FOR_PAGINATION = PAGINATION_PROBE_SIZE + 1;
 
-  // Default-status filter excludes these terminal statuses. The API returns capitalized labels
-  // for non-default statuses ("Fixed", "Remediated"); the auto-remediated flow has been observed
-  // both as "AutoRemediated" and "Auto-Remediated" depending on TeamServer version, so the
-  // assertion compares case-insensitively against both spellings.
+  // TeamServer returns display labels rather than canonical filter values for NotAProblem and
+  // AutoRemediated. Keep the default-filter assertion aligned with those returned values.
   private static final Set<String> DEFAULT_STATUS_FILTER_EXCLUDES =
-      Set.of("fixed", "remediated", "autoremediated", "auto-remediated", "notaproblem");
+      Set.of(
+          "fixed",
+          "remediated",
+          AUTO_REMEDIATED_VULN_STATUS_DISPLAY_LABEL.toLowerCase(Locale.ROOT),
+          NOT_A_PROBLEM_VULN_STATUS_DISPLAY_LABEL.toLowerCase(Locale.ROOT));
 
   // Severity labels returned by the API are capitalized ("Critical", "High", ...) — see
   // RuleSeverity in the SDK. Tests compare case-insensitively to insulate from label drift.
@@ -90,8 +98,7 @@ public class SearchVulnerabilitiesToolIT
 
   // Full status set — used to bypass the default-status filter when looking for tagged
   // vulnerabilities (which are commonly on Remediated/Fixed traces).
-  private static final String ALL_STATUSES =
-      "Reported,Suspicious,Confirmed,NotAProblem,Remediated,Fixed,AutoRemediated";
+  private static final String ALL_STATUSES = VALID_VULN_STATUSES_CSV;
 
   // Cap pages walked when searching for a seeded tag — bounds discovery cost on large orgs.
   private static final int TAG_DISCOVERY_PAGES = 5;
@@ -425,6 +432,38 @@ public class SearchVulnerabilitiesToolIT
   }
 
   @Test
+  void searchVulnerabilities_should_return_not_a_problem_display_label_when_filter_is_canonical() {
+    assertCanonicalStatusFilter(NOT_A_PROBLEM_VULN_STATUS, NOT_A_PROBLEM_VULN_STATUS_DISPLAY_LABEL);
+  }
+
+  @Test
+  void
+      searchVulnerabilities_should_return_auto_remediated_display_label_when_filter_is_canonical() {
+    assertCanonicalStatusFilter(
+        AUTO_REMEDIATED_VULN_STATUS, AUTO_REMEDIATED_VULN_STATUS_DISPLAY_LABEL);
+  }
+
+  private void assertCanonicalStatusFilter(String canonicalStatus, String expectedDisplayLabel) {
+    var response =
+        searchVulnerabilitiesTool.searchVulnerabilities(
+            1, DISCOVERY_PAGE_SIZE, null, canonicalStatus, null, null, null, null, null);
+
+    assertThat(response.isSuccess()).as("status-filtered query must succeed").isTrue();
+    assertThat(response.errors()).as("status filter must not produce errors").isEmpty();
+    assertThat(response.items())
+        .as(
+            "requires seeded vulnerabilities with canonical status '%s' — see"
+                + " INTEGRATION_TESTS.md",
+            canonicalStatus)
+        .isNotEmpty()
+        .allSatisfy(
+            vulnerability ->
+                assertThat(vulnerability.status())
+                    .as("%s.status", vulnerability.vulnID())
+                    .isEqualTo(expectedDisplayLabel));
+  }
+
+  @Test
   void searchVulnerabilities_should_apply_default_status_filter() {
     // When no status param is supplied, VulnerabilityFilterParams substitutes the default
     // (Reported, Suspicious, Confirmed) and emits a notice. This test verifies BOTH halves
@@ -438,7 +477,7 @@ public class SearchVulnerabilitiesToolIT
     assertThat(response.isSuccess()).as("default-filter query must succeed").isTrue();
     assertThat(response.notices())
         .as("must surface the default-status notice")
-        .anyMatch(w -> w.contains("excluding Fixed and Remediated"));
+        .contains(DEFAULT_VULN_STATUSES_NOTICE);
 
     if (response.items().isEmpty()) {
       // With the default filter applied, an empty result set is plausible only on orgs


### PR DESCRIPTION
<!-- pr-tools:stacked:v1 -->
<!-- pr-tools:parent-pr=213 -->
<!-- pr-tools:parent-branch=AIML-1355-onboard-ai-sdlc-plugin -->
<!-- pr-tools:parent-base=main -->
<!-- pr-tools:boundary-commit=01c26069b550be10c74ea91f87038c7057bfd33b -->
<!-- pr-tools:managed:start -->
<!-- pr-tools:managed:end -->

**Jira:** [AIML-1352](https://contrast.atlassian.net/browse/AIML-1352)

## Summary

The `statuses` parameter on both vulnerability search tools listed only 5 of 7 valid values, hiding `NotAProblem` and `AutoRemediated` from AI agents. This change documents all seven canonical vulnerability statuses from a single source of truth and explains the display-label mismatch on returned results.

- All seven vulnerability statuses are now discoverable from the tool schema
- Contract text (descriptions, notices, error messages) is single-sourced through `ValidationConstants` constants
- Result semantics document that TeamServer may return display labels (e.g. "Remediated - Auto-Verified") instead of canonical filter values

## Why This Change Exists

An AI agent that reads only the tool description could not filter by `NotAProblem` or `AutoRemediated` because those values were absent from the `statuses` parameter description. The only discovery path was triggering a validation error, which is not reasonable. QA confirmed the gap on staging via hosted MCP. A prior attempt (PR #171) was closed for over-abstracting with a `VulnStatus` enum. This take uses compile-time string constants in `ValidationConstants` instead.

## Approach

All contract text lives in `ValidationConstants` as `static final String` constants, which are compile-time constants legal in `@ToolParam` annotations. The CSV strings (`VALID_VULN_STATUSES_CSV`, `DEFAULT_VULN_STATUSES_CSV`) are the source of truth. The existing `Set` and `List` collections are derived from them by split. Both tools reference the same constants for their `statuses` description and the same notice for the default-filter message, so docs and validation cannot drift apart.

The tool description body now includes a result-semantics clause explaining that `statuses` takes canonical filter values while results may carry TeamServer display labels such as "Remediated - Auto-Verified". This documents the mismatch without changing the response shape.

## What Changed

### ValidationConstants
- `ValidationConstants.java` — Added `VALID_VULN_STATUSES_CSV`, `DEFAULT_VULN_STATUSES_CSV`, `VULN_STATUSES_PARAM_DESCRIPTION`, `DEFAULT_VULN_STATUSES_NOTICE`, `VULN_STATUS_RESULT_SEMANTICS`, and display-label constants. Derived `VALID_VULN_STATUSES` and `DEFAULT_VULN_STATUSES` from the CSV strings.

### Tool descriptions
- `SearchVulnerabilitiesTool.java`, `SearchAppVulnerabilitiesTool.java` — `statuses` param description now references `VULN_STATUSES_PARAM_DESCRIPTION`. Tool description body includes `VULN_STATUS_RESULT_SEMANTICS`.

### Params and notices
- `VulnerabilityFilterParams.java`, `SearchAppVulnerabilitiesParams.java` — Default notice uses `DEFAULT_VULN_STATUSES_NOTICE` constant. Updated Javadoc to reference `ValidationConstants#VALID_VULN_STATUSES`.

### Tests
- Unit tests reference constants instead of inline strings. New tests verify `NotAProblem` and `AutoRemediated` are accepted and mapped to the filter body. Error-path assertions strengthened to check full message shape.
- Integration tests add `assertCanonicalStatusFilter` for both newly documented statuses on both tools, with `allSatisfy` over the expected display label and loud seeded-data preconditions.

### Domain glossary
- `CONTEXT.md` (new) — Defines Vulnerability status, Issue Status, and status display label.
- `REPO-CONTEXT.md` — Points to `CONTEXT.md` for domain terms.
- `CLAUDE.md` — Added "share contract text with tests" coding standard.

## Testing

- **Unit tests** verify that CSV constants and derived collections agree, both param classes accept `NotAProblem`/`AutoRemediated` and pass them through to `ExtendedTraceFilterBody.status`, and tool annotations reference the shared constants.
- **Integration tests** (`SearchVulnerabilitiesToolIT`, `SearchAppVulnerabilitiesToolIT`) filter by each newly documented status with `allSatisfy` assertions against the confirmed TeamServer display labels ("Not a Problem", "Remediated - Auto-Verified"). Seeded-data preconditions fail loudly with `.as("requires seeded ...")`.
- Default-filter notice assertions across all test suites updated from `anyMatch` substring checks to exact constant equality.


[AIML-1352]: https://contrast.atlassian.net/browse/AIML-1352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ