### PR TITLE
AIML-1353 Validate vulnTypes against live org catalogue

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,6 +20,10 @@ _Avoid_: conflating SmartFix with the AutoRemediated status or with Auto-Verifie
 The NorthStar status vocabulary on Issue entities. The values are REPORTED, CONFIRMED, REMEDIATED, NOT_A_PROBLEM, and FIXED. Suspicious and AutoRemediated exist only as Vulnerability statuses, never as Issue Statuses.
 _Avoid_: using this term for legacy Vulnerability statuses
 
+**Vulnerability type**:
+The kind of vulnerability a finding represents, for example `sql-injection` or `reflected-xss`. Values are lowercase-hyphenated and org-specific, discoverable via `list_vulnerability_types`. Synonymous with the TeamServer term "rule name", a historical artifact: the Contrast Agent used a detection rule per vulnerability type, so the `sql-injection` rule found SQL injection vulnerabilities. Vulnerability type is the canonical term.
+_Avoid_: rule name, rule type, except when naming the raw TeamServer API surface (e.g. `getRules()`)
+
 **Status display label**:
 The human-readable status text TeamServer returns on vulnerability records, for example "Remediated - Auto-Verified" for a vulnerability in the AutoRemediated status. Filters take canonical Vulnerability statuses, and this server's tool results carry canonical Vulnerability statuses, not display labels.
 _Avoid_: treating a display label as a valid filter value or exposing one in a tool result

--- a/MCP_STANDARDS.md
+++ b/MCP_STANDARDS.md
@@ -121,6 +121,10 @@ Tools returning analytical data (reports, coverage, metadata) may use `get_*` ev
 - **Plural** for comma-separated: `severities`, `statuses`, `environments`
 - **Singular** for single values: `appId`, `keyword`, `sort`
 
+### Enumerated String Parameters
+
+**Be liberal in what you accept, conservative in what you send.** Enumerated string parameters match case-insensitively and ignore surrounding whitespace. The server forwards the canonical form downstream, never the caller's raw spelling. A value that fails to match after normalization is a validation error, never a silent pass-through.
+
 ### Sort Convention
 - Use a single optional `sort` string parameter when a tool exposes caller-controlled ordering.
 - Public MCP sort syntax is `property,DIRECTION`.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParams.java
@@ -136,7 +136,7 @@ public class AttackFilterParams extends BaseToolParams {
     params.includeBotBlockers = includeBotBlockers;
     params.includeIpBlacklist = includeIpBlacklist;
 
-    params.sort = ToolSortParser.parse(ctx, sort, SORT_FIELDS, true, null);
+    params.sort = ToolSortParser.parse(ctx, sort, SORT_FIELDS, null);
 
     // Parse rules (comma-separated list of rule IDs)
     params.rules = ctx.stringListParam(rules, "rules").get();

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/server/params/ServerFilterParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/server/params/ServerFilterParams.java
@@ -110,7 +110,7 @@ public class ServerFilterParams extends BaseToolParams {
     params.applicationIds = ctx.stringListParam(applicationIds, "applicationIds").get();
     params.agentVersions = ctx.stringListParam(agentVersions, "agentVersions").get();
     params.includeApplications = Boolean.TRUE.equals(includeApplications);
-    params.sort = ToolSortParser.parse(ctx, sort, SORT_FIELDS, false, DEFAULT_SORT);
+    params.sort = ToolSortParser.parse(ctx, sort, SORT_FIELDS, DEFAULT_SORT);
 
     params.setValidationResult(ctx);
     return params;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolSortParser.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolSortParser.java
@@ -37,7 +37,6 @@ public final class ToolSortParser {
    * @param context validation result collector
    * @param sort public sort value, or {@code null}
    * @param fields public property names mapped to their wire names
-   * @param propertyCaseSensitive whether public property matching is case-sensitive
    * @param defaultSort value returned when sort is absent or invalid
    * @return translated wire sort, prefixed with {@code -} for descending order
    */
@@ -45,7 +44,6 @@ public final class ToolSortParser {
       @NonNull ToolValidationContext context,
       @Nullable String sort,
       @NonNull Map<String, String> fields,
-      boolean propertyCaseSensitive,
       @Nullable String defaultSort) {
     if (!StringUtils.hasText(sort)) {
       return defaultSort;
@@ -60,8 +58,7 @@ public final class ToolSortParser {
 
     var property =
         fields.keySet().stream()
-            .filter(
-                candidate -> propertyMatches(candidate, parts.getFirst(), propertyCaseSensitive))
+            .filter(candidate -> candidate.equalsIgnoreCase(parts.getFirst()))
             .findFirst();
     var direction = parts.get(1).toUpperCase(Locale.ROOT);
     if (property.isEmpty() || !VALID_DIRECTIONS.contains(direction)) {
@@ -71,13 +68,6 @@ public final class ToolSortParser {
 
     var wireProperty = fields.get(property.get());
     return "DESC".equals(direction) ? "-" + wireProperty : wireProperty;
-  }
-
-  private static boolean propertyMatches(
-      String candidate, String requested, boolean propertyCaseSensitive) {
-    return propertyCaseSensitive
-        ? candidate.equals(requested)
-        : candidate.equalsIgnoreCase(requested);
   }
 
   private static String sortError(String sort, Map<String, String> fields) {

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java
@@ -52,6 +52,7 @@ public class SearchAppVulnerabilitiesTool
 
   private final ContrastApiClient contrastApiClient;
   private final VulnerabilityMapper vulnerabilityMapper;
+  private final VulnerabilityTypeValidator vulnerabilityTypeValidator;
 
   @Tool(
       name = "search_app_vulnerabilities",
@@ -178,6 +179,12 @@ public class SearchAppVulnerabilitiesTool
       PaginationParams pagination, SearchAppVulnerabilitiesParams params, NoticeCollector collector)
       throws Exception {
 
+    List<String> canonicalVulnTypes = null;
+    if (params.getVulnTypes() != null && !params.getVulnTypes().isEmpty()) {
+      canonicalVulnTypes =
+          vulnerabilityTypeValidator.validateAndCanonicalize(params.getVulnTypes());
+    }
+
     var appId = params.appId();
 
     // Handle useLatestSession - fetch agent session ID
@@ -207,6 +214,9 @@ public class SearchAppVulnerabilitiesTool
 
     // Build filter body and add session params if present
     var filterBody = params.toTraceFilterBody();
+    if (canonicalVulnTypes != null) {
+      filterBody.setVulnTypes(canonicalVulnTypes);
+    }
     if (agentSessionId != null) {
       filterBody.setAgentSessionId(agentSessionId);
     }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesTool.java
@@ -28,6 +28,7 @@ import com.contrast.labs.ai.mcp.contrast.tool.base.PaginationParams;
 import com.contrast.labs.ai.mcp.contrast.tool.vulnerability.params.VulnerabilityFilterParams;
 import com.contrastsecurity.http.TraceFilterForm.TraceExpandValue;
 import java.util.EnumSet;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.annotation.Tool;
@@ -44,6 +45,7 @@ public class SearchVulnerabilitiesTool extends PaginatedTool<VulnerabilityFilter
 
   private final ContrastApiClient contrastApiClient;
   private final VulnerabilityMapper vulnerabilityMapper;
+  private final VulnerabilityTypeValidator vulnerabilityTypeValidator;
 
   @Tool(
       name = "search_vulnerabilities",
@@ -156,7 +158,16 @@ public class SearchVulnerabilitiesTool extends PaginatedTool<VulnerabilityFilter
       PaginationParams pagination, VulnerabilityFilterParams params, NoticeCollector collector)
       throws Exception {
 
+    List<String> canonicalVulnTypes = null;
+    if (params.getVulnTypes() != null && !params.getVulnTypes().isEmpty()) {
+      canonicalVulnTypes =
+          vulnerabilityTypeValidator.validateAndCanonicalize(params.getVulnTypes());
+    }
+
     var filterBody = params.toTraceFilterBody();
+    if (canonicalVulnTypes != null) {
+      filterBody.setVulnTypes(canonicalVulnTypes);
+    }
 
     var traces =
         contrastApiClient.searchVulnerabilities(

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityTypeValidator.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityTypeValidator.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
+
+import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/** Validates vulnerability types against the live organization rule catalogue. */
+@Service
+@RequiredArgsConstructor
+public class VulnerabilityTypeValidator {
+
+  public static final String INVALID_VULN_TYPES_ERROR_FORMAT =
+      "Invalid vulnTypes: %s. Use list_vulnerability_types to discover valid values.";
+
+  private static final String CATALOGUE_UNAVAILABLE_ERROR =
+      "Vulnerability type catalogue is unavailable";
+
+  private final ContrastApiClient contrastApiClient;
+
+  /**
+   * Validates vulnerability types and returns the catalogue's canonical spelling for each value.
+   *
+   * @param vulnTypes vulnerability types supplied by the caller
+   * @return canonical vulnerability types in caller order
+   * @throws Exception when the live catalogue cannot be retrieved
+   * @throws IllegalArgumentException when any supplied value is not in the catalogue
+   */
+  public List<String> validateAndCanonicalize(List<String> vulnTypes) throws Exception {
+    var rules = contrastApiClient.getRules();
+    if (rules == null || rules.getRules() == null) {
+      throw new IllegalStateException(CATALOGUE_UNAVAILABLE_ERROR);
+    }
+
+    var canonicalTypes = new HashMap<String, String>();
+    for (var rule : rules.getRules()) {
+      var name = rule.getName();
+      if (StringUtils.hasText(name)) {
+        var canonical = name.trim();
+        canonicalTypes.put(canonical.toLowerCase(Locale.ROOT), canonical);
+      }
+    }
+    if (canonicalTypes.isEmpty()) {
+      throw new IllegalStateException(CATALOGUE_UNAVAILABLE_ERROR);
+    }
+
+    var canonicalized = new ArrayList<String>();
+    var invalid = new ArrayList<String>();
+    for (var vulnType : vulnTypes) {
+      var normalized = vulnType.trim();
+      var canonical = canonicalTypes.get(normalized.toLowerCase(Locale.ROOT));
+      if (canonical == null) {
+        invalid.add("'" + normalized + "'");
+      } else {
+        canonicalized.add(canonical);
+      }
+    }
+
+    if (!invalid.isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format(INVALID_VULN_TYPES_ERROR_FORMAT, String.join(", ", invalid)));
+    }
+
+    return List.copyOf(canonicalized);
+  }
+}

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParams.java
@@ -146,7 +146,10 @@ public class SearchAppVulnerabilitiesParams extends BaseToolParams {
   /**
    * Convert to ExtendedTraceFilterBody for POST endpoint API calls.
    *
-   * @return ExtendedTraceFilterBody configured with all filters including status
+   * <p>Vulnerability types are deliberately omitted. The tool adds their canonical values after
+   * validating them against the live catalogue.
+   *
+   * @return ExtendedTraceFilterBody configured with locally validated filters
    */
   public ExtendedTraceFilterBody toTraceFilterBody() {
     var body = new ExtendedTraceFilterBody();
@@ -156,9 +159,6 @@ public class SearchAppVulnerabilitiesParams extends BaseToolParams {
     }
     if (statuses != null) {
       body.setStatus(Set.copyOf(statuses));
-    }
-    if (vulnTypes != null) {
-      body.setVulnTypes(vulnTypes);
     }
     if (environments != null) {
       body.setEnvironments(environments.stream().toList());

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParams.java
@@ -120,7 +120,10 @@ public class VulnerabilityFilterParams extends BaseToolParams {
    * both are false, the API returns ALL vulnerabilities (both tracked and untracked). This avoids
    * the TraceFilterForm default of tracked=true which filters out untracked vulns.
    *
-   * @return ExtendedTraceFilterBody configured with all filters including status
+   * <p>Vulnerability types are deliberately omitted. The tool adds their canonical values after
+   * validating them against the live catalogue.
+   *
+   * @return ExtendedTraceFilterBody configured with locally validated filters
    */
   public ExtendedTraceFilterBody toTraceFilterBody() {
     var body = new ExtendedTraceFilterBody();
@@ -130,9 +133,6 @@ public class VulnerabilityFilterParams extends BaseToolParams {
     }
     if (statuses != null) {
       body.setStatus(Set.copyOf(statuses));
-    }
-    if (vulnTypes != null) {
-      body.setVulnTypes(vulnTypes);
     }
     if (environments != null) {
       body.setEnvironments(environments.stream().toList());

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParamsTest.java
@@ -191,22 +191,16 @@ class AttackFilterParamsTest {
     }
 
     @Test
-    void of_should_be_case_sensitive_starttime_lowercase_invalid() {
-      // API is case-sensitive - must match exact camelCase
-      var params =
+    void of_should_accept_sort_property_case_insensitively_and_forward_canonical_form() {
+      var lowercase =
           AttackFilterParams.of(null, null, null, null, null, null, "starttime,DESC", null);
+      var uppercase =
+          AttackFilterParams.of(null, null, null, null, null, null, "SOURCEIP,ASC", null);
 
-      assertThat(params.isValid()).isFalse();
-      assertThat(params.errors()).anyMatch(e -> e.contains("Invalid sort"));
-    }
-
-    @Test
-    void of_should_be_case_sensitive_STARTTIME_uppercase_invalid() {
-      var params =
-          AttackFilterParams.of(null, null, null, null, null, null, "STARTTIME,DESC", null);
-
-      assertThat(params.isValid()).isFalse();
-      assertThat(params.errors()).anyMatch(e -> e.contains("Invalid sort"));
+      assertThat(lowercase.isValid()).isTrue();
+      assertThat(lowercase.getSort()).isEqualTo("-startTime");
+      assertThat(uppercase.isValid()).isTrue();
+      assertThat(uppercase.getSort()).isEqualTo("sourceIP");
     }
 
     @Test

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolSortParserTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolSortParserTest.java
@@ -29,23 +29,20 @@ class ToolSortParserTest {
   void parse_should_translate_case_insensitive_property_and_direction() {
     var context = new ToolValidationContext();
 
-    var result = ToolSortParser.parse(context, "LASTACTIVITY,desc", FIELDS, false, null);
+    var result = ToolSortParser.parse(context, "LASTACTIVITY,desc", FIELDS, null);
 
     assertThat(result).isEqualTo("-last_activity");
     assertThat(context.isValid()).isTrue();
   }
 
   @Test
-  void parse_should_preserve_case_sensitive_property_contract() {
+  void parse_should_forward_canonical_property_when_case_differs() {
     var context = new ToolValidationContext();
 
-    var result = ToolSortParser.parse(context, "NAME,ASC", FIELDS, true, null);
+    var result = ToolSortParser.parse(context, "NAME,ASC", FIELDS, null);
 
-    assertThat(result).isNull();
-    assertThat(context.errors())
-        .containsExactly(
-            "Invalid sort: 'NAME,ASC'. Expected format: property,DIRECTION. Valid properties:"
-                + " lastActivity, name. Valid directions: ASC, DESC.");
+    assertThat(result).isEqualTo("server_name");
+    assertThat(context.isValid()).isTrue();
   }
 
   @Test
@@ -53,8 +50,8 @@ class ToolSortParserTest {
     var absentContext = new ToolValidationContext();
     var invalidContext = new ToolValidationContext();
 
-    var absent = ToolSortParser.parse(absentContext, null, FIELDS, false, "-last_activity");
-    var invalid = ToolSortParser.parse(invalidContext, "name", FIELDS, false, "-last_activity");
+    var absent = ToolSortParser.parse(absentContext, null, FIELDS, "-last_activity");
+    var invalid = ToolSortParser.parse(invalidContext, "name", FIELDS, "-last_activity");
 
     assertThat(absent).isEqualTo("-last_activity");
     assertThat(absentContext.isValid()).isTrue();

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolTest.java
@@ -17,10 +17,13 @@ package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 
 import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.VULN_STATUSES_PARAM_DESCRIPTION;
 import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.VULN_STATUS_RESULT_SEMANTICS;
+import static com.contrast.labs.ai.mcp.contrast.tool.vulnerability.VulnerabilityTypeValidator.INVALID_VULN_TYPES_ERROR_FORMAT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -32,9 +35,11 @@ import com.contrastsecurity.exceptions.HttpResponseException;
 import com.contrastsecurity.http.TraceFilterForm.TraceExpandValue;
 import com.contrastsecurity.models.MetadataFilterGroup;
 import com.contrastsecurity.models.MetadataFilterResponse;
+import com.contrastsecurity.models.Rules;
 import com.contrastsecurity.models.TraceFilterBody;
 import com.contrastsecurity.models.Traces;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,7 +62,10 @@ class SearchAppVulnerabilitiesToolTest {
   void setUp() {
     contrastApiClient = mock();
     vulnerabilityMapper = mock();
-    tool = new SearchAppVulnerabilitiesTool(contrastApiClient, vulnerabilityMapper);
+    var vulnerabilityTypeValidator = new VulnerabilityTypeValidator(contrastApiClient);
+    tool =
+        new SearchAppVulnerabilitiesTool(
+            contrastApiClient, vulnerabilityMapper, vulnerabilityTypeValidator);
   }
 
   @Test
@@ -69,6 +77,87 @@ class SearchAppVulnerabilitiesToolTest {
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors()).contains("appId is required");
     verifyNoInteractions(contrastApiClient, vulnerabilityMapper);
+  }
+
+  @Test
+  void searchAppVulnerabilities_should_reject_invalid_vuln_type_without_searching()
+      throws Exception {
+    var rules = catalogue("sql-injection");
+    when(contrastApiClient.getRules()).thenReturn(rules);
+
+    var result =
+        tool.searchAppVulnerabilities(
+            APP_ID,
+            1,
+            10,
+            null,
+            null,
+            "TOTALLY-FAKE-RULE-TYPE",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors())
+        .containsExactly(
+            String.format(INVALID_VULN_TYPES_ERROR_FORMAT, "'TOTALLY-FAKE-RULE-TYPE'"));
+    verify(contrastApiClient, never())
+        .searchAppVulnerabilities(any(), any(), anyInt(), anyInt(), any());
+    verifyNoInteractions(vulnerabilityMapper);
+  }
+
+  @Test
+  void searchAppVulnerabilities_should_reject_whole_request_when_vuln_types_are_mixed()
+      throws Exception {
+    var rules = catalogue("sql-injection");
+    when(contrastApiClient.getRules()).thenReturn(rules);
+
+    var result =
+        tool.searchAppVulnerabilities(
+            APP_ID,
+            1,
+            10,
+            null,
+            null,
+            "sql-injection,TOTALLY-FAKE-RULE-TYPE",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors())
+        .containsExactly(
+            String.format(INVALID_VULN_TYPES_ERROR_FORMAT, "'TOTALLY-FAKE-RULE-TYPE'"));
+    verify(contrastApiClient, never())
+        .searchAppVulnerabilities(any(), any(), anyInt(), anyInt(), any());
+    verifyNoInteractions(vulnerabilityMapper);
+  }
+
+  @Test
+  void searchAppVulnerabilities_should_forward_canonical_vuln_type_when_value_matches()
+      throws Exception {
+    var rules = catalogue("sql-injection");
+    var traces = emptyTraces();
+    when(contrastApiClient.getRules()).thenReturn(rules);
+    when(contrastApiClient.searchAppVulnerabilities(
+            eq(APP_ID), any(TraceFilterBody.class), eq(10), eq(0), any()))
+        .thenReturn(traces);
+
+    var result =
+        tool.searchAppVulnerabilities(
+            APP_ID, 1, 10, null, null, " SQL-Injection ", null, null, null, null, null, null);
+
+    assertThat(result.isSuccess()).isTrue();
+    ArgumentCaptor<TraceFilterBody> bodyCaptor = ArgumentCaptor.forClass(TraceFilterBody.class);
+    verify(contrastApiClient)
+        .searchAppVulnerabilities(eq(APP_ID), bodyCaptor.capture(), eq(10), eq(0), any());
+    assertThat(bodyCaptor.getValue().getVulnTypes()).containsExactly("sql-injection");
   }
 
   @Test
@@ -297,5 +386,20 @@ class SearchAppVulnerabilitiesToolTest {
     when(traces.getTraces()).thenReturn(List.of());
     when(traces.getCount()).thenReturn(0);
     return traces;
+  }
+
+  private static Rules catalogue(String... names) {
+    var rulesList =
+        Arrays.stream(names)
+            .map(
+                name -> {
+                  Rules.Rule rule = mock();
+                  when(rule.getName()).thenReturn(name);
+                  return rule;
+                })
+            .toList();
+    Rules rules = mock();
+    when(rules.getRules()).thenReturn(rulesList);
+    return rules;
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolTest.java
@@ -17,10 +17,13 @@ package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 
 import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.VULN_STATUSES_PARAM_DESCRIPTION;
 import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.VULN_STATUS_RESULT_SEMANTICS;
+import static com.contrast.labs.ai.mcp.contrast.tool.vulnerability.VulnerabilityTypeValidator.INVALID_VULN_TYPES_ERROR_FORMAT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -31,10 +34,12 @@ import com.contrastsecurity.exceptions.HttpResponseException;
 import com.contrastsecurity.http.RuleSeverity;
 import com.contrastsecurity.http.ServerEnvironment;
 import com.contrastsecurity.http.TraceFilterForm.TraceExpandValue;
+import com.contrastsecurity.models.Rules;
 import com.contrastsecurity.models.Trace;
 import com.contrastsecurity.models.TraceFilterBody;
 import com.contrastsecurity.models.Traces;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -58,7 +63,10 @@ class SearchVulnerabilitiesToolTest {
   void setUp() {
     contrastApiClient = mock();
     vulnerabilityMapper = mock();
-    tool = new SearchVulnerabilitiesTool(contrastApiClient, vulnerabilityMapper);
+    var vulnerabilityTypeValidator = new VulnerabilityTypeValidator(contrastApiClient);
+    tool =
+        new SearchVulnerabilitiesTool(
+            contrastApiClient, vulnerabilityMapper, vulnerabilityTypeValidator);
   }
 
   @Test
@@ -69,6 +77,41 @@ class SearchVulnerabilitiesToolTest {
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.errors()).anyMatch(e -> e.contains("Invalid severities"));
     verifyNoInteractions(contrastApiClient, vulnerabilityMapper);
+  }
+
+  @Test
+  void searchVulnerabilities_should_reject_invalid_vuln_type_without_searching() throws Exception {
+    var rules = catalogue("sql-injection");
+    when(contrastApiClient.getRules()).thenReturn(rules);
+
+    var result =
+        tool.searchVulnerabilities(
+            1, 10, null, null, "TOTALLY-FAKE-RULE-TYPE", null, null, null, null);
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors())
+        .containsExactly(
+            String.format(INVALID_VULN_TYPES_ERROR_FORMAT, "'TOTALLY-FAKE-RULE-TYPE'"));
+    verify(contrastApiClient, never()).searchVulnerabilities(any(), anyInt(), anyInt(), any());
+    verifyNoInteractions(vulnerabilityMapper);
+  }
+
+  @Test
+  void searchVulnerabilities_should_reject_whole_request_when_vuln_types_are_mixed()
+      throws Exception {
+    var rules = catalogue("sql-injection");
+    when(contrastApiClient.getRules()).thenReturn(rules);
+
+    var result =
+        tool.searchVulnerabilities(
+            1, 10, null, null, "sql-injection,TOTALLY-FAKE-RULE-TYPE", null, null, null, null);
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors())
+        .containsExactly(
+            String.format(INVALID_VULN_TYPES_ERROR_FORMAT, "'TOTALLY-FAKE-RULE-TYPE'"));
+    verify(contrastApiClient, never()).searchVulnerabilities(any(), anyInt(), anyInt(), any());
+    verifyNoInteractions(vulnerabilityMapper);
   }
 
   @Test
@@ -94,6 +137,8 @@ class SearchVulnerabilitiesToolTest {
     var toolContext = new ToolContext(Map.of("requestId", "req-123"));
     var capturedContext = new AtomicReference<ToolContext>();
 
+    var rules = catalogue("sql-injection");
+    when(contrastApiClient.getRules()).thenReturn(rules);
     tool.setAuthenticationStrategy(
         context -> {
           capturedContext.set(context);
@@ -119,7 +164,7 @@ class SearchVulnerabilitiesToolTest {
             10,
             "CRITICAL",
             "Reported",
-            "sql-injection",
+            " SQL-Injection ",
             "PRODUCTION",
             null,
             null,
@@ -217,5 +262,20 @@ class SearchVulnerabilitiesToolTest {
         String.class,
         String.class,
         ToolContext.class);
+  }
+
+  private static Rules catalogue(String... names) {
+    var rulesList =
+        Arrays.stream(names)
+            .map(
+                name -> {
+                  Rules.Rule rule = mock();
+                  when(rule.getName()).thenReturn(name);
+                  return rule;
+                })
+            .toList();
+    Rules rules = mock();
+    when(rules.getRules()).thenReturn(rulesList);
+    return rules;
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityTypeValidatorTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityTypeValidatorTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
+
+import static com.contrast.labs.ai.mcp.contrast.tool.vulnerability.VulnerabilityTypeValidator.INVALID_VULN_TYPES_ERROR_FORMAT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
+import com.contrastsecurity.models.Rules;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class VulnerabilityTypeValidatorTest {
+
+  private ContrastApiClient contrastApiClient;
+  private VulnerabilityTypeValidator validator;
+
+  @BeforeEach
+  void setUp() {
+    contrastApiClient = mock();
+    validator = new VulnerabilityTypeValidator(contrastApiClient);
+  }
+
+  @Test
+  void validateAndCanonicalize_should_return_canonical_values_when_values_are_valid()
+      throws Exception {
+    var rules = catalogue("sql-injection", "reflected-xss");
+    when(contrastApiClient.getRules()).thenReturn(rules);
+
+    var result = validator.validateAndCanonicalize(List.of("sql-injection", "reflected-xss"));
+
+    assertThat(result).containsExactly("sql-injection", "reflected-xss");
+  }
+
+  @Test
+  void validateAndCanonicalize_should_normalize_case_and_whitespace_when_values_match()
+      throws Exception {
+    var rules = catalogue("sql-injection");
+    when(contrastApiClient.getRules()).thenReturn(rules);
+
+    var result = validator.validateAndCanonicalize(List.of("SQL-Injection", " sql-injection "));
+
+    assertThat(result).containsExactly("sql-injection", "sql-injection");
+  }
+
+  @Test
+  void validateAndCanonicalize_should_list_all_invalid_values_when_values_are_unrecognized()
+      throws Exception {
+    var rules = catalogue("sql-injection");
+    when(contrastApiClient.getRules()).thenReturn(rules);
+
+    assertThatThrownBy(() -> validator.validateAndCanonicalize(List.of("sqli", "TOTALLY-FAKE")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(String.format(INVALID_VULN_TYPES_ERROR_FORMAT, "'sqli', 'TOTALLY-FAKE'"));
+  }
+
+  @Test
+  void validateAndCanonicalize_should_reject_whole_request_when_valid_and_invalid_values_are_mixed()
+      throws Exception {
+    var rules = catalogue("sql-injection");
+    when(contrastApiClient.getRules()).thenReturn(rules);
+
+    assertThatThrownBy(
+            () ->
+                validator.validateAndCanonicalize(List.of("sql-injection", " bad-one ", "BAD-TWO")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(String.format(INVALID_VULN_TYPES_ERROR_FORMAT, "'bad-one', 'BAD-TWO'"));
+  }
+
+  @Test
+  void validateAndCanonicalize_should_fail_closed_when_catalogue_response_is_null()
+      throws Exception {
+    when(contrastApiClient.getRules()).thenReturn(null);
+
+    assertThatThrownBy(() -> validator.validateAndCanonicalize(List.of("sql-injection")))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void validateAndCanonicalize_should_fail_closed_when_catalogue_rules_are_null() throws Exception {
+    Rules rules = mock();
+    when(rules.getRules()).thenReturn(null);
+    when(contrastApiClient.getRules()).thenReturn(rules);
+
+    assertThatThrownBy(() -> validator.validateAndCanonicalize(List.of("sql-injection")))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void validateAndCanonicalize_should_fail_closed_when_catalogue_is_empty() throws Exception {
+    Rules rules = mock();
+    when(rules.getRules()).thenReturn(List.of());
+    when(contrastApiClient.getRules()).thenReturn(rules);
+
+    assertThatThrownBy(() -> validator.validateAndCanonicalize(List.of("sql-injection")))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void validateAndCanonicalize_should_fail_closed_when_catalogue_has_no_named_rules()
+      throws Exception {
+    var rules = catalogue(" ");
+    when(contrastApiClient.getRules()).thenReturn(rules);
+
+    assertThatThrownBy(() -> validator.validateAndCanonicalize(List.of("sql-injection")))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void validateAndCanonicalize_should_propagate_exception_when_catalogue_request_fails()
+      throws Exception {
+    var failure = new IOException("rules unavailable");
+    when(contrastApiClient.getRules()).thenThrow(failure);
+
+    assertThatThrownBy(() -> validator.validateAndCanonicalize(List.of("sql-injection")))
+        .isSameAs(failure);
+  }
+
+  private static Rules catalogue(String... names) {
+    var rulesList =
+        Arrays.stream(names)
+            .map(
+                name -> {
+                  Rules.Rule rule = mock();
+                  when(rule.getName()).thenReturn(name);
+                  return rule;
+                })
+            .toList();
+    Rules rules = mock();
+    when(rules.getRules()).thenReturn(rulesList);
+    return rules;
+  }
+}

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParamsTest.java
@@ -299,7 +299,7 @@ class SearchAppVulnerabilitiesParamsTest {
   // -- toTraceFilterBody tests (POST endpoint) --
 
   @Test
-  void toTraceFilterBody_should_map_all_fields() {
+  void toTraceFilterBody_should_map_static_fields_without_raw_vuln_types() {
     var params =
         SearchAppVulnerabilitiesParams.of(
             VALID_APP_ID,
@@ -319,7 +319,8 @@ class SearchAppVulnerabilitiesParamsTest {
         .containsExactlyInAnyOrder(RuleSeverity.CRITICAL, RuleSeverity.HIGH);
     assertThat(body.getFilterTags()).containsExactly("reviewed");
     assertThat(body.getEnvironments()).containsExactly(ServerEnvironment.PRODUCTION);
-    assertThat(body.getVulnTypes()).containsExactly("sql-injection");
+    assertThat(params.getVulnTypes()).containsExactly("sql-injection");
+    assertThat(body.getVulnTypes()).isNull();
     assertThat(body.getStartDate()).isNotNull();
     assertThat(body.getEndDate()).isNotNull();
     assertThat(body.getTimestampFilter()).isEqualTo(TraceTimestampField.LAST);

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParamsTest.java
@@ -206,7 +206,7 @@ class VulnerabilityFilterParamsTest {
   // -- TraceFilterBody conversion (POST endpoint) --
 
   @Test
-  void toTraceFilterBody_should_map_all_fields() {
+  void toTraceFilterBody_should_map_static_fields_without_raw_vuln_types() {
     var params =
         VulnerabilityFilterParams.of(
             "CRITICAL,HIGH",
@@ -223,7 +223,8 @@ class VulnerabilityFilterParamsTest {
         .containsExactlyInAnyOrder(RuleSeverity.CRITICAL, RuleSeverity.HIGH);
     assertThat(body.getFilterTags()).containsExactly("reviewed");
     assertThat(body.getEnvironments()).containsExactly(ServerEnvironment.PRODUCTION);
-    assertThat(body.getVulnTypes()).containsExactly("sql-injection");
+    assertThat(params.getVulnTypes()).containsExactly("sql-injection");
+    assertThat(body.getVulnTypes()).isNull();
     assertThat(body.getStartDate()).isNotNull();
     assertThat(body.getEndDate()).isNotNull();
     assertThat(body.getTimestampFilter()).isEqualTo(TraceTimestampField.LAST);

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParamsTest.java
@@ -171,7 +171,8 @@ class VulnerabilityFilterParamsTest {
         .anyMatch(e -> e.contains("lastSeenAfter must be before lastSeenBefore"));
   }
 
-  // -- VulnTypes and VulnTags (pass-through, no validation) --
+  // -- VulnTypes (pass-through at params layer; validated at execution time in tools) and VulnTags
+  // --
 
   @Test
   void of_should_pass_through_vuln_types() {

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesLocalParityTest.java
@@ -55,12 +55,14 @@ class SearchAppVulnerabilitiesLocalParityTest {
   @Mock private ContrastSDKFactory sdkFactory;
   @Mock private SDKExtensionFactory sdkExtensionFactory;
   @Mock private ContrastSDK sdk;
+  @Mock private VulnerabilityTypeValidator vulnerabilityTypeValidator;
 
   @BeforeEach
   void setUp() {
     when(sdkFactory.getOrgId()).thenReturn(ORG_ID);
     tool =
-        new SearchAppVulnerabilitiesTool(new SdkApiClient(sdkFactory, sdkExtensionFactory), mapper);
+        new SearchAppVulnerabilitiesTool(
+            new SdkApiClient(sdkFactory, sdkExtensionFactory), mapper, vulnerabilityTypeValidator);
   }
 
   /**

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesLocalParityTest.java
@@ -35,6 +35,7 @@ import com.contrastsecurity.models.Trace;
 import com.contrastsecurity.sdk.ContrastSDK;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,13 +52,16 @@ class SearchVulnerabilitiesLocalParityTest {
   @Mock private ContrastSDKFactory sdkFactory;
   @Mock private SDKExtensionFactory sdkExtensionFactory;
   @Mock private ContrastSDK sdk;
+  @Mock private VulnerabilityTypeValidator vulnerabilityTypeValidator;
 
   private static final String TEST_ORG_ID = "test-org-id";
 
   @BeforeEach
   void setUp() {
     when(sdkFactory.getOrgId()).thenReturn(TEST_ORG_ID);
-    tool = new SearchVulnerabilitiesTool(new SdkApiClient(sdkFactory, sdkExtensionFactory), mapper);
+    tool =
+        new SearchVulnerabilitiesTool(
+            new SdkApiClient(sdkFactory, sdkExtensionFactory), mapper, vulnerabilityTypeValidator);
   }
 
   /**
@@ -197,6 +201,8 @@ class SearchVulnerabilitiesLocalParityTest {
   @Test
   void searchVulnerabilities_should_pass_vuln_types_filter_to_sdk() throws Exception {
     mockSdkWithTracesResponse(TracesJsonFixture.emptyTraces());
+    when(vulnerabilityTypeValidator.validateAndCanonicalize(any()))
+        .thenReturn(List.of("sql-injection", "xss"));
 
     tool.searchVulnerabilities(1, 10, null, null, "sql-injection,xss", null, null, null, null);
 

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolIT.java
@@ -20,6 +20,7 @@ import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConsta
 import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.NOT_A_PROBLEM_VULN_STATUS;
 import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.VALID_VULN_STATUSES;
 import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.VALID_VULN_STATUSES_CSV;
+import static com.contrast.labs.ai.mcp.contrast.tool.vulnerability.VulnerabilityTypeValidator.INVALID_VULN_TYPES_ERROR_FORMAT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrast.labs.ai.mcp.contrast.config.IntegrationTestConfig;
@@ -93,6 +94,7 @@ public class SearchVulnerabilitiesToolIT
   // ServerEnvironment values are reflected verbatim ("DEVELOPMENT", "QA", "PRODUCTION") — see
   // ServerEnvironment in the SDK and VulnerabilityMapper#extractEnvironments.
   private static final String PRODUCTION_ENV = "PRODUCTION";
+  private static final String INVALID_VULN_TYPE = "TOTALLY-FAKE-RULE-TYPE";
 
   // Date format accepted by VulnerabilityFilterParams.dateParam: ISO YYYY-MM-DD.
   private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
@@ -532,6 +534,24 @@ public class SearchVulnerabilitiesToolIT
             testData.sampleVulnType)
         .allSatisfy(
             v -> assertThat(v.type()).as("%s.type", v.vulnID()).isEqualTo(testData.sampleVulnType));
+  }
+
+  @Test
+  void searchVulnerabilities_should_reject_invalid_vuln_type_with_error_message() {
+    var response =
+        searchVulnerabilitiesTool.searchVulnerabilities(
+            1, 10, null, null, INVALID_VULN_TYPE, null, null, null, null);
+
+    assertThat(response.isSuccess()).as("invalid vulnTypes must fail validation").isFalse();
+    assertThat(response.errors())
+        .containsExactly(
+            String.format(INVALID_VULN_TYPES_ERROR_FORMAT, "'" + INVALID_VULN_TYPE + "'"))
+        .allSatisfy(
+            error ->
+                assertThat(error).contains(INVALID_VULN_TYPE).contains("list_vulnerability_types"));
+    assertThat(response.errors())
+        .as("validation error must not surface as a Contrast API error")
+        .noneMatch(error -> error.contains("Contrast API error"));
   }
 
   // ---------- Date range filters ----------


### PR DESCRIPTION
<!-- pr-tools:stacked:v1 -->
<!-- pr-tools:parent-pr=216 -->
<!-- pr-tools:parent-branch=AIML-1352-normalize-vuln-status -->
<!-- pr-tools:parent-base=AIML-1355-onboard-ai-sdlc-plugin -->
<!-- pr-tools:boundary-commit=b4d38c8f6a08e640b26810adf86af389589ddc29 -->
<!-- pr-tools:managed:start -->
<!-- pr-tools:managed:end -->

**Jira:** [AIML-1353](https://contrast.atlassian.net/browse/AIML-1353)

## Summary

Both `search_vulnerabilities` and `search_app_vulnerabilities` now validate the `vulnTypes` parameter against the live organization rule catalogue before searching. Invalid values produce an explicit error message pointing the caller to `list_vulnerability_types`, instead of silently returning empty results that look identical to a legitimate "no vulnerabilities found" response.

- Invalid or misspelled vulnerability types are caught before the search API is called
- Values are matched case-insensitively and whitespace-trimmed, with the canonical form forwarded downstream
- The fail-closed design refuses the request when the rule catalogue is unavailable

## Why This Change Exists

An AI agent that misspells a vulnerability type (for example `sqli` instead of `sql-injection`) gets back `success=true, items=[], totalItems=0`. That response is indistinguishable from a genuine empty result, so the agent concludes there are no matching vulnerabilities and moves on. The `severities`, `statuses`, and `environments` parameters already reject invalid values with clear error messages. `vulnTypes` was the inconsistent outlier.

## Approach

A new `VulnerabilityTypeValidator` service fetches the org's rules via `ContrastApiClient.getRules()`, builds a case-insensitive lookup map, and returns the canonical spelling for each supplied value. Any unrecognized values cause a single `IllegalArgumentException` that names every bad value and points to `list_vulnerability_types`. The `PaginatedTool` base class already converts `IllegalArgumentException` to a `success=false` response, so no error-handling plumbing was needed.

Validation happens in `doExecute()` of both tools, not in the params layer, because the params layer has no access to the API client. This matches the precedent set by session-metadata filter resolution in `SearchAppVulnerabilitiesTool`.

Rejected alternatives and the reasoning behind them are documented in the bead's design field.

## What Changed

### Validator
- `VulnerabilityTypeValidator.java` (new) - shared service injected into both search tools

### Search tools
- `SearchVulnerabilitiesTool.java` - calls the validator at the top of `doExecute()` when `vulnTypes` is present, overwrites the filter body with the canonical list
- `SearchAppVulnerabilitiesTool.java` - same validation wired in the same position

### Standards
- `MCP_STANDARDS.md` - new "Enumerated String Parameters" section codifying the Postel rule for all enumerated string params
- `CONTEXT.md` - added "Vulnerability type" to the domain glossary

### Tests
- `VulnerabilityTypeValidatorTest.java` (new) - 8 tests covering valid values, case/whitespace normalization, mixed valid+invalid rejection, null/empty catalogue fail-closed, and exception propagation
- `SearchVulnerabilitiesToolTest.java` - 2 new tests for invalid and mixed vulnTypes rejection, updated existing routing test to exercise case normalization
- `SearchAppVulnerabilitiesToolTest.java` - 3 new tests for invalid, mixed, and canonical-forwarding behavior
- `VulnerabilityFilterParamsTest.java` - updated section header comment to reflect that vulnTypes is now validated at execution time
- `SearchVulnerabilitiesLocalParityTest.java`, `SearchAppVulnerabilitiesLocalParityTest.java` - updated constructors for new validator dependency

## Testing

The validator has dedicated unit tests for every path: valid input, case normalization, whitespace trimming, single and multiple invalid values, mixed valid+invalid lists, null catalogue, empty catalogue, blank-named-only catalogue, and API failure propagation. Both tool tests verify that invalid vulnTypes produce `success=false` with the error constant, that the search API is never called, and that valid values with non-canonical casing are forwarded in canonical form. All 1,133 unit tests pass, coverage floors and PIT mutation strength floors are met.

Integration test coverage now verifies the rejection path and exact validation error shape, matching the `SearchAttacksToolIT` pattern.


[AIML-1353]: https://contrast.atlassian.net/browse/AIML-1353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ