### PR TITLE
AIML-1362 Add /release orchestration skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,79 +1,96 @@
 ---
 name: release
-description: Orchestrate a full release of mcp-contrast end to end. Preflight checks, release ticket and branch creation, changelog update and version stamp, smoke test, dispatch and monitoring of the Gradle Release workflow, post-release artifact verification, and the Jira/bead sweep. Run when a human asks to cut, make, or ship a release. Human gates at version choice, changelog approval, and dispatch. Optional argument is an explicit version, e.g. /release 2.5.0.
+description: Orchestrate a full release of mcp-contrast end to end, changelog-first. Preflight, deferred-landing changelog draft, version gate, release ticket and branch, smoke test, Gradle Release dispatch and monitoring, artifact verification, release-notes sync, tracker sweep, and Slack announcement. Run when a human asks to cut, make, or ship a release. Human gates at changelog approval, version choice, changelog PR merge, go/no-go, tracker sweep, and the Slack post.
 ---
 
 # Release orchestration
 
 Runs the whole release documented in RELEASING.md, composing `/update-changelog` and
-`/test-mcp-server`. The skill owns the sequence, the preflight judgment, the version
-stamp, workflow dispatch and monitoring, post-release verification, and the tracker
-sweep. Publishing to Artifactory and DockerHub is irreversible, so three human gates
-are mandatory: version choice, changelog approval, and go/no-go before dispatch.
+`/test-mcp-server`. The flow is changelog-first: the audited changelog draft is the
+evidence for the version decision, and the release ticket and branch are created only
+after the human approves the version, so they are born with the right number.
+Publishing to Artifactory and DockerHub is irreversible, so the human gates below are
+mandatory, never skipped.
 
 ## Usage
 
-- `/release` runs the full flow, recommending the next version.
-- `/release X.Y.Z` uses the given version (no leading `v`).
+`/release` takes no arguments. The version always comes from the suggest-and-approve
+gate in Phase 3.
 
 ## Re-entry
 
 Releases fail mid-flight more than anywhere else. On re-entry, detect completed work
-and skip it: if the stamped changelog is already on `origin/main`, go straight to
-Phase 4 or 5; if the release workflow already ran and only verification is missing,
-go to Phase 6. The workflow itself is safe to re-dispatch because it reuses an
-existing `vX.Y.Z` tag at HEAD.
+from the repo and skip it: stamped changelog already on `origin/main` → go to Phase 5
+or 6; release workflow already succeeded → go to Phase 7. The workflow itself is safe
+to re-dispatch because it reuses an existing `vX.Y.Z` tag at HEAD.
 
 ## Phase 1 — Preflight (read-only)
 
 1. `git fetch origin --tags -q`. Confirm the working tree is clean and HEAD matches
    `origin/main`. If not, stop and tell the human.
 2. Confirm CI is green: `gh run list --branch main --workflow build.yml --limit 1
-   --json conclusion,headSha` and check the run covers the current `origin/main` HEAD.
+   --json conclusion,headSha` and check the run covers the current `origin/main`
+   HEAD. Red or stale CI stops the release by default. The human may explicitly
+   override for a known-flaky failure, record the override in the final report.
 3. Find the last release tag: `git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1`.
 4. Enumerate the release content: `git log --oneline --merges vLAST..origin/main`,
    plus the same without `--merges` for direct commits. If the range is empty, there
    is nothing to release, stop.
-5. Recommend the next version from the change set: breaking changes → major, new
-   capabilities → minor, fixes only → patch. Confirm the version with the human
-   (explicit argument wins, but still show what the range contains). If later
-   changelog work changes the classification, re-confirm before stamping.
+5. If every change in the range is internal (CI config, dependabot, refactors), ask
+   the human whether to ship a dependency-bump release anyway. If yes, the Phase 2
+   draft must include a section summarizing the dependency updates (drawn from the
+   dependabot PR titles, house style) so the stamped section is never empty.
 
-## Phase 2 — Release ticket and branch
+## Phase 2 — Changelog draft (deferred landing)
+
+Run `/update-changelog` in its **deferred-landing mode**: it drafts, audits, and gets
+the human's approval of the `[Unreleased]` content, but commits nothing, the landing
+branch does not exist yet. It returns the approved draft and its suggested next
+version, computed under the semver definition that lives in that skill.
+
+## Phase 3 — Version gate
+
+Present the version decision with AskUserQuestion: three options, each showing the
+computed number and a one-line rationale citing the draft evidence, e.g.
+`Minor → 2.5.0 (Recommended)`, `Patch → 2.4.1`, `Major → 3.0.0`. The changelog
+skill's suggestion is the recommended option. The human's choice is final for
+naming, only the Phase 6 loop-back can reopen it.
+
+## Phase 4 — Release ticket, branch, and landing
 
 1. Create the release Jira ticket via the `jira-workflow` skill: AIML Task,
    component `Contrast MCP Server`, summary `Release mcp-contrast X.Y.Z`, assigned
    to the current user, transitioned to In Progress. Create the matching bead per
    `bead-workflow` (title prefix, external-ref, Jira URL comment).
-2. Create the release branch from `origin/main`: `AIML-<id>-release-X.Y.Z`. The
-   changelog and stamp commits land here.
+2. Create the release branch from `origin/main`: `AIML-<id>-release-X.Y.Z`.
+3. Land two commits: the approved changelog draft
+   (`AIML-<id> Update changelog for X.Y.Z release`), then the stamp, insert
+   `## [X.Y.Z] - <today>` directly below `## [Unreleased]`, moving the unreleased
+   content under the new heading and leaving `[Unreleased]` empty
+   (`AIML-<id> Stamp vX.Y.Z release heading`). Two commits, matching the
+   established pattern (e.g. v2.4.0).
+4. Push, open the PR with `pr-tools:create-pr`, and wait for the human to merge.
+   The PR is the human's second look at the changelog.
+5. Verify the stamp reached `origin/main` before continuing.
 
-## Phase 3 — Changelog and stamp
-
-1. From the release branch, run `/update-changelog`. Choose current-branch mode so
-   its commit lands on the release branch. It has its own approval gate.
-2. After approval, stamp the version: insert `## [X.Y.Z] - <today>` directly below
-   `## [Unreleased]`, moving the unreleased content under the new heading and leaving
-   `[Unreleased]` empty. Commit separately: `AIML-<id> Stamp vX.Y.Z release heading`
-   (matches the established two-commits-one-branch pattern, e.g. v2.4.0).
-3. Push and open the PR with `pr-tools:create-pr`, then wait for the human to merge.
-4. Verify the stamp reached `origin/main` before continuing.
-
-## Phase 4 — Smoke test
+## Phase 5 — Smoke test
 
 Sync the local checkout to the merged `origin/main` first, the test builds the jar
 from the current checkout and it must exercise the exact content that gets tagged.
 Then run `/test-mcp-server smoke` (always pass the mode explicitly, the skill asks
-otherwise). Show the human the report. It is a judgment aid, not a gate, but the
-human decides whether to continue.
+otherwise). Show the human the report. It is purely advisory, the smoke test drives
+a live org and flaky data is expected, so no failure class blocks by itself. The
+human decides at the next gate.
 
-## Phase 5 — Go/no-go and dispatch
+## Phase 6 — Go/no-go and dispatch
 
 1. Guard: re-fetch and confirm `origin/main` HEAD is still the commit the stamped
    changelog covers. If another PR merged in between, the tag would ship
-   undocumented changes, loop back to Phase 3. On that loop-back, this skill owns
-   folding the new entries into the stamped `[X.Y.Z]` section, `/update-changelog`
-   treats stamped versions as settled and will not reopen them.
+   undocumented changes. On this loop-back, this skill owns folding the new entries
+   into the stamped `[X.Y.Z]` section (`/update-changelog` treats stamped versions
+   as settled and will not reopen them). If the new entries escalate the version
+   class, re-confirm the version with the human, retitle the Jira ticket, restamp,
+   and keep the branch name, it is scaffolding with a merged PR hanging off it.
 2. Ask the human for an explicit go/no-go.
 3. Dispatch with the version spelled out, never blank, so the tag cannot diverge
    from the stamped heading:
@@ -87,10 +104,12 @@ human decides whether to continue.
    check `createdAt` is after the dispatch (guards against grabbing a stale run).
 5. Monitor with `gh run watch <id> --exit-status` as a background task
    (`run_in_background`), the run exceeds the foreground ceiling. Do not poll.
-6. On failure, `gh run view <id> --log-failed`, diagnose, and report. Transient
-   failures are fixed by re-dispatching (see Re-entry).
+6. On failure, `gh run view <id> --log-failed`, diagnose, report, and wait for the
+   human. Never re-dispatch on your own, the workflow publishes to three external
+   registries and a partial-publish state needs a human to see which steps
+   completed first.
 
-## Phase 6 — Post-release verification
+## Phase 7 — Post-release verification
 
 1. Release assets: `gh release view vX.Y.Z --json assets` must show five files, the
    jar plus four SBOMs (jar and Docker image, CycloneDX and SPDX each).
@@ -101,20 +120,42 @@ human decides whether to continue.
    If anonymous read is refused, note it and rely on the workflow's publish step
    having succeeded.
 
-## Phase 7 — Tracker sweep
+For any failed check, report it together with a suggested remediation path (which
+workflow step to inspect, whether re-dispatch is safe). Do not attempt remediation
+yourself, a half-published release is exactly where automation causes damage.
+
+## Phase 8 — Release notes
+
+Replace the workflow's auto-generated GitHub release notes with the stamped
+changelog section, one source of truth for what users read:
+
+```bash
+gh release edit vX.Y.Z --notes-file <file containing the [X.Y.Z] section>
+```
+
+## Phase 9 — Tracker sweep
 
 1. Derive shipped AIML ids from the merge commits in `vLAST..vX.Y.Z` (branch names
    in merge subjects). Skip dependabot PRs.
-2. Via the `jira-workflow` skill, transition shipped tickets from Ready to Deploy to
-   Closed (`81`), the release ticket included. Closed is reserved for code released
-   to production, which is now true.
-3. Close the matching beads per `bead-workflow`, asking the human first, then
-   `br sync --flush-only`.
+2. Show the human the full list with each ticket's current status and let them pick
+   the set to transition. Transition the chosen tickets to Closed (`81`) via the
+   `jira-workflow` skill, the release ticket included. Closed is reserved for code
+   released to production, which is now true.
+3. Close the matching beads per `bead-workflow` after one batch confirmation showing
+   the full list, then `br sync --flush-only`.
 
-## Phase 8 — Report
+## Phase 10 — Announce
 
-Close with the version, tag, GitHub Release URL, each verification result, and the
-tickets and beads transitioned.
+Only after Phase 7 passed, never for a failed or abandoned release: draft a Slack
+post for `#_aiml-team` from the stamped changelog section plus the GitHub Release
+link (which links onward to everything else). Show the human the draft and send it
+only on their approval.
+
+## Report
+
+Close with the version, tag, GitHub Release URL, each verification result, any CI
+override recorded in Phase 1, the tickets and beads transitioned, and the Slack
+post status.
 
 ## Notes
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -29,8 +29,8 @@ to re-dispatch because it reuses an existing `vX.Y.Z` tag at HEAD.
 1. `git fetch origin --tags -q`. Confirm the working tree is clean and HEAD matches
    `origin/main`. If not, stop and tell the human.
 2. Verify the `pr-tools` plugin is available (check for `/pr-tools:create-pr` in the
-   skill list). Phase 4 and `/update-changelog` depend on it. If missing, stop and
-   tell the human to install it per the CLAUDE.md "Required Plugins" section.
+   skill list). Phase 4 depends on it. If missing, stop and tell the human to
+   install it per the CLAUDE.md "Required Plugins" section.
 3. Confirm CI is green: `gh run list --branch main --workflow build.yml --limit 1
    --json conclusion,headSha` and check the run covers the current `origin/main`
    HEAD. Red or stale CI stops the release by default. The human may explicitly
@@ -143,11 +143,12 @@ gh release edit vX.Y.Z --notes-file <file containing the [X.Y.Z] section>
 
 ## Phase 9 — Tracker sweep
 
-1. Derive shipped AIML ids from the PRs merged to `main` in the `vLAST..vX.Y.Z`
-   range. List PRs merged in the window with `gh pr list --base main --state merged`
-   filtered to merge commits in the tag range, then extract `AIML-\d+` from PR
-   titles. Fall back to scanning all commit subjects in the range for `AIML-\d+` to
-   catch direct-to-main commits without a PR. Deduplicate and skip dependabot PRs.
+1. Derive shipped AIML ids from two sources, union and deduplicate the results.
+   First, `gh pr list --state merged --json number,title,mergeCommit --limit 200`,
+   keep PRs whose merge SHA appears in `git rev-list vLAST..vX.Y.Z`, extract
+   `AIML-\d+` from their titles. Second, scan every commit subject in
+   `vLAST..vX.Y.Z` for `AIML-\d+` to catch direct commits and collapsed stack
+   merges. Skip dependabot PRs.
 2. Show the human the full list with each ticket's current status and let them pick
    the set to transition. Transition the chosen tickets to Closed (`81`) via the
    `jira-workflow` skill, the release ticket included. Closed is reserved for code

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -48,6 +48,11 @@ the human's approval of the `[Unreleased]` content, but commits nothing, the lan
 branch does not exist yet. It returns the approved draft and its suggested next
 version, computed under the semver definition that lives in that skill.
 
+For a dependency-bump-only release (the Phase 1 ask), pass guidance overriding the
+usual internal classification, e.g. `treat the dependabot bumps as a Security entry,
+this is a dependency-only release`. Without it the skill classifies dependabot
+changes as internal and returns an empty draft.
+
 ## Phase 3 — Version gate
 
 Present the version decision with AskUserQuestion: three options, each showing the

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -28,15 +28,18 @@ to re-dispatch because it reuses an existing `vX.Y.Z` tag at HEAD.
 
 1. `git fetch origin --tags -q`. Confirm the working tree is clean and HEAD matches
    `origin/main`. If not, stop and tell the human.
-2. Confirm CI is green: `gh run list --branch main --workflow build.yml --limit 1
+2. Verify the `pr-tools` plugin is available (check for `/pr-tools:create-pr` in the
+   skill list). Phase 4 and `/update-changelog` depend on it. If missing, stop and
+   tell the human to install it per the CLAUDE.md "Required Plugins" section.
+3. Confirm CI is green: `gh run list --branch main --workflow build.yml --limit 1
    --json conclusion,headSha` and check the run covers the current `origin/main`
    HEAD. Red or stale CI stops the release by default. The human may explicitly
    override for a known-flaky failure, record the override in the final report.
-3. Find the last release tag: `git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1`.
-4. Enumerate the release content: `git log --oneline --merges vLAST..origin/main`,
+4. Find the last release tag: `git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1`.
+5. Enumerate the release content: `git log --oneline --merges vLAST..origin/main`,
    plus the same without `--merges` for direct commits. If the range is empty, there
    is nothing to release, stop.
-5. If every change in the range is internal (CI config, dependabot, refactors), ask
+6. If every change in the range is internal (CI config, dependabot, refactors), ask
    the human whether to ship a dependency-bump release anyway. If yes, the Phase 2
    draft must include a section summarizing the dependency updates (drawn from the
    dependabot PR titles, house style) so the stamped section is never empty.
@@ -140,8 +143,11 @@ gh release edit vX.Y.Z --notes-file <file containing the [X.Y.Z] section>
 
 ## Phase 9 — Tracker sweep
 
-1. Derive shipped AIML ids from the merge commits in `vLAST..vX.Y.Z` (branch names
-   in merge subjects). Skip dependabot PRs.
+1. Derive shipped AIML ids from the PRs merged to `main` in the `vLAST..vX.Y.Z`
+   range. List PRs merged in the window with `gh pr list --base main --state merged`
+   filtered to merge commits in the tag range, then extract `AIML-\d+` from PR
+   titles. Fall back to scanning all commit subjects in the range for `AIML-\d+` to
+   catch direct-to-main commits without a PR. Deduplicate and skip dependabot PRs.
 2. Show the human the full list with each ticket's current status and let them pick
    the set to transition. Transition the chosen tickets to Closed (`81`) via the
    `jira-workflow` skill, the release ticket included. Closed is reserved for code

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: release
+description: Orchestrate a full release of mcp-contrast end to end. Preflight checks, release ticket and branch creation, changelog update and version stamp, smoke test, dispatch and monitoring of the Gradle Release workflow, post-release artifact verification, and the Jira/bead sweep. Run when a human asks to cut, make, or ship a release. Human gates at version choice, changelog approval, and dispatch. Optional argument is an explicit version, e.g. /release 2.5.0.
+---
+
+# Release orchestration
+
+Runs the whole release documented in RELEASING.md, composing `/update-changelog` and
+`/test-mcp-server`. The skill owns the sequence, the preflight judgment, the version
+stamp, workflow dispatch and monitoring, post-release verification, and the tracker
+sweep. Publishing to Artifactory and DockerHub is irreversible, so three human gates
+are mandatory: version choice, changelog approval, and go/no-go before dispatch.
+
+## Usage
+
+- `/release` runs the full flow, recommending the next version.
+- `/release X.Y.Z` uses the given version (no leading `v`).
+
+## Re-entry
+
+Releases fail mid-flight more than anywhere else. On re-entry, detect completed work
+and skip it: if the stamped changelog is already on `origin/main`, go straight to
+Phase 4 or 5; if the release workflow already ran and only verification is missing,
+go to Phase 6. The workflow itself is safe to re-dispatch because it reuses an
+existing `vX.Y.Z` tag at HEAD.
+
+## Phase 1 — Preflight (read-only)
+
+1. `git fetch origin --tags -q`. Confirm the working tree is clean and HEAD matches
+   `origin/main`. If not, stop and tell the human.
+2. Confirm CI is green: `gh run list --branch main --workflow build.yml --limit 1
+   --json conclusion,headSha` and check the run covers the current `origin/main` HEAD.
+3. Find the last release tag: `git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1`.
+4. Enumerate the release content: `git log --oneline --merges vLAST..origin/main`,
+   plus the same without `--merges` for direct commits. If the range is empty, there
+   is nothing to release, stop.
+5. Recommend the next version from the change set: breaking changes → major, new
+   capabilities → minor, fixes only → patch. Confirm the version with the human
+   (explicit argument wins, but still show what the range contains). If later
+   changelog work changes the classification, re-confirm before stamping.
+
+## Phase 2 — Release ticket and branch
+
+1. Create the release Jira ticket via the `jira-workflow` skill: AIML Task,
+   component `Contrast MCP Server`, summary `Release mcp-contrast X.Y.Z`, assigned
+   to the current user, transitioned to In Progress. Create the matching bead per
+   `bead-workflow` (title prefix, external-ref, Jira URL comment).
+2. Create the release branch from `origin/main`: `AIML-<id>-release-X.Y.Z`. The
+   changelog and stamp commits land here.
+
+## Phase 3 — Changelog and stamp
+
+1. From the release branch, run `/update-changelog`. Choose current-branch mode so
+   its commit lands on the release branch. It has its own approval gate.
+2. After approval, stamp the version: insert `## [X.Y.Z] - <today>` directly below
+   `## [Unreleased]`, moving the unreleased content under the new heading and leaving
+   `[Unreleased]` empty. Commit separately: `AIML-<id> Stamp vX.Y.Z release heading`
+   (matches the established two-commits-one-branch pattern, e.g. v2.4.0).
+3. Push and open the PR with `pr-tools:create-pr`, then wait for the human to merge.
+4. Verify the stamp reached `origin/main` before continuing.
+
+## Phase 4 — Smoke test
+
+Run `/test-mcp-server smoke` (always pass the mode explicitly, the skill asks
+otherwise). Show the human the report. It is a judgment aid, not a gate, but the
+human decides whether to continue.
+
+## Phase 5 — Go/no-go and dispatch
+
+1. Guard: re-fetch and confirm `origin/main` HEAD is still the commit the stamped
+   changelog covers. If another PR merged in between, the tag would ship
+   undocumented changes, loop back to Phase 3.
+2. Ask the human for an explicit go/no-go.
+3. Dispatch with the version spelled out, never blank, so the tag cannot diverge
+   from the stamped heading:
+
+   ```bash
+   gh workflow run gradle-release.yml --ref main -f release_version=X.Y.Z
+   ```
+
+4. `gh workflow run` returns no run id. Fetch it with `gh run list
+   --workflow=gradle-release.yml --limit 1 --json databaseId,createdAt,status` and
+   check `createdAt` is after the dispatch (guards against grabbing a stale run).
+5. Monitor with `gh run watch <id> --exit-status` as a background task
+   (`run_in_background`), the run exceeds the foreground ceiling. Do not poll.
+6. On failure, `gh run view <id> --log-failed`, diagnose, and report. Transient
+   failures are fixed by re-dispatching (see Re-entry).
+
+## Phase 6 — Post-release verification
+
+1. Release assets: `gh release view vX.Y.Z --json assets` must show five files, the
+   jar plus four SBOMs (jar and Docker image, CycloneDX and SPDX each).
+2. Attestation: `gh release download vX.Y.Z --pattern '*.jar'` to a temp dir, then
+   `gh attestation verify mcp-contrast-X.Y.Z.jar --repo Contrast-Security-OSS/mcp-contrast`.
+3. DockerHub: `curl -sf https://hub.docker.com/v2/repositories/contrast/mcp-contrast/tags/X.Y.Z`.
+4. Artifactory: `curl -sfI https://contrastsecurity.jfrog.io/artifactory/contrast-mcp-release/com/contrast/labs/ai/mcp/contrast-mcp-core/X.Y.Z/contrast-mcp-core-X.Y.Z.pom`.
+   If anonymous read is refused, note it and rely on the workflow's publish step
+   having succeeded.
+
+## Phase 7 — Tracker sweep
+
+1. Derive shipped AIML ids from the merge commits in `vLAST..vX.Y.Z` (branch names
+   in merge subjects). Skip dependabot PRs.
+2. Via the `jira-workflow` skill, transition shipped tickets from Ready to Deploy to
+   Closed (`81`), the release ticket included. Closed is reserved for code released
+   to production, which is now true.
+3. Close the matching beads per `bead-workflow`, asking the human first, then
+   `br sync --flush-only`.
+
+## Phase 8 — Report
+
+Close with the version, tag, GitHub Release URL, each verification result, and the
+tickets and beads transitioned.
+
+## Notes
+
+- Never commit to `main` directly, everything lands via the release-branch PR.
+- `make verify` is not repeated here, the workflow runs the full validation build
+  including integration tests before tagging.
+- This skill does not modify the Gradle Release workflow or RELEASING.md steps, it
+  automates around them. If the workflow changes, update this skill to match.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -61,7 +61,9 @@ existing `vX.Y.Z` tag at HEAD.
 
 ## Phase 4 — Smoke test
 
-Run `/test-mcp-server smoke` (always pass the mode explicitly, the skill asks
+Sync the local checkout to the merged `origin/main` first, the test builds the jar
+from the current checkout and it must exercise the exact content that gets tagged.
+Then run `/test-mcp-server smoke` (always pass the mode explicitly, the skill asks
 otherwise). Show the human the report. It is a judgment aid, not a gate, but the
 human decides whether to continue.
 
@@ -69,7 +71,9 @@ human decides whether to continue.
 
 1. Guard: re-fetch and confirm `origin/main` HEAD is still the commit the stamped
    changelog covers. If another PR merged in between, the tag would ship
-   undocumented changes, loop back to Phase 3.
+   undocumented changes, loop back to Phase 3. On that loop-back, this skill owns
+   folding the new entries into the stamped `[X.Y.Z]` section, `/update-changelog`
+   treats stamped versions as settled and will not reopen them.
 2. Ask the human for an explicit go/no-go.
 3. Dispatch with the version spelled out, never blank, so the tag cannot diverge
    from the stamped heading:

--- a/.claude/skills/test-mcp-server/SKILL.md
+++ b/.claude/skills/test-mcp-server/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-mcp-server
-description: Pre-release exploratory test of the Contrast stdio MCP server. Builds the jar fresh, wires it into a separate headless Claude instance, and has that instance spawn one subagent per discovered tool to test it against a live org. Run on demand only, before a release or when a human explicitly asks, not during routine feature development. Runs in-depth by default; pass "smoke" for a fast is-it-alive pass.
+description: Pre-release exploratory test of the Contrast stdio MCP server. Builds the jar fresh, wires it into a separate headless Claude instance, and has that instance spawn one subagent per discovered tool to test it against a live org. Run on demand only, before a release or when a human explicitly asks, not during routine feature development. Asks which mode to run if not specified.
 ---
 
 # Pre-release MCP server test
@@ -17,18 +17,17 @@ on demand only.
 
 ## Usage
 
-- `/test-mcp-server` runs the in-depth (regular) pass with Sonnet testers.
+- `/test-mcp-server` runs the in-depth (regular) pass using the same model as the launching session.
 - `/test-mcp-server smoke` runs a fast pass that just checks each tool's main use case.
 - `/test-mcp-server regular <focus>` runs in-depth with a nudge, e.g. `/test-mcp-server regular focus on the server tools`.
-- `/test-mcp-server --model claude-opus-4-6` runs with Opus testers instead of Sonnet.
-- `--model <id>` can be combined with any mode, e.g. `/test-mcp-server smoke --model claude-opus-4-6`.
+- `--model <id>` overrides the model for orchestrator and testers, e.g. `/test-mcp-server smoke --model sonnet`.
 
 ## What to do
 
 1. Work out the mode and focus from the arguments. If the first word is `smoke` or
    `regular`, use it as the mode and treat the rest as focus text. If no mode was
-   provided, ask the user which mode to run (smoke or regular) before launching.
-   Always pass an explicit mode to the script.
+   provided, use `AskUserQuestion` to ask which mode to run before launching.
+   Never default to a mode on your own. Always pass an explicit mode to the script.
 2. Launch the helper in the background so the user can keep chatting. A regular
    run spawns one tester per tool and can take 15-20 minutes. Set
    `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0` in the command so the background

--- a/.claude/skills/test-mcp-server/run.sh
+++ b/.claude/skills/test-mcp-server/run.sh
@@ -23,7 +23,7 @@
 # Usage: run.sh [smoke|regular] [--model <id>] [focus text...]
 #   smoke              checks each tool's main use case only
 #   regular            (default) in-depth exploratory testing; accepts an optional focus
-#   --model <id>       model for tester subagents (default: sonnet)
+#   --model <id>       override model for orchestrator and testers (default: inherits from parent)
 #
 # The tool list is never hardcoded here. The orchestrator asks the running
 # server what it exposes, so a new tool is covered with no change to this script.
@@ -33,7 +33,7 @@ set -euo pipefail
 # --- parse mode, model, and focus -----------------------------------------
 # Mode (smoke or regular) must be the first positional argument.
 # The skill layer asks the user and always passes an explicit mode.
-TESTER_MODEL="sonnet"
+MODEL=""
 if [[ "${1:-}" == "smoke" || "${1:-}" == "regular" ]]; then
   MODE="$1"
   shift
@@ -48,10 +48,10 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --model)
       if [[ $# -lt 2 ]]; then
-        log "--model requires a value (e.g. --model sonnet)"
+        log "--model requires a value (e.g. --model opus)"
         exit 1
       fi
-      TESTER_MODEL="$2"; shift 2 ;;
+      MODEL="$2"; shift 2 ;;
     *) REMAINING_ARGS+=("$1"); shift ;;
   esac
 done
@@ -71,7 +71,15 @@ if ! ./gradlew :contrast-mcp-stdio-app:bootJar -q; then
   exit 1
 fi
 
-JAR="$(ls -t contrast-mcp-stdio-app/build/libs/mcp-contrast-*.jar 2>/dev/null | grep -v -- '-plain.jar' | head -1 || true)"
+# Pick the newest non-plain jar without ls|grep (SC2010).
+JAR=""
+for candidate in contrast-mcp-stdio-app/build/libs/mcp-contrast-*.jar; do
+  [ -e "$candidate" ] || continue
+  case "$candidate" in *-plain.jar) continue ;; esac
+  if [ -z "$JAR" ] || [ "$candidate" -nt "$JAR" ]; then
+    JAR="$candidate"
+  fi
+done
 if [ -z "$JAR" ]; then
   log "No runnable jar was produced under contrast-mcp-stdio-app/build/libs. Aborting."
   exit 1
@@ -116,10 +124,17 @@ EOF
 
 # --- the Sonnet tester persona (short and human on purpose) ---------------
 TESTER_PROMPT="You are a hands-on tester for one Contrast MCP tool. You have the Contrast tools available. Work out what your tool does from its description, then find real data to test it with by calling the other Contrast tools first (for example, search for an application, a vulnerability, or a server). Then actually call your tool and see how it behaves. When you are done, write your full results to a file using Bash: echo your report into $RESULTS_DIR/<tool-name>.txt (use the exact tool name, e.g. search_vulnerabilities.txt). Your report must include: what you tried, what worked, anything that looked wrong or confusing, and a one-word verdict line at the end: VERDICT: WORKS, VERDICT: ISSUES, VERDICT: BROKEN, or VERDICT: INCONCLUSIVE. Keep it short and honest. Do not spawn other agents."
-AGENTS_JSON="$(cat <<EOF
-{"mcp-tool-tester": {"description": "Exploratory tester for a single Contrast MCP tool", "prompt": "$TESTER_PROMPT", "model": "$TESTER_MODEL"}}
+if [ -n "$MODEL" ]; then
+  AGENTS_JSON="$(cat <<EOF
+{"mcp-tool-tester": {"description": "Exploratory tester for a single Contrast MCP tool", "prompt": "$TESTER_PROMPT", "model": "$MODEL"}}
 EOF
 )"
+else
+  AGENTS_JSON="$(cat <<EOF
+{"mcp-tool-tester": {"description": "Exploratory tester for a single Contrast MCP tool", "prompt": "$TESTER_PROMPT"}}
+EOF
+)"
+fi
 
 # --- the Opus orchestrator brief ------------------------------------------
 if [ "$MODE" == "smoke" ]; then
@@ -149,16 +164,16 @@ EOF
 )"
 
 # --- run the nested instance ----------------------------------------------
-log "Launching a $MODE test. Orchestrator: opus, testers: $TESTER_MODEL."
+MODEL_DISPLAY="${MODEL:-inherited from parent}"
+log "Launching a $MODE test. Model: $MODEL_DISPLAY."
 log "This can take several minutes for a full regular run."
 
 ORCH_EXIT=0
-claude -p "$ORCH_PROMPT" \
-  --model opus \
-  --mcp-config "$MCP_CONFIG" \
-  --strict-mcp-config \
-  --allowedTools "mcp__contrast Task Bash" \
-  --agents "$AGENTS_JSON" || ORCH_EXIT=$?
+CLAUDE_ARGS=(-p "$ORCH_PROMPT" --mcp-config "$MCP_CONFIG" --strict-mcp-config --allowedTools "mcp__contrast Task Bash" --agents "$AGENTS_JSON")
+if [ -n "$MODEL" ]; then
+  CLAUDE_ARGS+=(--model "$MODEL")
+fi
+claude "${CLAUDE_ARGS[@]}" || ORCH_EXIT=$?
 
 # --- if the orchestrator was killed, salvage individual results ------------
 if [ "$ORCH_EXIT" -ne 0 ]; then

--- a/.claude/skills/update-changelog/SKILL.md
+++ b/.claude/skills/update-changelog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-changelog
-description: Bring the [Unreleased] section of CHANGELOG.md up to date before a release. Diffs the last release tag against origin/main, drafts entries PR-by-PR, audits the draft for completeness with a read-only subagent, and lands the result on a branch after the user approves. Run pre-release, before dispatching the Gradle Release workflow, or whenever a human asks for a changelog update. Optional free text is treated as guidance, e.g. classification hints.
+description: Bring the [Unreleased] section of CHANGELOG.md up to date before a release. Diffs the last release tag against origin/main, drafts entries PR-by-PR, audits the draft for completeness with a read-only subagent, and lands the result on a branch after the user approves (or returns the approved draft to /release in deferred-landing mode). Run pre-release, before dispatching the Gradle Release workflow, or whenever a human asks for a changelog update. Optional free text is treated as guidance, e.g. classification hints.
 ---
 
 # Pre-release changelog update

--- a/.claude/skills/update-changelog/SKILL.md
+++ b/.claude/skills/update-changelog/SKILL.md
@@ -18,6 +18,11 @@ when a human explicitly asks. Not part of routine feature development.
 - `/update-changelog` runs the full flow.
 - `/update-changelog <guidance>` passes free-text hints, e.g.
   `/update-changelog the SBOM work is internal, skip it`.
+- **Deferred-landing mode**, invoked by the `/release` skill: draft, audit, and get
+  the human's approval as usual, but skip the branch question in Step 1 and all of
+  Step 6. The range is the base range only. Return the approved draft text and the
+  suggested next version to the caller, which creates the release branch and lands
+  the changelog itself.
 
 ## Ground rules
 
@@ -29,7 +34,12 @@ when a human explicitly asks. Not part of routine feature development.
   or wrong. Never delete one silently. Propose deletions in the draft and let the
   human decide.
 - Report a suggested next version (breaking changes → major, new capabilities → minor,
-  otherwise patch). It is informational only. Do not act on it.
+  otherwise patch). It is informational only. Do not act on it. **Breaking** here
+  means removed or renamed tools, or changes to hosting requirements, a new Java
+  version, a Spring Boot major, changed Docker or jar run instructions. Changes to
+  the `contrast-mcp-core` library API are not breaking on their own, its only
+  consumer is internal. Small tool contract changes (parameters, response shape)
+  stay minor, AI consumers adapt.
 - Do not create beads. This is a one-file docs change.
 
 ## Step 1 — Orient and choose the branch
@@ -79,6 +89,8 @@ For each range:
 
 - Section order within a version: Breaking Changes, Bug Fixes, Improvements, Security,
   Documentation. Include only non-empty sections.
+- Hosting-requirement changes (Java version, Spring Boot major, Docker or jar run
+  instructions) belong under Breaking Changes, that section drives the version bump.
 - Each entry is a short prose paragraph led by a **bold summary phrase**, wrapped at
   roughly 100 characters.
 - No PR numbers or ticket IDs in the published text. Cite external-system defects

--- a/.claude/skills/update-changelog/SKILL.md
+++ b/.claude/skills/update-changelog/SKILL.md
@@ -19,10 +19,10 @@ when a human explicitly asks. Not part of routine feature development.
 - `/update-changelog <guidance>` passes free-text hints, e.g.
   `/update-changelog the SBOM work is internal, skip it`.
 - **Deferred-landing mode**, invoked by the `/release` skill: draft, audit, and get
-  the human's approval as usual, but skip the branch question in Step 1 and all of
-  Step 6. The range is the base range only. Return the approved draft text and the
-  suggested next version to the caller, which creates the release branch and lands
-  the changelog itself.
+  the human's approval as usual, but skip the branch question in Step 1, all of
+  Step 6, and Step 7. The range is the base range only. Return the approved draft
+  text and the suggested next version to the caller, which creates the release
+  branch and lands the changelog itself.
 
 ## Ground rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -482,7 +482,7 @@ Run the harness-engineering playbooks against this repo on demand via `/harness-
 
 ### Release orchestration
 
-`/release` runs the full release end to end: preflight, release ticket and branch, `/update-changelog` plus version stamp, `/test-mcp-server smoke`, Gradle Release dispatch and monitoring, artifact verification, and the Jira/bead sweep. Human gates at version choice, changelog approval, and go/no-go. Run only when a human asks to cut a release. See `.claude/skills/release/`.
+`/release` runs the full release end to end, changelog-first: preflight, `/update-changelog` in deferred-landing mode, version gate, release ticket and branch, version stamp, `/test-mcp-server smoke`, Gradle Release dispatch and monitoring, artifact verification, release-notes sync, Jira/bead sweep, and Slack announcement. Human gates at changelog approval, version choice, PR merge, go/no-go, sweep, and the post. Run only when a human asks to cut a release. See `.claude/skills/release/`.
 
 ## Spawning Codex via Herdr
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -480,6 +480,10 @@ Run the harness-engineering playbooks against this repo on demand via `/harness-
 
 `/update-changelog` brings `[Unreleased]` in CHANGELOG.md up to date against everything merged since the last release tag, audits completeness with a read-only subagent per range, and lands the result on a branch after user approval. Run before dispatching the Gradle Release workflow or when explicitly asked. See `.claude/skills/update-changelog/`.
 
+### Release orchestration
+
+`/release` runs the full release end to end: preflight, release ticket and branch, `/update-changelog` plus version stamp, `/test-mcp-server smoke`, Gradle Release dispatch and monitoring, artifact verification, and the Jira/bead sweep. Human gates at version choice, changelog approval, and go/no-go. Run only when a human asks to cut a release. See `.claude/skills/release/`.
+
 ## Spawning Codex via Herdr
 
 When spawning a Codex agent through Herdr:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,6 +12,16 @@ This project uses the **Gradle Release** GitHub Actions workflow. Release versio
 - Access to trigger GitHub Actions workflows
 - A green `main` branch
 
+## Orchestrated Release
+
+The whole process below can be driven from a Claude Code session with `/release`.
+The skill runs the preflight checks, creates the release ticket and branch, runs the
+changelog update and version stamp, runs the smoke test, dispatches and monitors the
+Gradle Release workflow, verifies the published artifacts, and sweeps Jira and beads
+afterward. You keep three decisions: the version, the changelog draft, and the final
+go/no-go before dispatch. See `.claude/skills/release/` for details. The manual steps
+below remain authoritative if you release by hand.
+
 ## Pre-release Testing
 
 Before you cut a release, exercise the shipped tools against a live org. From a

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,12 +15,15 @@ This project uses the **Gradle Release** GitHub Actions workflow. Release versio
 ## Orchestrated Release
 
 The whole process below can be driven from a Claude Code session with `/release`.
-The skill runs the preflight checks, creates the release ticket and branch, runs the
-changelog update and version stamp, runs the smoke test, dispatches and monitors the
-Gradle Release workflow, verifies the published artifacts, and sweeps Jira and beads
-afterward. You keep three decisions: the version, the changelog draft, and the final
-go/no-go before dispatch. See `.claude/skills/release/` for details. The manual steps
-below remain authoritative if you release by hand.
+The skill runs the preflight checks, drafts and audits the changelog first, takes
+your version decision from that evidence, then creates the release ticket and branch,
+lands the changelog and version stamp, runs the smoke test, dispatches and monitors
+the Gradle Release workflow, verifies the published artifacts, syncs the GitHub
+release notes from the changelog, sweeps Jira and beads, and announces in Slack. You
+keep the decisions: the changelog draft, the version, the changelog PR merge, the
+go/no-go before dispatch, the tracker sweep, and the announcement. See
+`.claude/skills/release/` for details. The manual steps below remain authoritative if
+you release by hand.
 
 ## Pre-release Testing
 


### PR DESCRIPTION
**Jira:** [AIML-1362](https://contrast.atlassian.net/browse/AIML-1362)

## Summary
Adds a `/release` skill that orchestrates the full mcp-contrast release end to end, composing the existing `/update-changelog` and `/test-mcp-server` skills around the Gradle Release workflow.

- One command drives the whole release, with human gates at changelog approval, version choice, changelog PR merge, go/no-go before dispatch, the tracker sweep, and the Slack announcement.
- The flow is changelog-first. The audited draft is the evidence for the version decision, so the release ticket and branch are created already carrying the approved version.
- `/test-mcp-server` now inherits the launching session's model instead of hardcoding Opus and Sonnet.

## Why This Change Exists
The release process lived in RELEASING.md as manual steps plus two disconnected skills. Nothing owned the sequence, the preflight judgment, the version stamp, workflow monitoring, post-release verification, or the Jira and bead sweep, so each release depended on someone remembering all of it. Recovery knowledge, such as the workflow being safe to re-dispatch because it reuses an existing tag at HEAD, was tribal.

An initial ticket-first design had a flaw. The version was chosen from raw PR titles before the changelog audit, so a breaking change discovered during the audit could invalidate a branch and ticket already named with the wrong version. A design-review session settled 23 decisions and inverted the order.

## Approach
Changelog-first sequencing. `/update-changelog` gains a **deferred-landing mode** that drafts, audits, and gets approval without committing, because the landing branch does not exist yet. Its suggested version feeds a three-option gate (major, minor, patch, each with the computed number). Only after the human picks does the skill create the release ticket and the `AIML-<id>-release-X.Y.Z` branch, then land the changelog and stamp commits there.

The semver definition now lives in `/update-changelog` where the suggestion is computed. Majors are removed or renamed tools and hosting-requirement changes (new Java version, Spring Boot major, changed run instructions). `contrast-mcp-core` API changes are explicitly not breaking, its only consumer is internal. Small tool contract changes stay minor because AI consumers adapt.

Automation stops where human judgment or irreversibility begins. The smoke test is advisory, workflow failures always wait for a human (partial publishes to three registries need eyes before re-dispatch), post-verify failures get a suggested remediation path but no automated remediation, and the Slack post to `#_aiml-team` sends only on approval.

## What Changed
### New release skill
- `.claude/skills/release/SKILL.md` (new) — ten phases: preflight (red CI stops unless explicitly overridden, all-internal ranges ask about dependency-bump-only releases), deferred-landing changelog draft, version gate, ticket/branch/landing, smoke test, go/no-go and dispatch with explicit `release_version` and background `gh run watch`, five-asset and attestation and DockerHub and Artifactory verification, GitHub release-notes overwrite from the stamped changelog, pick-list tracker sweep with batch bead confirmation, gated Slack announcement. Includes re-entry guidance for mid-flight failures.

### update-changelog integration
- `.claude/skills/update-changelog/SKILL.md` — deferred-landing mode, the semver definition, and a house-style rule putting hosting-requirement changes under Breaking Changes so that section drives the bump.

### test-mcp-server model inheritance
- `.claude/skills/test-mcp-server/SKILL.md`, `run.sh` — with no `--model` flag the nested instance and its testers inherit the launching session's model, `--model` overrides both. Mode selection is asked via AskUserQuestion, never defaulted. The jar-discovery `ls | grep` was replaced with a glob loop to satisfy the shellcheck pre-commit hook (SC2010).

### Cross-references
- `RELEASING.md` — new Orchestrated Release section, manual steps stay authoritative.
- `CLAUDE.md` — agent-skills entry for `/release`.

## Testing
Docs and skill instructions plus one shell script, no Java changes, so the unit and coverage gates do not apply. `make check` passes. `run.sh` passes shellcheck and `bash -n`. The skill flow itself is validated by design review (23 settled decisions) and two advisor audits that mapped each decision to the files, its first real exercise will be the next release.

## Risks / Rollout / Follow-ups
- The skill commits the Slack channel name `#_aiml-team` to a public repo. Precedent exists (SECURITY.md publicly names `#contrast-labs`).
- The deferred-landing contract couples `/release` to `/update-changelog`. The mode is documented in both skills so the dependency is visible to future editors.


[AIML-1362]: https://contrast.atlassian.net/browse/AIML-1362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ