### PR TITLE
AIML-1381 Update README hosted tools to match hosted server

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,9 +311,6 @@ These prompts work with either server, except where a section says otherwise.
 #### Retrieve Applications by Metadata
 * Please give me the applications with metadata "dev-team" and "backend-team."
 
-#### Static Scan (SAST) Results
-* Give me the details and vulnerability counts for scan project X.
-
 #### Retrieve Vulnerabilities by Session Metadata
 * Give me the session metadata for Application X.
 * Give me the vulnerabilities in the latest session for Application X.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ The hosted server provides read-only tools across the domains below. Your agent 
 | `search_applications` | Search applications by name, tag, or metadata filters |
 | `get_session_metadata` | Get session metadata fields available for an application |
 
+#### Servers
+| Tool | Description |
+|------|-------------|
+| `search_servers` | Search the server inventory for agent health and Protect coverage |
+
 #### Libraries (SCA)
 | Tool | Description |
 |------|-------------|
@@ -150,25 +155,24 @@ The hosted server provides read-only tools across the domains below. Your agent 
 |------|-------------|
 | `get_scan_project` | Get SAST project details and vulnerability counts |
 
-#### Issues, Incidents, and Observations
+#### CVEs, Issues, Incidents, and Observations
 These tools require the Contrast unified data platform (NorthStar) to be enabled for your organization.
 
 | Tool | Description |
 |------|-------------|
+| `search_cves` | Search CVEs across your organization for CVE Shield exposure and risk |
+| `list_cve_issues` | List affected applications and libraries for a CVE, one issue per pair |
+| `get_cve_impact` | Get CVE risk, exposure, and shield protection posture across your organization |
 | `search_issues` | Search and filter security issues across your organization |
 | `get_issue` | Get full details for a specific issue |
-| `get_issue_summary` | Get a concise summary of a specific issue |
-| `get_issue_count` | Count issues matching filters without fetching full details |
 | `list_issue_incidents` | List incidents linked to an issue |
 | `list_issues_by_library` | List open issues associated with an application library |
 | `search_incidents` | Search and filter incidents |
 | `get_incident` | Get full details for a specific incident |
-| `get_incident_summary` | Get a concise summary of a specific incident |
 | `list_incident_issues` | List issues linked to an incident |
 | `get_observation` | Get full details for a specific observation |
 | `list_issue_observations` | List observations linked to an issue (cursor-paginated) |
 | `list_incident_observations` | List observations linked to an incident (cursor-paginated) |
-| `get_incident_observation_count` | Count observations linked to an incident without paging |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Getting the JAR file (download, attestation verification, and build from source)
 
 ## Sample prompts
 
-These prompts work with either server.
+These prompts work with either server, except where a section says otherwise.
 
 ### For the Developer
 #### Remediate Vulnerabilities in Code
@@ -311,6 +311,9 @@ These prompts work with either server.
 #### Retrieve Applications by Metadata
 * Please give me the applications with metadata "dev-team" and "backend-team."
 
+#### Static Scan (SAST) Results
+* Give me the details and vulnerability counts for scan project X.
+
 #### Retrieve Vulnerabilities by Session Metadata
 * Give me the session metadata for Application X.
 * Give me the vulnerabilities in the latest session for Application X.
@@ -322,6 +325,18 @@ These prompts work with either server.
 * Please give me a breakdown of applications and servers vulnerable to CVE-xxxx-xxxx.
 * Please list the libraries for the application named xxx and tell me what version of commons-collections is being used.
 * Which vulnerabilities in Application X are being blocked by a Protect or ADR rule?
+* Which production servers do not have Protect enabled?
+* Show me servers whose agents are out of date.
+* Show me attack events from the last 7 days and tell me which were exploited.
+
+### Hosted server with the unified data platform (NorthStar)
+These prompts require the hosted server and the Contrast unified data platform (NorthStar) to be enabled for your organization.
+* Which CVEs pose the highest risk across my organization?
+* Is my organization shielded from CVE-xxxx-xxxx?
+* Which applications and libraries are affected by CVE-xxxx-xxxx?
+* Show me open security issues for Application X.
+* Give me the details of incident X and the issues linked to it.
+* What observations provide evidence for issue X?
 
 ## Data privacy
 
@@ -334,6 +349,7 @@ Depending on what questions you ask the following information will be provided t
 * Route Coverage data
 * ADR/Protect Attack Event Details
 * Server inventory and agent details (hostnames, paths, agent versions, environments, log levels, and tags)
+* Issue, incident, observation, and CVE Shield data (hosted server with NorthStar)
 
 ## Changelog
 


### PR DESCRIPTION
**Jira:** [AIML-1381](https://contrast.atlassian.net/browse/AIML-1381)

## Summary
Brings the README's hosted tool list back in line with what the hosted MCP server actually registers, and extends the sample prompts to cover the tools that had none. The tool list had drifted in three ways, a missing always-on tool, three missing CVE tools, and four documented tools that no longer exist.

- Adds `search_servers` to the hosted list under a new Servers heading
- Adds the three NorthStar CVE tools, `search_cves`, `list_cve_issues`, `get_cve_impact`
- Removes four stale tools, `get_issue_summary`, `get_issue_count`, `get_incident_summary`, `get_incident_observation_count`
- Adds sample prompts for servers, attacks, and the hosted-only NorthStar tools

## Why This Change Exists
A comparison of the README against the hosted server's tool registration (`HostedMcpToolConfig` on the hosted repo's default branch) showed the hosted list no longer matches the server. Users reading the README would look for tools that do not exist and miss tools that do. The same review found that several tools, including all NorthStar tools, had no sample prompts and that the data privacy list omitted the data those tools expose.

## What Changed
### README hosted tools section
- `README.md` — adds a Servers table with `search_servers`, renames the NorthStar heading to "CVEs, Issues, Incidents, and Observations", adds the three CVE tool rows with descriptions condensed from the tool classes, and deletes the four rows for removed tools

### README sample prompts and data privacy
- `README.md` — adds prompts for `search_servers` and `search_attacks`, adds a hosted-only NorthStar prompt subsection for the CVE, issue, incident, and observation tools, and adds NorthStar data to the data privacy list

## Testing
- Documentation-only change, no code paths affected
- Verified every name in the updated hosted list matches a tool registered in the hosted server's tool callback provider, and that no removed name remains anywhere in the README


[AIML-1381]: https://contrast.atlassian.net/browse/AIML-1381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ