### PR TITLE
AIML-1363 Release mcp-contrast 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-08-11
+
 ### Bug Fixes
 
 **`get_route_coverage` explains license and archive denials instead of suggesting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+**`get_route_coverage` explains license and archive denials instead of suggesting
+credential problems**: When called on an unlicensed or archived application, the tool
+previously returned a generic "Access denied" error that led agents to retry or question
+their credentials. It now returns a distinct, non-retryable message explaining the actual
+cause and what to do about it.
+
+### Improvements
+
+**Vulnerability status values normalized for round-trip filtering**: Both
+`search_vulnerabilities` and `search_app_vulnerabilities` now return canonical status
+values (`NotAProblem`, `AutoRemediated`) instead of TeamServer display labels ("Not a
+Problem", "Remediated - Auto-Verified"). All seven valid statuses are listed in
+parameter descriptions, so agents can discover and filter by any status without first
+encountering a validation error.
+
+**Vulnerability type parameters validated against the live organization catalogue**: Both
+`search_vulnerabilities` and `search_app_vulnerabilities` now validate `vulnTypes` against
+the organization's rule catalogue before searching. Invalid or misspelled values produce an
+explicit error pointing to `list_vulnerability_types`, instead of silently returning empty
+results indistinguishable from a genuine "no vulnerabilities found" response. Values are
+matched case-insensitively.
+
 ## [2.4.0] - 2026-08-10
 
 ### Bug Fixes


### PR DESCRIPTION
**Jira:** [AIML-1363](https://contrast.atlassian.net/browse/AIML-1363)

## Summary

Changelog draft and version stamp for the v2.5.0 release, covering vulnerability status normalization, vulnTypes validation, and route coverage license denial improvements merged since v2.4.0.

## Why This Change Exists

The release process lands the audited changelog on a branch so it can be reviewed before the Gradle Release workflow tags and publishes.

## What Changed

### Changelog
- `CHANGELOG.md` — added the `[2.5.0] - 2026-08-11` section with three entries (one bug fix, two improvements) and left `[Unreleased]` empty for post-release work.


[AIML-1363]: https://contrast.atlassian.net/browse/AIML-1363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ