### PR TITLE
AIML-1354 Explain route coverage license denials

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -480,6 +480,12 @@ Run the harness-engineering playbooks against this repo on demand via `/harness-
 
 `/update-changelog` brings `[Unreleased]` in CHANGELOG.md up to date against everything merged since the last release tag, audits completeness with a read-only subagent per range, and lands the result on a branch after user approval. Run before dispatching the Gradle Release workflow or when explicitly asked. See `.claude/skills/update-changelog/`.
 
+## Spawning Codex via Herdr
+
+When spawning a Codex agent through Herdr:
+
+1. `herdr agent start <name> --kind codex --pane <pane-id>` with no extra args after `--`. Default Codex startup is correct. Do not pass `--full-auto` or `--permission-mode auto`.
+2. `herdr agent prompt <name> "<brief>" --wait` with NO `--timeout` flag. Codex runs often exceed 10 minutes. Omitting `--timeout` lets Herdr wait indefinitely. The Bash tool's own 10-minute ceiling applies, so run the prompt call with `run_in_background: true` and wait for the task notification.
 
 
 @SECURITY.md

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,6 +24,14 @@ _Avoid_: using this term for legacy Vulnerability statuses
 The kind of vulnerability a finding represents, for example `sql-injection` or `reflected-xss`. Values are lowercase-hyphenated and org-specific, discoverable via `list_vulnerability_types`. Synonymous with the TeamServer term "rule name", a historical artifact: the Contrast Agent used a detection rule per vulnerability type, so the `sql-injection` rule found SQL injection vulnerabilities. Vulnerability type is the canonical term.
 _Avoid_: rule name, rule type, except when naming the raw TeamServer API surface (e.g. `getRules()`)
 
+**Licensed application**:
+An application whose merged license service level in TeamServer is exactly Licensed, meaning it holds an Assess license. TeamServer refuses route coverage and single-vulnerability detail reads for unlicensed applications with an opaque HTTP 403 "Authorization failure".
+_Avoid_: describing those 403s as credential problems, missing data, or language limitations
+
+**Route coverage**:
+The set of routes an Assess agent observed in an application, each either discovered (found in the code) or exercised (hit by an HTTP request).
+_Avoid_: route data, endpoint coverage
+
 **Status display label**:
 The human-readable status text TeamServer returns on vulnerability records, for example "Remediated - Auto-Verified" for a vulnerability in the AutoRemediated status. Filters take canonical Vulnerability statuses, and this server's tool results carry canonical Vulnerability statuses, not display labels.
 _Avoid_: treating a display label as a valid filter value or exposing one in a tool result

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/client/ContrastApiClient.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/client/ContrastApiClient.java
@@ -24,6 +24,7 @@ import com.contrast.labs.ai.mcp.contrast.sdkextension.data.adr.AttacksFilterBody
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.adr.AttacksResponse;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.AppMetadataField;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.AppMetadataFilter;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.Application;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.ApplicationsResponse;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.routecoverage.RouteCoverageResponse;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.sca.LibraryObservation;
@@ -50,6 +51,8 @@ public interface ContrastApiClient {
       throws Exception;
 
   List<AppMetadataField> getApplicationMetadataFields() throws Exception;
+
+  Application getApplicationWithLicense(String appId) throws Exception;
 
   MetadataFilterResponse getSessionMetadata(String appId) throws Exception;
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/client/ContrastApiClient.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/client/ContrastApiClient.java
@@ -52,6 +52,10 @@ public interface ContrastApiClient {
 
   List<AppMetadataField> getApplicationMetadataFields() throws Exception;
 
+  /**
+   * Returns application details including its merged license service level. Hosted implementors
+   * (aiml-services) must wire this method through their transport adapter.
+   */
   Application getApplicationWithLicense(String appId) throws Exception;
 
   MetadataFilterResponse getSessionMetadata(String appId) throws Exception;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/Application.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/Application.java
@@ -115,6 +115,9 @@ public class Application {
   @SerializedName("onboarded_time")
   private Long onboardedTime;
 
+  @SerializedName("license")
+  private ApplicationLicense license;
+
   // Defensive getters - return empty collections instead of null (Effective Java Item 54)
   // These override Lombok's generated getters to ensure null-safety
 

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/ApplicationLicense.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/ApplicationLicense.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.sdkextension.data.application;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+/** Application license details returned by TeamServer's license expansion. */
+@Data
+public class ApplicationLicense {
+
+  @SerializedName("level")
+  private String level;
+}

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/ApplicationResponse.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/ApplicationResponse.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.sdkextension.data.application;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+/** Response envelope from the single-application endpoint. */
+@Data
+public class ApplicationResponse {
+
+  @SerializedName("application")
+  private Application application;
+}

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/application/ApplicationLicenseDiscriminator.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/application/ApplicationLicenseDiscriminator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool.application;
+
+import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
+import com.contrastsecurity.exceptions.UnauthorizedException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/** Classifies an application after an application-scoped endpoint returns HTTP 403. */
+@Service
+@RequiredArgsConstructor
+public class ApplicationLicenseDiscriminator {
+
+  public static final String LICENSED_LEVEL = "Licensed";
+
+  private final ContrastApiClient contrastApiClient;
+
+  /**
+   * Fetches the application through an endpoint that remains available for archived and unlicensed
+   * applications, then classifies the cause of the original denial.
+   *
+   * @param appId application identifier from the denied request
+   * @param originalForbidden original HTTP 403 to preserve when discrimination fails
+   * @return the application's access-relevant state
+   * @throws UnauthorizedException the original denial when the discriminator lookup fails
+   */
+  public ApplicationState discriminate(String appId, UnauthorizedException originalForbidden) {
+    try {
+      var application = contrastApiClient.getApplicationWithLicense(appId);
+      if (application == null) {
+        throw originalForbidden;
+      }
+      if (application.isArchived()) {
+        return ApplicationState.ARCHIVED;
+      }
+      if (application.getLicense() == null
+          || !LICENSED_LEVEL.equals(application.getLicense().getLevel())) {
+        return ApplicationState.UNLICENSED;
+      }
+      return ApplicationState.LICENSED;
+    } catch (Exception fetchFailure) {
+      throw originalForbidden;
+    }
+  }
+
+  public enum ApplicationState {
+    ARCHIVED,
+    UNLICENSED,
+    LICENSED
+  }
+}

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/ActionableToolErrorException.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/ActionableToolErrorException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool.base;
+
+/** A tool failure whose message is safe and actionable for the caller. */
+public class ActionableToolErrorException extends RuntimeException {
+
+  public ActionableToolErrorException(String message) {
+    super(message);
+  }
+}

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseTool.java
@@ -26,6 +26,10 @@ import org.springframework.lang.Nullable;
  */
 public abstract class BaseTool {
 
+  public static final String AUTHENTICATION_OR_NOT_FOUND_ERROR =
+      "Authentication failed or resource not found. Verify credentials and that the resource ID"
+          + " is correct.";
+
   private static final AutoCloseable NOOP_AUTHENTICATION_SCOPE = () -> {};
 
   private AuthenticationStrategy authenticationStrategy;
@@ -61,9 +65,7 @@ public abstract class BaseTool {
    */
   protected String mapHttpErrorCode(int code) {
     return switch (code) {
-      case 401 ->
-          "Authentication failed or resource not found. Verify credentials and that the resource ID"
-              + " is correct.";
+      case 401 -> AUTHENTICATION_OR_NOT_FOUND_ERROR;
       case 403 ->
           "Access denied or resource not found. Verify credentials and that the resource ID is"
               + " correct.";

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java
@@ -86,6 +86,8 @@ public abstract class CursorPaginatedTool<P extends ToolParams, R> extends BaseT
       return handleException(e, pagination, requestId, "Resource not found");
     } catch (HttpResponseException e) {
       return handleHttpResponseException(e, pagination, requestId, collector);
+    } catch (ActionableToolErrorException e) {
+      return handleException(e, pagination, requestId, e.getMessage());
     } catch (IllegalArgumentException e) {
       return handleException(e, pagination, requestId, e.getMessage());
     } catch (Exception e) {

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
@@ -116,6 +116,8 @@ public abstract class PaginatedTool<P extends ToolParams, R> extends BaseTool {
       return handleException(e, pagination, requestId, "Resource not found");
     } catch (HttpResponseException e) {
       return handleHttpResponseException(e, pagination, requestId, collector);
+    } catch (ActionableToolErrorException e) {
+      return handleException(e, pagination, requestId, e.getMessage());
     } catch (IllegalArgumentException e) {
       // User-input rejection raised mid-execution (e.g., resolveAppMetadataFilters when an
       // unknown field name is supplied). The exception message is the actionable user message.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
@@ -99,6 +99,8 @@ public abstract class SingleTool<P extends ToolParams, R> extends BaseTool {
       return handleException(e, requestId, mapHttpErrorCode(e.getCode()), collector);
     } catch (HttpResponseException e) {
       return handleHttpResponseException(e, requestId, collector);
+    } catch (ActionableToolErrorException e) {
+      return handleException(e, requestId, e.getMessage(), collector);
     } catch (IllegalArgumentException e) {
       // User-input rejection raised mid-execution (e.g., resolveSessionMetadataFilters when an
       // unknown field name is supplied). The exception message is the actionable user message.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageTool.java
@@ -18,10 +18,14 @@ package com.contrast.labs.ai.mcp.contrast.tool.coverage;
 import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
 import com.contrast.labs.ai.mcp.contrast.result.RouteCoverageResponseLight;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.routecoverage.RouteCoverageBySessionIDAndMetadataRequestExtended;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.data.routecoverage.RouteCoverageResponse;
+import com.contrast.labs.ai.mcp.contrast.tool.application.ApplicationLicenseDiscriminator;
+import com.contrast.labs.ai.mcp.contrast.tool.base.ActionableToolErrorException;
 import com.contrast.labs.ai.mcp.contrast.tool.base.NoticeCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleTool;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleToolResponse;
 import com.contrast.labs.ai.mcp.contrast.tool.coverage.params.RouteCoverageParams;
+import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.models.RouteCoverageMetadataLabelValues;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
@@ -41,15 +45,32 @@ import org.springframework.stereotype.Service;
 public class GetRouteCoverageTool
     extends SingleTool<RouteCoverageParams, RouteCoverageResponseLight> {
 
+  public static final String ARCHIVED_APPLICATION_ERROR =
+      "This application is archived. Route coverage is not available for archived applications."
+          + " The application ID is correct, do not retry. Unarchive the application in Contrast"
+          + " to view route coverage.";
+  public static final String UNLICENSED_APPLICATION_ERROR =
+      "This application is unlicensed and route coverage requires an Assess license. The"
+          + " application ID is correct, do not retry. Apply an Assess license to the application"
+          + " in Contrast to view route coverage.";
+  public static final String LICENSED_APPLICATION_ACCESS_DENIED_ERROR =
+      "Contrast denied access to route coverage even though the application is visible and"
+          + " licensed. This can occur briefly after a license change.";
+
+  private static final int HTTP_FORBIDDEN = 403;
+
   private final ContrastApiClient contrastApiClient;
   private final RouteMapper routeMapper;
+  private final ApplicationLicenseDiscriminator applicationLicenseDiscriminator;
 
   @Tool(
       name = "get_route_coverage",
       description =
           """
           Get route coverage for an application: which routes have been exercised by HTTP requests
-          and which were only discovered. Use search_applications to find application IDs.
+          and which were only discovered. Use search_applications to find application IDs. Route
+          coverage requires the application to hold an Assess license; unlicensed applications
+          return an error.
           """)
   public SingleToolResponse<RouteCoverageResponseLight> getRouteCoverage(
       @ToolParam(description = "Application ID") String appId,
@@ -133,7 +154,7 @@ public class GetRouteCoverageTool
 
     // Call API client to get route coverage
     log.debug("Fetching route coverage data for application ID: {}", params.appId());
-    var response = contrastApiClient.getRouteCoverage(params.appId(), request);
+    var response = fetchRouteCoverage(params.appId(), request);
 
     // Defensive null checks - API may return null on errors or permission issues
     if (response == null) {
@@ -164,5 +185,25 @@ public class GetRouteCoverageTool
 
     // Transform to light response to reduce payload size for AI agents
     return routeMapper.toResponseLight(response);
+  }
+
+  private RouteCoverageResponse fetchRouteCoverage(
+      String appId, RouteCoverageBySessionIDAndMetadataRequestExtended request) throws Exception {
+    try {
+      return contrastApiClient.getRouteCoverage(appId, request);
+    } catch (UnauthorizedException originalForbidden) {
+      if (originalForbidden.getCode() != HTTP_FORBIDDEN) {
+        throw originalForbidden;
+      }
+
+      var applicationState = applicationLicenseDiscriminator.discriminate(appId, originalForbidden);
+      var message =
+          switch (applicationState) {
+            case ARCHIVED -> ARCHIVED_APPLICATION_ERROR;
+            case UNLICENSED -> UNLICENSED_APPLICATION_ERROR;
+            case LICENSED -> LICENSED_APPLICATION_ACCESS_DENIED_ERROR;
+          };
+      throw new ActionableToolErrorException(message);
+    }
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/ApplicationLicenseDiscriminatorTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/ApplicationLicenseDiscriminatorTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.Application;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.ApplicationLicense;
+import com.contrast.labs.ai.mcp.contrast.tool.application.ApplicationLicenseDiscriminator.ApplicationState;
+import com.contrastsecurity.exceptions.UnauthorizedException;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ApplicationLicenseDiscriminatorTest {
+
+  private static final String APP_ID = "app-123";
+
+  private ContrastApiClient contrastApiClient;
+  private ApplicationLicenseDiscriminator discriminator;
+  private UnauthorizedException originalForbidden;
+
+  @BeforeEach
+  void setUp() {
+    contrastApiClient = mock();
+    discriminator = new ApplicationLicenseDiscriminator(contrastApiClient);
+    originalForbidden = new UnauthorizedException("Forbidden", "GET", "/route", 403, "Forbidden");
+  }
+
+  @Test
+  void discriminate_should_return_archived_when_application_is_archived() throws Exception {
+    var application = application(true, "Unlicensed");
+    when(contrastApiClient.getApplicationWithLicense(APP_ID)).thenReturn(application);
+
+    var result = discriminator.discriminate(APP_ID, originalForbidden);
+
+    assertThat(result).isEqualTo(ApplicationState.ARCHIVED);
+  }
+
+  @Test
+  void discriminate_should_return_unlicensed_when_application_is_not_licensed() throws Exception {
+    var application = application(false, "Unlicensed");
+    when(contrastApiClient.getApplicationWithLicense(APP_ID)).thenReturn(application);
+
+    var result = discriminator.discriminate(APP_ID, originalForbidden);
+
+    assertThat(result).isEqualTo(ApplicationState.UNLICENSED);
+  }
+
+  @Test
+  void discriminate_should_return_unlicensed_when_application_license_is_missing()
+      throws Exception {
+    var application = application(false, null);
+    when(contrastApiClient.getApplicationWithLicense(APP_ID)).thenReturn(application);
+
+    var result = discriminator.discriminate(APP_ID, originalForbidden);
+
+    assertThat(result).isEqualTo(ApplicationState.UNLICENSED);
+  }
+
+  @Test
+  void discriminate_should_return_licensed_when_application_is_visible_and_licensed()
+      throws Exception {
+    var application = application(false, ApplicationLicenseDiscriminator.LICENSED_LEVEL);
+    when(contrastApiClient.getApplicationWithLicense(APP_ID)).thenReturn(application);
+
+    var result = discriminator.discriminate(APP_ID, originalForbidden);
+
+    assertThat(result).isEqualTo(ApplicationState.LICENSED);
+  }
+
+  @Test
+  void discriminate_should_rethrow_original_forbidden_when_application_fetch_fails()
+      throws Exception {
+    when(contrastApiClient.getApplicationWithLicense(APP_ID))
+        .thenThrow(new IOException("Application lookup failed"));
+
+    assertThatThrownBy(() -> discriminator.discriminate(APP_ID, originalForbidden))
+        .isSameAs(originalForbidden);
+  }
+
+  @Test
+  void discriminate_should_rethrow_original_forbidden_when_application_fetch_returns_null()
+      throws Exception {
+    when(contrastApiClient.getApplicationWithLicense(APP_ID)).thenReturn(null);
+
+    assertThatThrownBy(() -> discriminator.discriminate(APP_ID, originalForbidden))
+        .isSameAs(originalForbidden);
+  }
+
+  private static Application application(boolean archived, String licenseLevel) {
+    var application = new Application();
+    application.setArchived(archived);
+    if (licenseLevel != null) {
+      var license = new ApplicationLicense();
+      license.setLevel(licenseLevel);
+      application.setLicense(license);
+    }
+    return application;
+  }
+}

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
@@ -213,6 +213,23 @@ class CursorPaginatedToolTest {
   }
 
   @Test
+  void executePipeline_should_surface_actionableToolErrorException_message_as_user_error() {
+    var actionableMessage = "Fix this condition before retrying.";
+    tool.setDoExecuteHandler(
+        (pagination, params, collector) -> {
+          throw new ActionableToolErrorException(actionableMessage);
+        });
+
+    var result = tool.executePipeline(OPAQUE_CURSOR, 25, TestParams::valid);
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors())
+        .as("ActionableToolErrorException message must surface verbatim")
+        .containsExactly(actionableMessage);
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
   void executePipeline_should_track_duration() {
     tool.setDoExecuteHandler(
         (pagination, params, collector) -> CursorExecutionResult.of(List.of("item"), null, false));

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolTest.java
@@ -203,6 +203,23 @@ class PaginatedToolTest {
   }
 
   @Test
+  void executePipeline_should_surface_actionableToolErrorException_message_as_user_error() {
+    var actionableMessage = "Fix this condition before retrying.";
+    tool.setDoExecuteHandler(
+        (pagination, params, collector) -> {
+          throw new ActionableToolErrorException(actionableMessage);
+        });
+
+    var result = tool.executePipeline(1, 10, () -> TestParams.valid());
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors())
+        .as("ActionableToolErrorException message must surface verbatim")
+        .containsExactly(actionableMessage);
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
   void executePipeline_should_calculate_hasMorePages_with_known_total() {
     tool.setDoExecuteHandler(
         (pagination, params, collector) ->

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolTest.java
@@ -216,6 +216,23 @@ class SingleToolTest {
   }
 
   @Test
+  void executePipeline_should_surface_actionableToolErrorException_message_as_user_error() {
+    var actionableMessage = "Fix this condition before retrying.";
+    tool.setDoExecuteHandler(
+        (params, collector) -> {
+          throw new ActionableToolErrorException(actionableMessage);
+        });
+
+    var result = tool.executePipeline(() -> TestParams.valid());
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors())
+        .as("ActionableToolErrorException message must surface verbatim")
+        .containsExactly(actionableMessage);
+    assertThat(result.data()).isNull();
+  }
+
+  @Test
   void executePipeline_should_include_params_notices() {
     tool.setDoExecuteHandler((params, notices) -> "result");
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolTest.java
@@ -34,6 +34,7 @@ import com.contrast.labs.ai.mcp.contrast.sdkextension.data.sessionmetadata.Agent
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.sessionmetadata.SessionMetadataResponse;
 import com.contrast.labs.ai.mcp.contrast.tool.application.ApplicationLicenseDiscriminator;
 import com.contrast.labs.ai.mcp.contrast.tool.application.ApplicationLicenseDiscriminator.ApplicationState;
+import com.contrast.labs.ai.mcp.contrast.tool.base.BaseTool;
 import com.contrastsecurity.exceptions.HttpResponseException;
 import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.models.RouteCoverageBySessionIDAndMetadataRequest;
@@ -292,6 +293,18 @@ class GetRouteCoverageToolTest {
   }
 
   @Test
+  void getRouteCoverage_should_bypass_license_discriminator_for_401() throws Exception {
+    when(contrastApiClient.getRouteCoverage(eq(VALID_APP_ID), isNull()))
+        .thenThrow(unauthorizedFailure(401));
+
+    var result = tool.getRouteCoverage(VALID_APP_ID, null, null, null, null);
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors()).containsExactly(BaseTool.AUTHENTICATION_OR_NOT_FOUND_ERROR);
+    verifyNoInteractions(applicationLicenseDiscriminator);
+  }
+
+  @Test
   void getRouteCoverage_should_return_unlicensed_error_when_route_coverage_403_is_discriminated()
       throws Exception {
     var originalForbidden = unauthorizedFailure();
@@ -405,7 +418,11 @@ class GetRouteCoverageToolTest {
   }
 
   private static UnauthorizedException unauthorizedFailure() {
+    return unauthorizedFailure(403);
+  }
+
+  private static UnauthorizedException unauthorizedFailure(int status) {
     return new UnauthorizedException(
-        "Downstream failure", "GET", "/ng/org/route", 403, "Forbidden", SECRET_BODY);
+        "Downstream failure", "GET", "/ng/org/route", status, "Unauthorized", SECRET_BODY);
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolTest.java
@@ -32,7 +32,10 @@ import com.contrast.labs.ai.mcp.contrast.sdkextension.data.routecoverage.RouteCo
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.routecoverage.RouteCoverageResponse;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.sessionmetadata.AgentSession;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.sessionmetadata.SessionMetadataResponse;
+import com.contrast.labs.ai.mcp.contrast.tool.application.ApplicationLicenseDiscriminator;
+import com.contrast.labs.ai.mcp.contrast.tool.application.ApplicationLicenseDiscriminator.ApplicationState;
 import com.contrastsecurity.exceptions.HttpResponseException;
+import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.models.RouteCoverageBySessionIDAndMetadataRequest;
 import com.contrastsecurity.sdk.internal.GsonFactory;
 import java.lang.reflect.Method;
@@ -80,12 +83,16 @@ class GetRouteCoverageToolTest {
       """;
 
   private ContrastApiClient contrastApiClient;
+  private ApplicationLicenseDiscriminator applicationLicenseDiscriminator;
   private GetRouteCoverageTool tool;
 
   @BeforeEach
   void setUp() {
     contrastApiClient = mock();
-    tool = new GetRouteCoverageTool(contrastApiClient, new RouteMapper());
+    applicationLicenseDiscriminator = mock();
+    tool =
+        new GetRouteCoverageTool(
+            contrastApiClient, new RouteMapper(), applicationLicenseDiscriminator);
   }
 
   @Test
@@ -111,6 +118,8 @@ class GetRouteCoverageToolTest {
     assertThat(result.data().totalRoutes()).isEqualTo(2);
     assertThat(result.notices()).doesNotContain(FILTERED_ENVIRONMENTS_NOTICE);
     verify(contrastApiClient).getRouteCoverage(eq(VALID_APP_ID), isNull());
+    verify(contrastApiClient, never()).getApplicationWithLicense(any());
+    verifyNoInteractions(applicationLicenseDiscriminator);
   }
 
   @Test
@@ -279,6 +288,57 @@ class GetRouteCoverageToolTest {
             "Access denied or resource not found. Verify credentials and that the resource ID is"
                 + " correct.");
     assertThat(result.toString()).doesNotContain(SECRET_BODY, "/ng/org/route");
+    verifyNoInteractions(applicationLicenseDiscriminator);
+  }
+
+  @Test
+  void getRouteCoverage_should_return_unlicensed_error_when_route_coverage_403_is_discriminated()
+      throws Exception {
+    var originalForbidden = unauthorizedFailure();
+    when(contrastApiClient.getRouteCoverage(eq(VALID_APP_ID), isNull()))
+        .thenThrow(originalForbidden);
+    when(applicationLicenseDiscriminator.discriminate(VALID_APP_ID, originalForbidden))
+        .thenReturn(ApplicationState.UNLICENSED);
+
+    var result = tool.getRouteCoverage(VALID_APP_ID, null, null, null, null);
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors()).containsExactly(GetRouteCoverageTool.UNLICENSED_APPLICATION_ERROR);
+    assertThat(result.data()).isNull();
+    verify(applicationLicenseDiscriminator).discriminate(VALID_APP_ID, originalForbidden);
+  }
+
+  @Test
+  void getRouteCoverage_should_return_archived_error_when_route_coverage_403_is_discriminated()
+      throws Exception {
+    var originalForbidden = unauthorizedFailure();
+    when(contrastApiClient.getRouteCoverage(eq(VALID_APP_ID), isNull()))
+        .thenThrow(originalForbidden);
+    when(applicationLicenseDiscriminator.discriminate(VALID_APP_ID, originalForbidden))
+        .thenReturn(ApplicationState.ARCHIVED);
+
+    var result = tool.getRouteCoverage(VALID_APP_ID, null, null, null, null);
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors()).containsExactly(GetRouteCoverageTool.ARCHIVED_APPLICATION_ERROR);
+    assertThat(result.data()).isNull();
+  }
+
+  @Test
+  void getRouteCoverage_should_return_residual_error_when_route_coverage_403_is_discriminated()
+      throws Exception {
+    var originalForbidden = unauthorizedFailure();
+    when(contrastApiClient.getRouteCoverage(eq(VALID_APP_ID), isNull()))
+        .thenThrow(originalForbidden);
+    when(applicationLicenseDiscriminator.discriminate(VALID_APP_ID, originalForbidden))
+        .thenReturn(ApplicationState.LICENSED);
+
+    var result = tool.getRouteCoverage(VALID_APP_ID, null, null, null, null);
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors())
+        .containsExactly(GetRouteCoverageTool.LICENSED_APPLICATION_ACCESS_DENIED_ERROR);
+    assertThat(result.data()).isNull();
   }
 
   @Test
@@ -342,5 +402,10 @@ class GetRouteCoverageToolTest {
   private static HttpResponseException apiFailure(int status) {
     return new HttpResponseException(
         "Downstream failure", "POST", "/ng/org/route", status, "Downstream failure", SECRET_BODY);
+  }
+
+  private static UnauthorizedException unauthorizedFailure() {
+    return new UnauthorizedException(
+        "Downstream failure", "GET", "/ng/org/route", 403, "Forbidden", SECRET_BODY);
   }
 }

--- a/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/client/SdkApiClient.java
+++ b/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/client/SdkApiClient.java
@@ -27,6 +27,7 @@ import com.contrast.labs.ai.mcp.contrast.sdkextension.data.adr.AttacksFilterBody
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.adr.AttacksResponse;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.AppMetadataField;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.AppMetadataFilter;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.Application;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.ApplicationsResponse;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.routecoverage.RouteCoverageResponse;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.sca.LibraryObservation;
@@ -69,6 +70,13 @@ public class SdkApiClient implements ContrastApiClient {
   @Override
   public List<AppMetadataField> getApplicationMetadataFields() throws Exception {
     return sdkExtensionFactory.getSDKExtension().getApplicationMetadataFields(localOrganization());
+  }
+
+  @Override
+  public Application getApplicationWithLicense(String appId) throws Exception {
+    return sdkExtensionFactory
+        .getSDKExtension()
+        .getApplicationWithLicense(localOrganization(), appId);
   }
 
   @Override

--- a/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtension.java
+++ b/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtension.java
@@ -23,6 +23,8 @@ import com.contrast.labs.ai.mcp.contrast.sdkextension.data.adr.AttacksResponse;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.AppMetadataField;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.AppMetadataFieldsResponse;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.AppMetadataFilter;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.Application;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.ApplicationResponse;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.ApplicationsFilterRequest;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.ApplicationsResponse;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.routecoverage.RouteCoverageResponse;
@@ -34,6 +36,7 @@ import com.contrast.labs.ai.mcp.contrast.sdkextension.data.server.ServersRespons
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.sessionmetadata.SessionMetadataResponse;
 import com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants;
 import com.contrastsecurity.exceptions.UnauthorizedException;
+import com.contrastsecurity.http.FilterForm.ApplicationExpandValues;
 import com.contrastsecurity.http.HttpMethod;
 import com.contrastsecurity.http.LibraryFilterForm;
 import com.contrastsecurity.http.MediaType;
@@ -268,7 +271,8 @@ public class SDKExtension {
   public ApplicationsResponse getApplications(String organizationId)
       throws UnauthorizedException, IOException {
     var url =
-        urlBuilder.getApplicationsUrl(organizationId) + "&expand=metadata,technologies,skip_links";
+        urlBuilder.getApplicationsUrl(organizationId)
+            + "&expand=metadata,technologies,license,skip_links";
 
     // When debug logging is enabled, buffer the response for logging
     if (log.isDebugEnabled()) {
@@ -331,6 +335,19 @@ public class SDKExtension {
                 HttpMethod.POST, url, gson.toJson(requestBody), MediaType.JSON);
         Reader reader = new InputStreamReader(is, StandardCharsets.UTF_8)) {
       return gson.fromJson(reader, ApplicationsResponse.class);
+    }
+  }
+
+  /** Fetches one application with its merged license level, including archived applications. */
+  public Application getApplicationWithLicense(String organizationId, String appId)
+      throws UnauthorizedException, IOException {
+    var url =
+        urlBuilder.getApplicationUrl(
+            organizationId, appId, EnumSet.of(ApplicationExpandValues.LICENSE));
+
+    try (InputStream is = contrastSDK.makeRequest(HttpMethod.GET, url);
+        Reader reader = new InputStreamReader(is, StandardCharsets.UTF_8)) {
+      return gson.fromJson(reader, ApplicationResponse.class).getApplication();
     }
   }
 

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtensionResponseHandlingTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtensionResponseHandlingTest.java
@@ -222,7 +222,7 @@ class SDKExtensionResponseHandlingTest {
     }
 
     @Test
-    void getApplications_should_request_the_metadata_and_technologies_expansions()
+    void getApplications_should_request_metadata_technologies_and_license_expansions()
         throws Exception {
       when(sdk.makeRequest(any(), any())).thenReturn(body("{\"applications\":[]}"));
 
@@ -231,7 +231,7 @@ class SDKExtensionResponseHandlingTest {
       verify(sdk)
           .makeRequest(
               eq(HttpMethod.GET),
-              argThat(url -> url.contains("expand=metadata,technologies,skip_links")));
+              argThat(url -> url.contains("expand=metadata,technologies,license,skip_links")));
     }
   }
 

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtensionTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtensionTest.java
@@ -128,6 +128,36 @@ class SDKExtensionTest {
   }
 
   @Test
+  void getApplicationWithLicense_should_fetch_single_application_with_license_expand()
+      throws Exception {
+    var mockResponse =
+        """
+        {
+          "application": {
+            "app_id": "app-456",
+            "archived": true,
+            "license": {"level": "Unlicensed"}
+          }
+        }
+        """;
+    when(sdk.makeRequest(eq(HttpMethod.GET), any()))
+        .thenReturn(new ByteArrayInputStream(mockResponse.getBytes(StandardCharsets.UTF_8)));
+
+    var result = sdkExtension.getApplicationWithLicense("org-123", "app-456");
+
+    assertThat(result.getAppId()).isEqualTo("app-456");
+    assertThat(result.isArchived()).isTrue();
+    assertThat(result.getLicense().getLevel()).isEqualTo("Unlicensed");
+    verify(sdk)
+        .makeRequest(
+            eq(HttpMethod.GET),
+            argThat(
+                url ->
+                    url.contains("/ng/org-123/applications/app-456")
+                        && url.contains("expand=license")));
+  }
+
+  @Test
   void getApplicationsFiltered_should_include_metadata_filters_in_request() throws Exception {
     var mockResponse =
         """

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageLocalParityTest.java
@@ -26,10 +26,14 @@ import com.contrast.labs.ai.mcp.contrast.client.SdkApiClient;
 import com.contrast.labs.ai.mcp.contrast.config.ContrastSDKFactory;
 import com.contrast.labs.ai.mcp.contrast.config.SDKExtensionFactory;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.SDKExtension;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.Application;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.ApplicationLicense;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.routecoverage.Route;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.routecoverage.RouteCoverageResponse;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.sessionmetadata.AgentSession;
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.sessionmetadata.SessionMetadataResponse;
+import com.contrast.labs.ai.mcp.contrast.tool.application.ApplicationLicenseDiscriminator;
+import com.contrastsecurity.exceptions.UnauthorizedException;
 import com.contrastsecurity.models.RouteCoverageBySessionIDAndMetadataRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
@@ -58,7 +62,9 @@ class GetRouteCoverageLocalParityTest {
   @BeforeEach
   void setUp() {
     var sdkApiClient = new SdkApiClient(sdkFactory, sdkExtensionFactory);
-    tool = new GetRouteCoverageTool(sdkApiClient, new RouteMapper());
+    tool =
+        new GetRouteCoverageTool(
+            sdkApiClient, new RouteMapper(), new ApplicationLicenseDiscriminator(sdkApiClient));
     when(sdkFactory.getOrgId()).thenReturn(TEST_ORG_ID);
     when(sdkExtensionFactory.getSDKExtension()).thenReturn(sdkExtension);
   }
@@ -101,6 +107,26 @@ class GetRouteCoverageLocalParityTest {
     assertThat(result.isSuccess()).isTrue();
     assertThat(requestCaptor.getValue().getSessionID()).isEqualTo(TEST_SESSION_ID);
     assertThat(objectMapper.writeValueAsString(result)).doesNotContain(TEST_ORG_ID);
+  }
+
+  @Test
+  void getRouteCoverage_should_surface_unlicensed_error_through_local_sdk_client()
+      throws Exception {
+    var originalForbidden =
+        new UnauthorizedException("Forbidden", "GET", "/route", 403, "Forbidden");
+    var application = new Application();
+    var license = new ApplicationLicense();
+    license.setLevel("Unlicensed");
+    application.setLicense(license);
+    when(sdkExtension.getRouteCoverage(TEST_ORG_ID, TEST_APP_ID, null))
+        .thenThrow(originalForbidden);
+    when(sdkExtension.getApplicationWithLicense(TEST_ORG_ID, TEST_APP_ID)).thenReturn(application);
+
+    var result = tool.getRouteCoverage(TEST_APP_ID, null, null, null);
+
+    verify(sdkExtension).getApplicationWithLicense(TEST_ORG_ID, TEST_APP_ID);
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors()).containsExactly(GetRouteCoverageTool.UNLICENSED_APPLICATION_ERROR);
   }
 
   private static RouteCoverageResponse routeCoverageResponse(String signature) {

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolIT.java
@@ -15,11 +15,15 @@
  */
 package com.contrast.labs.ai.mcp.contrast.tool.coverage;
 
+import static com.contrast.labs.ai.mcp.contrast.tool.application.ApplicationLicenseDiscriminator.LICENSED_LEVEL;
+import static com.contrast.labs.ai.mcp.contrast.tool.coverage.GetRouteCoverageTool.UNLICENSED_APPLICATION_ERROR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrast.labs.ai.mcp.contrast.config.IntegrationTestConfig;
 import com.contrast.labs.ai.mcp.contrast.result.RouteCoverageResponseLight;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.data.application.Application;
 import com.contrast.labs.ai.mcp.contrast.util.AbstractIntegrationTest;
+import com.contrast.labs.ai.mcp.contrast.util.IntegrationTestDataCache;
 import com.contrast.labs.ai.mcp.contrast.util.TestDataDiscoveryHelper;
 import com.contrast.labs.ai.mcp.contrast.util.TestDataDiscoveryHelper.RouteCoverageTestData;
 import java.io.IOException;
@@ -96,19 +100,22 @@ public class GetRouteCoverageToolIT
     boolean hasSessionMetadata;
     String sessionMetadataName;
     String sessionMetadataValue;
+    String unlicensedAppId;
     int routeCount;
 
     @Override
     public String toString() {
       return String.format(
           "TestData{appId='%s', appName='%s', hasRouteCoverage=%s, hasSessionMetadata=%s, "
-              + "sessionMetadataName='%s', sessionMetadataValue='%s', routeCount=%d}",
+              + "sessionMetadataName='%s', sessionMetadataValue='%s', unlicensedAppId='%s', "
+              + "routeCount=%d}",
           appId,
           appName,
           hasRouteCoverage,
           hasSessionMetadata,
           sessionMetadataName,
           sessionMetadataValue,
+          unlicensedAppId,
           routeCount);
     }
   }
@@ -121,6 +128,11 @@ public class GetRouteCoverageToolIT
   @Override
   protected Class<TestData> testDataType() {
     return TestData.class;
+  }
+
+  @Override
+  protected int discoveryVersion() {
+    return 2;
   }
 
   @Override
@@ -148,6 +160,13 @@ public class GetRouteCoverageToolIT
       throw new NoTestDataException(buildTestDataErrorMessage(50));
     }
 
+    var unlicensedApplication = findUnlicensedApplication();
+    if (unlicensedApplication.isEmpty()) {
+      throw new NoTestDataException(
+          "No visible unlicensed application found in the application list returned with license"
+              + " expansion.");
+    }
+
     var candidate = routeCandidate.get();
     var data = new TestData();
     data.appId = candidate.application().getAppId();
@@ -157,7 +176,17 @@ public class GetRouteCoverageToolIT
     data.hasSessionMetadata = candidate.hasSessionMetadata();
     data.sessionMetadataName = candidate.sessionMetadataName();
     data.sessionMetadataValue = candidate.sessionMetadataValue();
+    data.unlicensedAppId = unlicensedApplication.get().getAppId();
     return data;
+  }
+
+  private Optional<Application> findUnlicensedApplication() throws IOException {
+    var applications = IntegrationTestDataCache.getApplications(orgId, sdkExtension);
+    return applications.stream()
+        .filter(application -> !application.isArchived())
+        .filter(application -> application.getLicense() != null)
+        .filter(application -> !LICENSED_LEVEL.equals(application.getLicense().getLevel()))
+        .findFirst();
   }
 
   @Override
@@ -413,6 +442,21 @@ public class GetRouteCoverageToolIT
   }
 
   // ========== Error handling tests ==========
+
+  @Test
+  void getRouteCoverage_should_return_unlicensed_error_for_unlicensed_application() {
+    assertThat(testData.unlicensedAppId)
+        .as("requires an unlicensed application discovered with license expansion")
+        .isNotBlank();
+
+    var response =
+        getRouteCoverageTool.getRouteCoverage(testData.unlicensedAppId, null, null, null);
+
+    assertThat(response.isSuccess()).isFalse();
+    assertThat(response.found()).isFalse();
+    assertThat(response.data()).isNull();
+    assertThat(response.errors()).containsExactly(UNLICENSED_APPLICATION_ERROR);
+  }
 
   @Test
   void getRouteCoverage_should_not_return_populated_data_for_invalid_appId() {


### PR DESCRIPTION
<!-- pr-tools:stacked:v1 -->
<!-- pr-tools:parent-pr=217 -->
<!-- pr-tools:parent-branch=AIML-1353-validate-vuln-types -->
<!-- pr-tools:parent-base=AIML-1352-normalize-vuln-status -->
<!-- pr-tools:boundary-commit=3be18148fd4c98e4743c1249418d389bae22e726 -->
<!-- pr-tools:managed:start -->
<!-- pr-tools:managed:end -->

**Jira:** [AIML-1354](https://contrast.atlassian.net/browse/AIML-1354)

## Summary

When an AI agent calls `get_route_coverage` on an unlicensed or archived application, TeamServer returns an opaque HTTP 403 ("Authorization failure") that the MCP server surfaces as "Access denied or resource not found. Verify credentials and that the resource ID is correct." The agent then retries in a loop, questions its credentials, and reports a broken setup. This PR discriminates the cause of the 403 and returns a truthful, actionable error that tells the agent exactly what is wrong and what to do about it.

- Unlicensed, archived, and residual-denial cases each get a distinct, non-retryable error message
- Zero added API calls on the happy path
- Shared `ActionableToolErrorException` mechanism for future use by sibling ticket AIML-1137

## Why This Change Exists

TeamServer's `RouteCoverageAnalyticsRestController` enforces `isAppEnterprise(#app)` at the class level, which requires the application's merged license service level to be exactly "Licensed". Any other level produces an undiscriminated 403. The MCP server's generic 403 handler cannot distinguish a credential problem from a license denial, so it emits advice that is factually wrong for the license case. Verified against staging: 9/9 unlicensed apps across six languages returned 403, 2/2 licensed apps returned 200, and an app with no coverage data returns 200 with an empty routes list.

## Approach

Follows the AIML-1137 precedent: discriminate only after a 403 arrives, never speculatively. On a 403 from the route coverage endpoint, `GetRouteCoverageTool.fetchRouteCoverage` catches the `UnauthorizedException`, calls `ApplicationLicenseDiscriminator.discriminate`, and throws an `ActionableToolErrorException` with the appropriate message. The discriminator fetches the single application with license expansion (an endpoint that remains available for archived and unlicensed apps) and classifies the state as ARCHIVED, UNLICENSED, or LICENSED. If the discriminator lookup itself fails, the original 403 is rethrown so the generic message surfaces, which is then actually true.

`ActionableToolErrorException` is a new exception type caught by `SingleTool.executePipeline` and surfaced verbatim as the error message. This replaces the need for `IllegalArgumentException` overloading and will be reused by AIML-1137.

## What Changed

### Core domain (`contrast-mcp-core`)
- `ApplicationLicenseDiscriminator` (new) — reusable service that fetches an application's license state after a 403 and classifies it as ARCHIVED, UNLICENSED, or LICENSED
- `ApplicationLicense`, `ApplicationResponse` (new) — data models for the single-application-with-license response
- `Application` — added `license` field with `@SerializedName`
- `ActionableToolErrorException` (new) — exception whose message is safe and actionable for the caller, caught by `SingleTool`
- `SingleTool` — catches `ActionableToolErrorException` and surfaces its message verbatim
- `GetRouteCoverageTool` — extracted `fetchRouteCoverage` that intercepts 403s, runs the discriminator, and throws the appropriate actionable error; updated tool description to mention the Assess license requirement
- `ContrastApiClient` — added `getApplicationWithLicense(appId)` method

### Local app (`contrast-mcp-stdio-app`)
- `SdkApiClient` — implements `getApplicationWithLicense` via `SDKExtension`
- `SDKExtension` — added `getApplicationWithLicense` using the single-application endpoint with `expand=license`; also added `license` to the existing `getApplications` expansion list

### Domain glossary
- `CONTEXT.md` — added "Licensed application" and "Route coverage" terms

## Testing

**Unit tests:**
- `ApplicationLicenseDiscriminatorTest` — all discriminator branches: archived app, unlicensed app, null license, licensed app, fetch failure (rethrows original), null application (rethrows original)
- `GetRouteCoverageToolTest` — three new tests covering the unlicensed, archived, and residual-denial 403 paths; existing happy-path test verifies discriminator is never invoked on success
- `SingleToolTest` — verifies `ActionableToolErrorException` message surfaces verbatim as user error
- `SDKExtensionTest` — verifies `getApplicationWithLicense` sends the correct URL with `expand=license`
- `SDKExtensionResponseHandlingTest` — updated to verify the applications list endpoint now includes `license` in its expansion

**Parity test:**
- `GetRouteCoverageLocalParityTest` — new test wires the real `SdkApiClient` → `SDKExtension` → discriminator chain end-to-end with mocks and verifies the unlicensed error surfaces through the local client

**Integration test:**
- `GetRouteCoverageToolIT` — new test discovers an unlicensed application via the license expansion on `search_applications` results, calls `get_route_coverage` against it, and asserts the exact `UNLICENSED_APPLICATION_ERROR` message. Discovery version bumped to invalidate stale cached test data.

## Risks / Rollout / Follow-ups

- Error message wording ships without blocking product sign-off. The messages are factual and actionable, but phrasing may be refined after review.
- The discriminator makes one extra API call only on the 403 path. Happy-path performance is unchanged.
- Follow-up bead `mcp-q5zb8` tracks surfacing license level in `search_applications` results so agents can predict which apps will work before calling `get_route_coverage`.
- Sibling ticket AIML-1137 will reuse `ApplicationLicenseDiscriminator` and `ActionableToolErrorException` for vulnerability detail reads.
- Hosted MCP (`aiml-services`) needs a corresponding `getApplicationWithLicense` implementation, tracked separately.


[AIML-1354]: https://contrast.atlassian.net/browse/AIML-1354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ