### PR TITLE
AIML-1396 Burn down SDK containment violations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,11 @@ See [REPO-CONTEXT.md](./REPO-CONTEXT.md) for domain definitions, architecture no
 
 ## Branching and PR Requirements
 
-**All code changes must be made on a feature branch.** Never commit directly to `main`. Use `pr-tools` plugin skills when available: `/pr-tools:create-stacked-branch` for new branches, `/pr-tools:create-pr` for pull requests. Do not use raw `git checkout -b` or `gh pr create` when the skills are loaded.
+**All code changes must be made on a feature branch.** Never commit directly to `main`. Never use raw `git checkout -b` or `gh pr create` when pr-tools skills are loaded.
+
+**Default to stacking.** When unmerged feature branches exist, create new branches stacked on the tip of the current stack using `/pr-tools:create-stacked-branch`. Only branch off `main` when the user explicitly says so. If unsure which branch is the stack tip, check with the user rather than defaulting to `main`.
+
+Use `/pr-tools:create-pr` for pull requests.
 
 Branch naming: `AIML-<ticket-id>-<short-description>` (e.g., `AIML-391-add-medium-low-note-counts`)
 


### PR DESCRIPTION
## Summary

- Add ArchUnit architectural tests enforcing layering, SDK containment, domain isolation, and naming conventions with FreezingArchRule ratcheting
- Extract `TimestampFormatter` to `util` package and decouple `RecommendationMarkdownRenderer` from direct SDK imports
- Move `ApplicationLicenseDiscriminator` from `tool.application` to `tool.base` to resolve cross-package dependency violation
- Add ArchUnit guardrail hooks (pre-tool reminder and store-guard) with smoke tests
- Add `archunit` skill documenting the fix-then-shrink workflow for SDK containment

## Test plan

- [ ] `make check-test` passes (ArchUnit rules, unit tests, coverage, mutation)
- [ ] ArchUnit freeze store shrinks monotonically as violations are fixed
- [ ] Hook smoke tests pass (`bash .claude/hooks/test-archunit-hooks.sh`)