### PR TITLE
AIML-1407 Standardize verification on Gradle check and verify lifecycles

### DIFF
--- a/.claude/commands/improve-harness.md
+++ b/.claude/commands/improve-harness.md
@@ -32,7 +32,7 @@ bounded, representative job before starting.
    expected effect.
 
 5. Implement the smallest reversible change at the earliest owner, then verify
-   both layers. Run this repo's native checks (`make check-test`, plus
+   both layers. Run this repo's native checks (`make check`, plus
    `make verify` when credentials allow), and exercise the user or operational
    journey that establishes the accepted outcome.
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,9 +9,9 @@
       "Bash(br show *)",
       "Bash(br list *)",
       "Bash(br ready)",
-      "Bash(make check-test)",
+      "Bash(make check)",
       "Bash(make check *)",
-      "Bash(make test *)",
+      "Bash(make lint)",
       "Bash(cass search *)",
       "Bash(cass timeline *)",
       "mcp__plugin_atlassian_atlassian__getJiraIssue"

--- a/.claude/skills/archunit/SKILL.md
+++ b/.claude/skills/archunit/SKILL.md
@@ -9,7 +9,7 @@ ArchUnit rules in `ArchitectureTest` enforce layering, SDK containment, domain i
 
 ## When this skill applies
 
-- An ArchUnit test fails during `make check-test` or `./gradlew :contrast-mcp-core:test`
+- An ArchUnit test fails during `make check` or `./gradlew :contrast-mcp-core:test`
 - You are fixing a grandfathered violation from the freeze store
 - New code you wrote introduces a dependency the architecture rules forbid
 
@@ -26,7 +26,7 @@ The store is **shrink-only by design**. `-ParchStoreUpdate` lets ArchUnit remove
 1. **Fix the code.** Change the production code so the violation no longer exists.
 2. **Run the store update.** `./gradlew :contrast-mcp-core:test -ParchStoreUpdate` removes fixed entries.
 3. **If tests still fail,** the remaining violations need code fixes, not more store entries. Go back to step 1.
-4. **Run the full gate.** `make check-test` must pass.
+4. **Run the full gate.** `make check` must pass.
 5. **Commit the shrunken store** alongside the code changes.
 
 ## Fixing SDK containment violations

--- a/.claude/skills/bead-workflow/SKILL.md
+++ b/.claude/skills/bead-workflow/SKILL.md
@@ -76,7 +76,7 @@ This atomically sets the assignee and status to `in_progress`. Record the branch
 
 **Read the full context.** Run `br show <id>` for the bead. If it has a Jira `external-ref`, also fetch the ticket body and comments with `getJiraIssue` so both descriptions and any ticket discussion inform the work.
 
-**Do the work.** Write tests for all code changes. `make check-test` must pass, and `make verify` (integration tests) must pass before review, see CLAUDE.md Testing Requirements.
+**Do the work.** Write tests for all code changes. `make check` must pass, and `make verify` (integration tests) must pass before review, see CLAUDE.md Testing Requirements.
 
 **Commit and push before closing.** A bead that produced code changes must not be closed until those changes are committed and pushed. This is non-negotiable.
 

--- a/.claude/skills/test-mcp-server/SKILL.md
+++ b/.claude/skills/test-mcp-server/SKILL.md
@@ -53,4 +53,4 @@ on demand only.
 - The tool list is discovered from the running server, so a newly added tool is
   covered automatically with no change to this skill.
 - This is a live exercise of the shipped tools. It does not run the unit or
-  integration suites, which you run separately with `make check-test` and `make verify`.
+  integration suites, which you run separately with `make check` and `make verify`.

--- a/.env.integration-test.template
+++ b/.env.integration-test.template
@@ -1,6 +1,6 @@
 # Integration Test Environment Variables
 # Copy this file to .env.integration-test and fill in your Contrast credentials
-# Then source it before running integration tests: source .env.integration-test
+# Gradle sources this file automatically for integration tests (real env vars win).
 
 export CONTRAST_HOST_NAME=app.contrastsecurity.com
 export CONTRAST_API_KEY=your-api-key-here

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,9 +41,10 @@ jobs:
     - name: Run buildSrc checks and tests
       run: ./gradlew -p buildSrc check --no-daemon
 
-    # `test` is omitted deliberately: jacocoTestReport already pulls it in.
-    - name: Run checks, tests, coverage, and build
-      run: ./gradlew spotlessCheck checkstyleMain checkstyleTest jacocoTestCoverageVerification :contrast-mcp-stdio-app:bootJar --no-daemon
+    # check is the single verification gate (ADR 0003); new verifications attached to it
+    # are picked up here with no workflow change.
+    - name: Run check lifecycle and build
+      run: ./gradlew check :contrast-mcp-stdio-app:bootJar --no-daemon
 
     # Pull requests only. With no base the task falls back to the working tree, which is
     # clean on a fresh checkout and would pass vacuously.
@@ -56,10 +57,6 @@ jobs:
         ./gradlew jacocoChangedFileCoverageVerification
         -PjacocoChangedBase="$BASE_SHA"
         --no-daemon
-
-    - name: Run mutation testing
-      if: github.event_name == 'pull_request'
-      run: ./gradlew :contrast-mcp-core:pitest --no-daemon
 
     # Runs even when the coverage floor fails, since that is exactly when the
     # numbers and the HTML report are needed to diagnose the failure. coverageSummary

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -73,8 +73,16 @@ jobs:
           git diff --quiet
           git diff --cached --quiet
 
+      # verify = check + integration tests (ADR 0003/0004). Without the CONTRAST_* secrets
+      # every IT silently skips. AIML-1408 migrates them to a service account.
       - name: Run release validation build
-        run: ./gradlew clean spotlessCheck check :contrast-mcp-stdio-app:integrationTest :contrast-mcp-stdio-app:bootJar --no-daemon
+        env:
+          CONTRAST_HOST_NAME: ${{ secrets.CONTRAST_HOST_NAME }}
+          CONTRAST_API_KEY: ${{ secrets.CONTRAST_API_KEY }}
+          CONTRAST_SERVICE_KEY: ${{ secrets.CONTRAST_SERVICE_KEY }}
+          CONTRAST_USERNAME: ${{ secrets.CONTRAST_USERNAME }}
+          CONTRAST_ORG_ID: ${{ secrets.CONTRAST_ORG_ID }}
+        run: ./gradlew clean verify :contrast-mcp-stdio-app:bootJar --no-daemon
 
       - name: Create or reuse release tag
         id: versions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ See [REPO-CONTEXT.md](./REPO-CONTEXT.md) for domain definitions, architecture no
 
 ## Git Hooks
 
-**ABSOLUTE RULE: NEVER skip git hooks.** Do not use `--no-verify`, `--no-gpg-sign`, `SKIP_COVERAGE_HOOK=1`, or any other mechanism to bypass pre-commit, pre-push, or any other git hook. No exceptions. No shortcuts. If a hook fails, fix the underlying problem. A skipped hook caused a CI build failure; this rule exists to prevent that from ever happening again. If you skip a hook, you have made an error.
+**ABSOLUTE RULE: NEVER skip git hooks.** Do not use `--no-verify`, `--no-gpg-sign`, `SKIP_PUSH_GATE=1`, `SKIP_COVERAGE_HOOK=1`, or any other mechanism to bypass pre-commit, pre-push, or any other git hook. No exceptions. No shortcuts. If a hook fails, fix the underlying problem. A skipped hook caused a CI build failure; this rule exists to prevent that from ever happening again. If you skip a hook, you have made an error.
 
 ## Uncommitted Changes
 
@@ -49,62 +49,59 @@ The workflows below use the **pr-tools** plugin (`/pr-tools:*` commands). If tho
 
 ### Building the Project
 
-Use these make targets for all checks and tests:
+The Gradle `check` and `verify` lifecycles are the single source of truth for verification (ADR 0003, ADR 0004; Check/Verify/Lint defined in CONTEXT.md). Make targets are thin quiet-output wrappers:
 
 ```bash
-make check       # Auto-format then run static analysis (no need to run make format first)
-make test        # Run unit tests (quiet output)
-make coverage    # Verify JaCoCo coverage floors and print the summary
-make check-test  # Run static analysis, unit tests, coverage, and mutation testing
-make verify      # Run the complete local gate including integration tests
-make format      # Auto-format code with Spotless (also runs automatically via make check)
+make check       # Auto-format, then the full Gradle check lifecycle: static analysis,
+                 # unit tests, coverage floors, CRAP gate, PIT mutation testing
+make verify      # check + integration tests (needs Contrast credentials, fails loudly without)
+make lint        # Fast inner loop: auto-format + checkstyle only. Not a gate
+make format      # Auto-format code with Spotless (also runs inside check/verify/lint)
 make build       # Build the project
 make clean       # Clean build artifacts
 
-make test-coverage                 # Unit tests plus coverage floors in one gradle invocation
+make buildsrc-check                # buildSrc is a separate Gradle build; check never covers it
 make coverage-changed              # Changed src/main/java files must meet the changed-file floor
 make coverage-changed BASE=origin/main   # Compare against a ref instead of the working tree
-make buildsrc-check                # Static analysis, tests and coverage for buildSrc
-make mutation                       # PIT mutation testing on contrast-mcp-core
-make install-hooks                 # Install the pre-push hook (backs up any hook it replaces)
+make install-hooks                 # Install the git hooks (backs up any hook it replaces)
 
 # Verbose output when debugging failures
-make test VERBOSE=1
 make check VERBOSE=1
-make coverage VERBOSE=1
+make verify VERBOSE=1
 ```
 
-**CRAP gate:** `./gradlew crapReport` for advisory per-module reports, `./gradlew crapCheck` for the enforcing gate. Existing violations live in each module's `crap4j-baseline.json`; use `./gradlew crapBaseline` to generate or regenerate a baseline, and `./gradlew crapBaselineTighten` to remove baseline slack after improving code.
+Never re-enumerate Gradle task names in make targets, CI, or hooks; attach new verifications to the Gradle `check` lifecycle so every gate inherits them.
 
-**After a compilation failure**, stale `.class` files may remain and cause confusing follow-up failures. Always run `make clean && make test` to recover before continuing.
+**CRAP gate:** part of `check` (`attachToCheck = true`). `./gradlew crapReport` for advisory per-module reports, `./gradlew crapCheck` to run the gate alone. Existing violations live in each module's `crap4j-baseline.json`; use `./gradlew crapBaseline` to generate or regenerate a baseline, and `./gradlew crapBaselineTighten` to remove baseline slack after improving code.
+
+**After a compilation failure**, stale `.class` files may remain and cause confusing follow-up failures. Always run `make clean` then `./gradlew test` to recover before continuing.
 
 **Direct Gradle commands** (verbose output, use make targets above for quiet output):
 - **Build**: `./gradlew :contrast-mcp-stdio-app:bootJar`
 - **Test (unit)**: `./gradlew test`
-- **Test (all)**: `source .env.integration-test && ./gradlew test :contrast-mcp-stdio-app:integrationTest`
-- **Static analysis**: `./gradlew spotlessCheck checkstyleMain checkstyleTest`
-- **Coverage**: `./gradlew jacocoTestCoverageVerification coverageSummary`
+- **Full gate**: `./gradlew check` (static analysis, unit tests, coverage floors, CRAP, PIT)
+- **Full gate + integration tests**: `./gradlew verify` (credentials auto-sourced from `.env.integration-test`; real env vars win)
 - **Changed-file coverage**: `./gradlew jacocoChangedFileCoverageVerification -PjacocoChangedBase=origin/main`
 - **Core publication metadata**: `./gradlew :contrast-mcp-core:verifyCorePublicationMetadata`
-- **Mutation testing**: `./gradlew :contrast-mcp-core:pitest`
+- **Mutation testing alone**: `./gradlew :contrast-mcp-core:pitest`
 - **Format code**: `./gradlew spotlessApply`
 - **Run locally**: `java -jar contrast-mcp-stdio-app/build/libs/mcp-contrast-*.jar --CONTRAST_HOST_NAME=<host> --CONTRAST_API_KEY=<key> --CONTRAST_SERVICE_KEY=<key> --CONTRAST_USERNAME=<user> --CONTRAST_ORG_ID=<org>`
 
-**Note:** `make check` auto-formats before checking — no separate `make format` step needed. `make check-test` is the standard local verification command for static analysis, unit tests, and coverage.
+**Note:** `make check` auto-formats before checking — no separate `make format` step needed. `make check` is the standard local verification command; `make verify` is required before review.
 
 **Coverage floors:** Per-module minimums live in `ext.coverageMinimums` in the root `build.gradle` and are enforced by `jacocoTestCoverageVerification`, which `check` depends on. Floors sit a couple of points under the measured figures on purpose, so one new uncovered branch cannot redden `main`. Raise a floor as coverage improves; never lower one to make a build pass. `verifyCoverageMinimums` fails the build if any floor drops below `ext.coverageStandardMinimum` (85%). `McpContrastApplication` is the only class excluded.
 
-**Mutation testing:** PIT runs against `contrast-mcp-core` via the `info.solidsoft.pitest` Gradle plugin. It gates on test strength (killed / (killed + survived)), not mutation score, so it measures test quality independent of JaCoCo coverage. The `testStrengthThreshold` floor lives in `contrast-mcp-core/build.gradle` and is enforced in CI on pull requests. Raise the floor as survivors get fixed, never lower it. `lombok.config` at the repo root enables `@lombok.Generated` so both PIT and JaCoCo skip Lombok-generated code.
+**Mutation testing:** PIT runs against `contrast-mcp-core` via the `info.solidsoft.pitest` Gradle plugin, as part of `check`. It gates on test strength (killed / (killed + survived)), not mutation score, so it measures test quality independent of JaCoCo coverage. The `testStrengthThreshold` floor lives in `contrast-mcp-core/build.gradle`. Raise the floor as survivors get fixed, never lower it. `lombok.config` at the repo root enables `@lombok.Generated` so both PIT and JaCoCo skip Lombok-generated code.
 
 **Fixing PIT survivors:** When a mutation survives, determine whether it is a genuine test gap or an equivalent mutant. A genuine gap (the mutated behavior is observably different but no test catches it) is fixed by writing a better test. An equivalent mutant (the mutated behavior produces identical output through the public API) is left alone and accommodated by threshold headroom. Never restructure production code to eliminate equivalent-mutant sites. Small well-named helpers naturally create branches that are unreachable from their sole call site, and collapsing them to satisfy a metric trades readability for a number.
 
 **Architecture tests:** ArchUnit rules in `ArchitectureTest` enforce layering, SDK containment, domain isolation, and conventions. When an ArchUnit test fails, invoke the `archunit` skill for the fix-then-shrink workflow, SDK containment patterns, and anti-patterns. Never edit store files manually or weaken types to dodge a violation.
 
-**Changed-file coverage:** `ext.changedFileCoverageMinimum` (85%) is enforced per changed `src/main/java` file by `jacocoChangedFileCoverageVerification`. Runs in CI on every pull request regardless of base branch, so stacked PRs are gated too, plus the pre-push hook (`make install-hooks`, bypass with `SKIP_COVERAGE_HOOK=1`) and `make coverage-changed`. The hook warns but still runs when dirty source, build, or resource files could change JaCoCo output; pull-request CI remains authoritative because it tests a clean checkout. Unrelated changes such as Markdown files do not warn. Set `COVERAGE_BASE_REF=origin/<parent>` on the first push of a new stacked branch. Not wired into `check`, which has no base ref to diff against. Logic lives in `buildSrc/`, which has its own checks via `make buildsrc-check`. See `scripts/git-hooks/README.md`.
+**Changed-file coverage:** `ext.changedFileCoverageMinimum` (85%) is enforced per changed `src/main/java` file by `jacocoChangedFileCoverageVerification`. Runs in CI on every pull request regardless of base branch, so stacked PRs are gated too, plus the pre-push hook (`make install-hooks`) and `make coverage-changed`. The pre-push hook also runs the full `check` lifecycle; `SKIP_PUSH_GATE=1` bypasses the whole hook (humans only, emergencies only). The hook warns but still runs when dirty source, build, or resource files could change JaCoCo output; pull-request CI remains authoritative because it tests a clean checkout. Unrelated changes such as Markdown files do not warn. Set `COVERAGE_BASE_REF=origin/<parent>` on the first push of a new stacked branch. Not wired into `check`, which has no base ref to diff against. Logic lives in `buildSrc/`, which has its own checks via `make buildsrc-check`. See `scripts/git-hooks/README.md`.
 
 The gate fails closed. A changed file absent from the JaCoCo report fails unless it is listed in `ext.coverageExcludedClassFiles`; a missing or empty report fails. A file that is in the report with no `LINE` counter has nothing countable to measure, so it passes and is named in the output. That covers roughly 49 of the 128 `contrast-mcp-core` sources, mostly interfaces and Lombok-only types.
 
-**Integration Tests:** Require Contrast credentials in `.env.integration-test` (copy from `.env.integration-test.template`). See INTEGRATION_TESTS.md for details. Integration tests are intentionally skipped when credentials are not available (e.g., in CI forks or local builds without `.env.integration-test`).
+**Integration Tests:** Require Contrast credentials. Gradle sources `.env.integration-test` itself (copy from `.env.integration-test.template`); real environment variables override file values. `verify` fails loudly when no credentials are available; bare `integrationTest` skips instead, so forks and credential-less checkouts still build. `verify` is the maintainer gate — contributors without credentials run `check` and rely on CI. Release CI runs `verify` with credentials from repo secrets. See INTEGRATION_TESTS.md and ADR 0004.
 
 ### Docker Commands
 - **Build Docker image**: `docker build -t mcp-contrast .`
@@ -404,9 +401,9 @@ The bead and Jira lifecycle (starting work, branching, stacked branches, labels,
 
 **CRITICAL: Before requesting review, you MUST:**
 1. **Write tests for ALL code changes** - No exceptions
-2. **Run local quality verification** - `make check-test` must pass with 0 failures (static analysis, unit tests, coverage, and mutation testing)
-3. **Run complete verification** - `make verify` must pass; it includes `make check-test` plus integration tests (integration tests require credentials in `.env.integration-test`)
-   - If credentials unavailable, verify integration tests pass in CI/CD
+2. **Run local quality verification** - `make check` must pass with 0 failures (static analysis, unit tests, coverage, CRAP, and mutation testing)
+3. **Run complete verification** - `make verify` must pass; it is `check` plus integration tests and fails loudly without credentials
+   - If credentials unavailable, run `make check` and confirm integration tests pass in release CI
 4. **Verify new tests are included** - Ensure your tests ran and passed
 
 All code changes require corresponding test coverage. Do not create a PR until `make verify` passes. Do not move to review without tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ See [REPO-CONTEXT.md](./REPO-CONTEXT.md) for domain definitions, architecture no
 
 ## Git Hooks
 
-**ABSOLUTE RULE: NEVER skip git hooks.** Do not use `--no-verify`, `--no-gpg-sign`, `SKIP_PUSH_GATE=1`, `SKIP_COVERAGE_HOOK=1`, or any other mechanism to bypass pre-commit, pre-push, or any other git hook. No exceptions. No shortcuts. If a hook fails, fix the underlying problem. A skipped hook caused a CI build failure; this rule exists to prevent that from ever happening again. If you skip a hook, you have made an error.
+**ABSOLUTE RULE: NEVER skip git hooks.** Do not use `--no-verify`, `--no-gpg-sign`, `SKIP_PUSH_GATE=1`, or any other mechanism to bypass pre-commit, pre-push, or any other git hook. No exceptions. No shortcuts. If a hook fails, fix the underlying problem. A skipped hook caused a CI build failure; this rule exists to prevent that from ever happening again. If you skip a hook, you have made an error.
 
 ## Uncommitted Changes
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,3 +43,17 @@ _Avoid_: conflating with Recommendation or `howToFix`
 **Status display label**:
 The human-readable status text TeamServer returns on vulnerability records, for example "Remediated - Auto-Verified" for a vulnerability in the AutoRemediated status. Filters take canonical Vulnerability statuses, and this server's tool results carry canonical Vulnerability statuses, not display labels.
 _Avoid_: treating a display label as a valid filter value or exposing one in a tool result
+
+## Build verification
+
+**Check**:
+All verification provable from the repository alone, needing no external credentials or comparison ref. The Gradle `check` lifecycle task is its definition (ADR 0003); anything else claiming to be "the checks" is a subset or a drift.
+_Avoid_: check-test, "the checks" for hand-picked task lists
+
+**Verify**:
+Check plus the live TeamServer integration contract. Requires Contrast credentials and fails loudly without them, a Verify that ran zero integration tests has not verified (ADR 0004).
+_Avoid_: full build, treating a credential-less run as verified
+
+**Lint**:
+The fast inner-loop subset, formatting and style only. A convenience, never a gate.
+_Avoid_: calling a lint-only run a Check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,10 @@ Use the Gradle wrapper from a JDK 21 shell. The public repo is a two-module buil
 Common commands:
 
 ```bash
-./gradlew spotlessCheck checkstyleMain checkstyleTest test
+./gradlew check
 ./gradlew :contrast-mcp-stdio-app:bootJar
 ./gradlew :contrast-mcp-core:publishToMavenLocal :contrast-mcp-core:verifyCorePublicationMetadata
-make check-test
+make check
 make verify
 ```
 
@@ -34,7 +34,7 @@ Checkstyle rules and suppressions are the same rules used before the Gradle spli
 
 ## Test Coverage
 
-JaCoCo measures coverage on every `test` run and writes HTML and XML reports to `<module>/build/reports/jacoco/test/`. `make coverage` verifies the floors and prints a summary, and `make check-test` includes it.
+JaCoCo measures coverage on every `test` run and writes HTML and XML reports to `<module>/build/reports/jacoco/test/`. `make check` verifies the floors and prints a summary.
 
 Per-module floors live in `ext.coverageMinimums` in the root `build.gradle` and are enforced by `jacocoTestCoverageVerification`, which `check` depends on. They are set just below the measured baseline so they block regression rather than blocking adoption. Raise a floor as coverage improves. Never lower one to make a build pass. CI runs the same verification and uploads the reports as a build artifact.
 

--- a/INTEGRATION_TESTS.md
+++ b/INTEGRATION_TESTS.md
@@ -17,26 +17,18 @@ This project includes integration tests that run against a real Contrast TeamSer
    - `CONTRAST_USERNAME` - Your username
    - `CONTRAST_ORG_ID` - Your organization ID
 
-3. **Source the environment file:**
-   ```bash
-   source .env.integration-test
-   ```
+That's it. Gradle sources `.env.integration-test` itself; no `source` step is needed. Real environment variables override file values, so CI secrets and one-off shells win without editing the file.
 
 ## Running Integration Tests
+
+### Full gate plus integration tests (the pre-review command):
+```bash
+make verify
+```
 
 ### Run integration tests only:
 ```bash
 ./gradlew :contrast-mcp-stdio-app:integrationTest
-```
-
-### Run all tests (unit + integration):
-```bash
-./gradlew clean test :contrast-mcp-stdio-app:integrationTest
-```
-
-### Skip integration tests:
-```bash
-./gradlew test
 ```
 
 ### Run only unit tests (default):
@@ -48,8 +40,9 @@ This project includes integration tests that run against a real Contrast TeamSer
 
 - **Unit tests** (`*Test.java`) run with the Gradle `test` task
 - **Integration tests** (`*IT.java`) run with the Gradle `:contrast-mcp-stdio-app:integrationTest` task
-- Integration tests only execute if `CONTRAST_HOST_NAME` environment variable is set
-- If environment variables are missing, integration tests are automatically skipped
+- Credentials resolve from real environment variables first, then `.env.integration-test`
+- `verify` fails loudly when no credentials are available (ADR 0004) — a verify that ran zero integration tests has not verified
+- Bare `integrationTest` skips instead when `CONTRAST_HOST_NAME` is unset, so forks and credential-less checkouts still build
 
 ## GitHub Actions / CI
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 GRADLE ?= ./gradlew
 
-.PHONY: help build test test-verbose check check-verbose check-test buildsrc-check buildsrc-check-verbose coverage coverage-verbose coverage-changed coverage-changed-verbose test-coverage test-coverage-verbose mutation mutation-verbose install-hooks format clean verify verify-verbose
+.PHONY: help build lint lint-verbose format check check-verbose verify verify-verbose buildsrc-check buildsrc-check-verbose coverage-changed coverage-changed-verbose install-hooks clean
 
 help: ## Display available make targets
-	@awk 'BEGIN {FS=":.*##"; printf "\nUsage: make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_\-]+:.*##/ {printf "  %-12s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS=":.*##"; printf "\nUsage: make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_\-]+:.*##/ {printf "  %-16s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 build: ## Build the project (compile + package)
 	@if [ -n "$$VERBOSE" ]; then \
@@ -12,26 +12,76 @@ build: ## Build the project (compile + package)
 		. ./hack/run_silent.sh && run_silent "Building mcp-contrast" "$(GRADLE) :contrast-mcp-stdio-app:bootJar -x test"; \
 	fi
 
-## Check targets (formatting and static analysis)
+# check and verify are defined in Gradle (ADR 0003); make adds only quiet output and
+# auto-formatting. Attach new verifications to the Gradle check lifecycle, not here.
 
-check: format ## Run format and static analysis checks (quiet output)
+## Lint (fast inner loop, deliberately NOT a gate)
+
+lint: ## Auto-format and run style checks only (fast, no tests)
 	@if [ -n "$$VERBOSE" ]; then \
-		$(GRADLE) spotlessCheck checkstyleMain checkstyleTest; \
+		$(GRADLE) spotlessApply checkstyleMain checkstyleTest; \
+	else \
+		$(MAKE) lint-quiet; \
+	fi
+
+lint-quiet:
+	@. ./hack/run_silent.sh && print_main_header "Linting"
+	@. ./hack/run_silent.sh && run_silent "Formatting code" "$(GRADLE) spotlessApply"
+	@. ./hack/run_silent.sh && print_header "mcp-contrast" "Checkstyle"
+	@. ./hack/run_silent.sh && run_with_quiet "Lint passed" "$(GRADLE) checkstyleMain checkstyleTest"
+
+lint-verbose: ## Run lint with verbose output
+	@VERBOSE=1 $(MAKE) lint
+
+## Check (the standard local gate: everything provable from the repo alone)
+
+check: ## Auto-format, then run the full Gradle check lifecycle and print the coverage summary
+	@if [ -n "$$VERBOSE" ]; then \
+		$(GRADLE) spotlessApply && $(GRADLE) --continue check coverageSummary; \
 	else \
 		$(MAKE) check-quiet; \
 	fi
 
+# Summary prints even when check fails (held exit code): a breached floor is when the
+# numbers are wanted.
 check-quiet:
-	@. ./hack/run_silent.sh && print_main_header "Running Checks"
-	@. ./hack/run_silent.sh && print_header "mcp-contrast" "Static analysis"
-	@. ./hack/run_silent.sh && run_with_quiet "All checks passed" "$(GRADLE) spotlessCheck checkstyleMain checkstyleTest"
+	@. ./hack/run_silent.sh && print_main_header "Running Check"
+	@. ./hack/run_silent.sh && run_silent "Formatting code" "$(GRADLE) spotlessApply"
+	@. ./hack/run_silent.sh && print_header "mcp-contrast" "check (static analysis, tests, coverage, CRAP, mutation)"
+	@status=0; \
+	. ./hack/run_silent.sh && run_silent_with_test_count "check passed" "$(GRADLE) check" "gradle" || status=$$?; \
+	$(GRADLE) --quiet coverageSummary; \
+	exit $$status
 
-check-verbose: ## Run checks with verbose output
+check-verbose: ## Run check with verbose output
 	@VERBOSE=1 $(MAKE) check
 
-# buildSrc is a separate Gradle build, so `gradlew test` and `gradlew check` in the root
-# build never schedule its tests. The changed-file coverage gate lives here, so it needs
-# its own invocation or nothing verifies it.
+## Verify (check plus the credential-gated integration tests)
+
+verify: ## Run check plus integration tests (requires Contrast credentials, fails loudly without them)
+	@if [ -n "$$VERBOSE" ]; then \
+		$(GRADLE) spotlessApply && $(GRADLE) --continue verify coverageSummary; \
+	else \
+		$(MAKE) verify-quiet; \
+	fi
+
+verify-quiet:
+	@. ./hack/run_silent.sh && print_main_header "Running Verify"
+	@. ./hack/run_silent.sh && run_silent "Formatting code" "$(GRADLE) spotlessApply"
+	@. ./hack/run_silent.sh && print_header "mcp-contrast" "verify (check + integration tests)"
+	@status=0; \
+	. ./hack/run_silent.sh && run_silent_with_test_count "verify passed" "$(GRADLE) verify" "gradle" || status=$$?; \
+	$(GRADLE) --quiet coverageSummary; \
+	exit $$status
+
+verify-verbose: ## Run verify with verbose output
+	@VERBOSE=1 $(MAKE) verify
+
+## Gates that genuinely cannot live in the check lifecycle
+
+# buildSrc is a separate Gradle build, so `gradlew check` in the root build never schedules
+# its tests. The changed-file coverage gate's logic lives here, so it needs its own
+# invocation or nothing verifies it.
 buildsrc-check: ## Run buildSrc static analysis and tests
 	@if [ -n "$$VERBOSE" ]; then \
 		$(GRADLE) -p buildSrc check; \
@@ -47,63 +97,7 @@ buildsrc-check-quiet:
 buildsrc-check-verbose: ## Run buildSrc checks with verbose output
 	@VERBOSE=1 $(MAKE) buildsrc-check
 
-## Test targets
-
-test: ## Run unit tests (quiet output)
-	@if [ -n "$$VERBOSE" ]; then \
-		$(GRADLE) test; \
-	else \
-		$(MAKE) test-quiet; \
-	fi
-
-test-quiet:
-	@. ./hack/run_silent.sh && print_main_header "Running Tests"
-	@. ./hack/run_silent.sh && print_header "mcp-contrast" "Unit tests"
-	@. ./hack/run_silent.sh && run_silent_with_test_count "Unit tests passed" "$(GRADLE) test" "gradle"
-
-test-verbose: ## Run tests with verbose output
-	@VERBOSE=1 $(MAKE) test
-
-## Verify targets (complete local gate including integration tests)
-
-verify: check-test ## Run all local verification including integration tests (quiet output)
-	@if [ -n "$$VERBOSE" ]; then \
-		$(GRADLE) :contrast-mcp-stdio-app:integrationTest; \
-	else \
-		$(MAKE) verify-quiet; \
-	fi
-
-verify-quiet:
-	@. ./hack/run_silent.sh && print_main_header "Running Integration Tests"
-	@. ./hack/run_silent.sh && print_header "contrast-mcp-stdio-app" "Integration tests"
-	@. ./hack/run_silent.sh && run_silent_with_test_count "Integration tests passed" "$(GRADLE) :contrast-mcp-stdio-app:integrationTest" "gradle"
-
-verify-verbose: ## Run all local verification including integration tests with verbose output
-	@VERBOSE=1 $(MAKE) verify
-
-## Coverage targets
-
-coverage: ## Verify coverage floors and print the summary
-	@if [ -n "$$VERBOSE" ]; then \
-		$(GRADLE) --continue jacocoTestCoverageVerification coverageSummary; \
-	else \
-		$(MAKE) coverage-quiet; \
-	fi
-
-# The summary runs after verification and regardless of its result, because a breached
-# floor is exactly when the numbers are wanted. The verification exit code is held and
-# re-raised at the end so a failure still fails the target.
-coverage-quiet:
-	@. ./hack/run_silent.sh && print_main_header "Checking Coverage"
-	@. ./hack/run_silent.sh && print_header "mcp-contrast" "Coverage floors"
-	@status=0; \
-	. ./hack/run_silent.sh && run_with_quiet "Coverage floors met" "$(GRADLE) jacocoTestCoverageVerification" || status=$$?; \
-	$(GRADLE) --quiet coverageSummary; \
-	exit $$status
-
-coverage-verbose: ## Run coverage with verbose output
-	@VERBOSE=1 $(MAKE) coverage
-
+# Needs a base ref, so it cannot join check (a working-tree run in CI would pass vacuously).
 # Measures the working tree by default. Pass BASE to compare against a ref instead, which is
 # what the pre-push hook does: make coverage-changed BASE=origin/main
 coverage-changed: ## Check changed src/main/java files meet the changed-file coverage minimum
@@ -121,53 +115,6 @@ coverage-changed-quiet:
 
 coverage-changed-verbose: ## Run changed-file coverage with verbose output
 	@VERBOSE=1 $(MAKE) coverage-changed
-
-# One invocation on purpose. bootBuildInfo rewrites build-info.properties every run, so the
-# app's test task is never UP-TO-DATE and separate `make test` + `make coverage` runs it twice.
-test-coverage: ## Run unit tests and verify coverage floors in one invocation
-	@if [ -n "$$VERBOSE" ]; then \
-		$(GRADLE) --continue test jacocoTestCoverageVerification coverageSummary; \
-	else \
-		$(MAKE) test-coverage-quiet; \
-	fi
-
-# Held exit code as in coverage-quiet: the summary is wanted precisely when a floor breaks.
-test-coverage-quiet:
-	@. ./hack/run_silent.sh && print_main_header "Running Tests and Coverage"
-	@. ./hack/run_silent.sh && print_header "mcp-contrast" "Unit tests + coverage floors"
-	@status=0; \
-	. ./hack/run_silent.sh && run_silent_with_test_count "Tests passed, coverage floors met" \
-		"$(GRADLE) test jacocoTestCoverageVerification" "gradle" || status=$$?; \
-	$(GRADLE) --quiet coverageSummary; \
-	exit $$status
-
-test-coverage-verbose: ## Run tests and coverage with verbose output
-	@VERBOSE=1 $(MAKE) test-coverage
-
-## Combined targets
-
-check-test: ## Run all checks, unit tests, coverage, and mutation testing
-	@$(MAKE) check
-	@$(MAKE) buildsrc-check
-	@$(MAKE) test-coverage
-	@$(MAKE) mutation
-
-## Mutation testing
-
-mutation: ## Run PIT mutation testing on contrast-mcp-core
-	@if [ -n "$$VERBOSE" ]; then \
-		$(GRADLE) :contrast-mcp-core:pitest; \
-	else \
-		$(MAKE) mutation-quiet; \
-	fi
-
-mutation-quiet:
-	@. ./hack/run_silent.sh && print_main_header "Running Mutation Tests"
-	@. ./hack/run_silent.sh && print_header "contrast-mcp-core" "PIT mutation testing"
-	@. ./hack/run_silent.sh && run_with_quiet "Mutation test strength floor met" "$(GRADLE) :contrast-mcp-core:pitest"
-
-mutation-verbose: ## Run mutation testing with verbose output
-	@VERBOSE=1 $(MAKE) mutation
 
 ## Other targets
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -119,7 +119,7 @@ test -f contrast-mcp-stdio-app/build/libs/mcp-contrast-X.Y.Z.jar
 
 Then create a GitHub release for the tag and attach `contrast-mcp-stdio-app/build/libs/mcp-contrast-X.Y.Z.jar`. Note that these manual instructions do not publish to Artifactory, sign the Docker image, generate SBOMs, or create attestations. Use the workflow whenever possible.
 
-**Coverage gate:** `check` runs `jacocoTestCoverageVerification`, so a release aborts if either module falls below its floor in `ext.coverageMinimums`. Because releases only run from `main`, and the same task and floors already gated the commit in `build.yml`, this should not fire in practice. If it does, run `make coverage` locally for the per-module numbers, or read the `test-reports` artifact (JaCoCo coverage plus PIT mutation reports) from that commit's build run.
+**Validation gate:** the release runs `verify`, which is the full `check` lifecycle (static analysis, unit tests, coverage floors, CRAP gate, PIT) plus the integration tests against the org named by the `CONTRAST_*` repo secrets. Because releases only run from `main`, and `check` already gated the commit in `build.yml`, only the integration tests are genuinely new here. If a floor fires anyway, run `make check` locally for the per-module numbers, or read the `test-reports` artifact from that commit's build run.
 
 ## Verify the Release
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -110,7 +110,7 @@ Use this only if the workflow cannot run:
 ```bash
 git switch main
 git pull
-./gradlew clean spotlessCheck check :contrast-mcp-stdio-app:integrationTest :contrast-mcp-stdio-app:bootJar
+./gradlew clean verify :contrast-mcp-stdio-app:bootJar
 ./gradlew release -Prelease.forceVersion=X.Y.Z
 git checkout vX.Y.Z
 ./gradlew clean :contrast-mcp-stdio-app:bootJar -x test

--- a/REPO-CONTEXT.md
+++ b/REPO-CONTEXT.md
@@ -13,9 +13,9 @@ Domain terms live in [CONTEXT.md](./CONTEXT.md). Read it before touching tool co
 
 **Build and verify:**
 ```bash
-make check-test    # static analysis + unit tests + coverage + mutation (standard local gate)
-make verify        # complete local gate + integration tests (integration requires .env.integration-test)
-make mutation      # PIT mutation testing on contrast-mcp-core
+make check         # standard local gate: static analysis + unit tests + coverage + CRAP + mutation
+make verify        # check + integration tests (requires credentials, fails loudly without)
+make lint          # fast inner loop: format + checkstyle only, not a gate
 ```
 
 **Run locally:**

--- a/build.gradle
+++ b/build.gradle
@@ -492,6 +492,22 @@ subprojects {
     // Apply after the existing JaCoCo report configuration so crap4j can finalize the XML output
     // without preventing this build from declaring its report requirements first.
     apply plugin: 'com.architester.crap4j'
+
+    // The plugin defaults attachToCheck to false; check is the single verification gate (ADR 0003).
+    crap4j {
+        attachToCheck = true
+    }
+}
+
+// check + the credential-gated integration tests (ADR 0003/0004). buildSrc is a separate
+// Gradle build and cannot be wired in here.
+tasks.register('verify') {
+    group = 'verification'
+    description = 'Runs check in every project plus the integration tests.'
+    dependsOn tasks.named('check')
+    dependsOn subprojects.collect { ":${it.name}:check" }
+    dependsOn ':contrast-mcp-stdio-app:requireIntegrationTestCredentials'
+    dependsOn ':contrast-mcp-stdio-app:integrationTest'
 }
 
 tasks.register('coverageSummary') {

--- a/buildSrc/src/main/java/com/contrast/labs/build/EnvFileParser.java
+++ b/buildSrc/src/main/java/com/contrast/labs/build/EnvFileParser.java
@@ -1,0 +1,79 @@
+package com.contrast.labs.build;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Parses {@code .env}-style files into key-value pairs.
+ *
+ * <p>Handles comment lines, {@code export} prefixes, and single/double-quoted values. Values from
+ * real environment variables take precedence when resolved through {@link #resolve}.
+ */
+public final class EnvFileParser {
+
+  private EnvFileParser() {}
+
+  /**
+   * Parses an env file into a map of key-value pairs. Returns an empty map if the file is absent.
+   */
+  public static Map<String, String> parse(File envFile) {
+    if (!envFile.exists()) {
+      return Map.of();
+    }
+    try {
+      return parseLines(Files.readAllLines(envFile.toPath(), StandardCharsets.UTF_8));
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read " + envFile, e);
+    }
+  }
+
+  /** Parses raw lines into a map, for testability without touching the filesystem. */
+  static Map<String, String> parseLines(Iterable<String> lines) {
+    Map<String, String> values = new LinkedHashMap<>();
+    for (String rawLine : lines) {
+      String line = rawLine.trim();
+      if (line.isEmpty() || line.startsWith("#")) {
+        continue;
+      }
+      if (line.startsWith("export ")) {
+        line = line.substring("export ".length()).trim();
+      }
+      int separator = line.indexOf('=');
+      if (separator < 1) {
+        continue;
+      }
+      String key = line.substring(0, separator).trim();
+      String value = line.substring(separator + 1).trim();
+      if (value.length() > 1
+          && ((value.startsWith("\"") && value.endsWith("\""))
+              || (value.startsWith("'") && value.endsWith("'")))) {
+        value = value.substring(1, value.length() - 1);
+      }
+      values.put(key, value);
+    }
+    return values;
+  }
+
+  /**
+   * Resolves credential values for the given names. Real environment variables win over file
+   * values.
+   *
+   * @param envFile the {@code .env} file to fall back to
+   * @param credentialNames the environment variable names to resolve
+   * @return map of name to resolved value (null when absent from both sources)
+   */
+  public static Map<String, String> resolve(File envFile, Iterable<String> credentialNames) {
+    Map<String, String> fileValues = parse(envFile);
+    Map<String, String> resolved = new LinkedHashMap<>();
+    for (String name : credentialNames) {
+      String envValue = System.getenv(name);
+      resolved.put(name, envValue != null ? envValue : fileValues.get(name));
+    }
+    return resolved;
+  }
+}

--- a/buildSrc/src/test/java/com/contrast/labs/build/EnvFileParserTest.java
+++ b/buildSrc/src/test/java/com/contrast/labs/build/EnvFileParserTest.java
@@ -1,0 +1,144 @@
+package com.contrast.labs.build;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class EnvFileParserTest {
+
+  @TempDir Path tmp;
+
+  @Test
+  void parseLines_should_return_empty_map_when_no_lines() {
+    assertThat(EnvFileParser.parseLines(List.of())).isEmpty();
+  }
+
+  @Test
+  void parseLines_should_skip_comment_lines() {
+    var result = EnvFileParser.parseLines(List.of("# this is a comment", "KEY=value"));
+    assertThat(result).containsExactly(Map.entry("KEY", "value"));
+  }
+
+  @Test
+  void parseLines_should_skip_blank_lines() {
+    var result = EnvFileParser.parseLines(List.of("", "  ", "KEY=value"));
+    assertThat(result).containsExactly(Map.entry("KEY", "value"));
+  }
+
+  @Test
+  void parseLines_should_strip_export_prefix() {
+    var result = EnvFileParser.parseLines(List.of("export FOO=bar"));
+    assertThat(result).containsExactly(Map.entry("FOO", "bar"));
+  }
+
+  @Test
+  void parseLines_should_strip_double_quotes_from_values() {
+    var result = EnvFileParser.parseLines(List.of("KEY=\"quoted value\""));
+    assertThat(result).containsExactly(Map.entry("KEY", "quoted value"));
+  }
+
+  @Test
+  void parseLines_should_strip_single_quotes_from_values() {
+    var result = EnvFileParser.parseLines(List.of("KEY='quoted value'"));
+    assertThat(result).containsExactly(Map.entry("KEY", "quoted value"));
+  }
+
+  @Test
+  void parseLines_should_not_strip_mismatched_quotes() {
+    var result = EnvFileParser.parseLines(List.of("KEY=\"mismatched'"));
+    assertThat(result).containsExactly(Map.entry("KEY", "\"mismatched'"));
+  }
+
+  @Test
+  void parseLines_should_not_strip_single_char_quoted_value() {
+    var result = EnvFileParser.parseLines(List.of("KEY=\""));
+    assertThat(result).containsExactly(Map.entry("KEY", "\""));
+  }
+
+  @Test
+  void parseLines_should_handle_empty_value() {
+    var result = EnvFileParser.parseLines(List.of("KEY="));
+    assertThat(result).containsExactly(Map.entry("KEY", ""));
+  }
+
+  @Test
+  void parseLines_should_skip_lines_without_separator() {
+    var result = EnvFileParser.parseLines(List.of("NOSEP", "KEY=value"));
+    assertThat(result).containsExactly(Map.entry("KEY", "value"));
+  }
+
+  @Test
+  void parseLines_should_skip_lines_with_leading_equals() {
+    var result = EnvFileParser.parseLines(List.of("=value", "KEY=value"));
+    assertThat(result).containsExactly(Map.entry("KEY", "value"));
+  }
+
+  @Test
+  void parseLines_should_use_first_equals_as_separator() {
+    var result = EnvFileParser.parseLines(List.of("KEY=val=ue"));
+    assertThat(result).containsExactly(Map.entry("KEY", "val=ue"));
+  }
+
+  @Test
+  void parseLines_should_trim_whitespace_around_key_and_value() {
+    var result = EnvFileParser.parseLines(List.of("  KEY  =  value  "));
+    assertThat(result).containsExactly(Map.entry("KEY", "value"));
+  }
+
+  @Test
+  void parseLines_should_handle_export_with_quotes() {
+    var result = EnvFileParser.parseLines(List.of("export KEY=\"hello world\""));
+    assertThat(result).containsExactly(Map.entry("KEY", "hello world"));
+  }
+
+  @Test
+  void parseLines_should_preserve_order() {
+    var result = EnvFileParser.parseLines(List.of("A=1", "B=2", "C=3"));
+    assertThat(result.keySet()).containsExactly("A", "B", "C");
+  }
+
+  @Test
+  void parse_should_return_empty_map_when_file_does_not_exist() {
+    assertThat(EnvFileParser.parse(new File(tmp.toFile(), "missing"))).isEmpty();
+  }
+
+  @Test
+  void parse_should_read_file_contents() throws IOException {
+    Path envFile = tmp.resolve("test.env");
+    Files.writeString(envFile, "export HOST=example.com\nAPI_KEY='secret'\n");
+    var result = EnvFileParser.parse(envFile.toFile());
+    assertThat(result)
+        .containsEntry("HOST", "example.com")
+        .containsEntry("API_KEY", "secret")
+        .hasSize(2);
+  }
+
+  @Test
+  void parseLines_should_handle_template_format() {
+    var result =
+        EnvFileParser.parseLines(
+            List.of(
+                "# Integration Test Environment Variables",
+                "# Copy this file and fill in your credentials",
+                "",
+                "export CONTRAST_HOST_NAME=app.contrastsecurity.com",
+                "export CONTRAST_API_KEY=your-api-key-here",
+                "export CONTRAST_SERVICE_KEY=your-service-key-here",
+                "export CONTRAST_USERNAME=your-username-here",
+                "export CONTRAST_ORG_ID=your-org-id-here",
+                "",
+                "# Note: .env.integration-test is in .gitignore"));
+    assertThat(result)
+        .hasSize(5)
+        .containsEntry("CONTRAST_HOST_NAME", "app.contrastsecurity.com")
+        .containsEntry("CONTRAST_API_KEY", "your-api-key-here")
+        .containsEntry("CONTRAST_ORG_ID", "your-org-id-here");
+  }
+}

--- a/contrast-mcp-core/build.gradle
+++ b/contrast-mcp-core/build.gradle
@@ -185,6 +185,11 @@ pitest {
     threads = Runtime.runtime.availableProcessors()
 }
 
+// PIT rides check (ADR 0003); up-to-date checking makes it free when core is unchanged.
+tasks.named('check') {
+    dependsOn tasks.named('pitest')
+}
+
 String mcpCoreArtifactProperty(String name) {
     def propertiesFile = rootProject.file('gradle/contrast-mcp-core-artifact.properties')
     def properties = new Properties()

--- a/contrast-mcp-stdio-app/build.gradle
+++ b/contrast-mcp-stdio-app/build.gradle
@@ -47,41 +47,11 @@ def contrastIntegrationTestCredentialEnvVars = [
 ]
 
 // Credentials come from real environment variables first, then .env.integration-test (ADR 0004).
-def parseIntegrationTestEnvFile = { File envFile ->
-    def values = [:]
-    if (!envFile.exists()) {
-        return values
-    }
-    envFile.readLines().each { rawLine ->
-        def line = rawLine.trim()
-        if (line.isEmpty() || line.startsWith('#')) {
-            return
-        }
-        if (line.startsWith('export ')) {
-            line = line.substring('export '.length()).trim()
-        }
-        def separator = line.indexOf('=')
-        if (separator < 1) {
-            return
-        }
-        def key = line.substring(0, separator).trim()
-        def value = line.substring(separator + 1).trim()
-        def quoted = value.length() > 1 &&
-            ((value.startsWith('"') && value.endsWith('"')) ||
-                (value.startsWith("'") && value.endsWith("'")))
-        if (quoted) {
-            value = value.substring(1, value.length() - 1)
-        }
-        values[key] = value
-    }
-    values
-}
+// Parsing logic lives in buildSrc (EnvFileParser) with unit tests.
+import com.contrast.labs.build.EnvFileParser
 
 def resolveIntegrationTestCredentials = { ->
-    def fileValues = parseIntegrationTestEnvFile(rootProject.file('.env.integration-test'))
-    contrastIntegrationTestCredentialEnvVars.collectEntries { name ->
-        [(name): System.getenv(name) ?: fileValues[name]]
-    }
+    EnvFileParser.resolve(rootProject.file('.env.integration-test'), contrastIntegrationTestCredentialEnvVars)
 }
 
 test {

--- a/contrast-mcp-stdio-app/build.gradle
+++ b/contrast-mcp-stdio-app/build.gradle
@@ -46,6 +46,44 @@ def contrastIntegrationTestCredentialEnvVars = [
     'CONTRAST_ORG_ID'
 ]
 
+// Credentials come from real environment variables first, then .env.integration-test (ADR 0004).
+def parseIntegrationTestEnvFile = { File envFile ->
+    def values = [:]
+    if (!envFile.exists()) {
+        return values
+    }
+    envFile.readLines().each { rawLine ->
+        def line = rawLine.trim()
+        if (line.isEmpty() || line.startsWith('#')) {
+            return
+        }
+        if (line.startsWith('export ')) {
+            line = line.substring('export '.length()).trim()
+        }
+        def separator = line.indexOf('=')
+        if (separator < 1) {
+            return
+        }
+        def key = line.substring(0, separator).trim()
+        def value = line.substring(separator + 1).trim()
+        def quoted = value.length() > 1 &&
+            ((value.startsWith('"') && value.endsWith('"')) ||
+                (value.startsWith("'") && value.endsWith("'")))
+        if (quoted) {
+            value = value.substring(1, value.length() - 1)
+        }
+        values[key] = value
+    }
+    values
+}
+
+def resolveIntegrationTestCredentials = { ->
+    def fileValues = parseIntegrationTestEnvFile(rootProject.file('.env.integration-test'))
+    contrastIntegrationTestCredentialEnvVars.collectEntries { name ->
+        [(name): System.getenv(name) ?: fileValues[name]]
+    }
+}
+
 test {
     exclude '**/*IT.class'
     exclude '**/*IntegrationTest.class'
@@ -61,11 +99,29 @@ tasks.register('integrationTest', Test) {
     shouldRunAfter test
     include '**/*IT.class'
     include '**/*IntegrationTest.class'
-    contrastIntegrationTestCredentialEnvVars.each { credentialEnvVar ->
-        def credentialValue = System.getenv(credentialEnvVar)
+    resolveIntegrationTestCredentials().each { credentialEnvVar, credentialValue ->
         if (credentialValue) {
             systemProperty credentialEnvVar, credentialValue
             environment credentialEnvVar, credentialValue
+        }
+    }
+    mustRunAfter 'requireIntegrationTestCredentials'
+}
+
+// Depended on only by the root verify task; bare integrationTest keeps its skip behavior
+// for credential-less checkouts (ADR 0004).
+tasks.register('requireIntegrationTestCredentials') {
+    group = 'verification'
+    description = 'Fails when no Contrast credentials are available for the integration tests.'
+    doLast {
+        def credentials = resolveIntegrationTestCredentials()
+        def missing = credentials.findAll { name, value -> !value }.keySet()
+        if (!missing.isEmpty()) {
+            throw new GradleException(
+                "verify requires Contrast integration-test credentials, but these are unset: " +
+                    "${missing.join(', ')}. Export them or create .env.integration-test from " +
+                    ".env.integration-test.template (see INTEGRATION_TESTS.md). Contributors " +
+                    "without credentials run `check`; pull-request CI stays authoritative.")
         }
     }
 }

--- a/docs/adr/0003-standardize-on-gradle-check-and-verify-lifecycles.md
+++ b/docs/adr/0003-standardize-on-gradle-check-and-verify-lifecycles.md
@@ -1,0 +1,21 @@
+# Standardize verification on the Gradle lifecycle tasks check and verify
+
+The Makefile, PR CI, and the release workflow each enumerated Gradle task names by hand, so every new verification had to be added to every invoker separately. The crap4j gate (AIML-1227) proved the failure mode: `crapCheck` was registered but no gate anywhere ran it, and the invokers had already drifted from each other (pitest ran on PRs but not releases, `verifyCoverageMinimums` reached CI only via a transitive dependency). We decided that Gradle lifecycle tasks are the single source of truth and invokers call them by lifecycle name:
+
+- `check` = every verification provable from the repository alone: Spotless, Checkstyle, unit tests (including ArchUnit), JaCoCo floors plus `verifyCoverageMinimums`, `crapCheck` (via `crap4j { attachToCheck = true }`), and PIT.
+- `verify` = a custom root lifecycle task, borrowing Maven's name: `check` plus `:contrast-mcp-stdio-app:integrationTest`. The only delta is the credential-gated live-API contract (see ADR 0004).
+
+Make targets become thin quiet-output wrappers that forward to one lifecycle task each; the composite targets (`check-test`, `test-coverage`) that defined their own version of the gate are deleted. `make lint` survives as a deliberately named fast subset (format + checkstyle, ~4s) so the inner loop keeps a quick path without overloading the word `check`.
+
+## Considered options
+
+- **Keep enumerated task lists** in make and CI. Rejected: enumeration is the mechanism by which `crapCheck` ran nowhere, and it will recur for every future gate.
+- **Keep PIT out of `check`** as a slow-path extra. Rejected after measurement: a full PIT run is 38s locally and cached by Gradle up-to-date checks when core is unchanged. Carving it out would recreate the enumeration disease for one task.
+- **Keep `make check` as the fast no-test loop.** Rejected: a make target named `check` that does less than `gradlew check` is exactly the ambiguity this decision removes. The fast path gets its own name (`lint`).
+
+## Consequences
+
+- `make check` grows from a 5s lint pass to the full gate (~5s clean, ~60s when core changed, PIT dominating).
+- Merge-to-main and release CI gain PIT (~3 minutes on runner hardware); both previously shipped without mutation testing.
+- The pre-push hook runs `gradlew check` before the changed-file coverage check. Up-to-date checking makes it ~6s when `make check` already ran, and the full cost lands exactly on pushes that skipped it. One human-only bypass, `SKIP_PUSH_GATE=1`, replaces `SKIP_COVERAGE_HOOK`.
+- The deliberate exceptions stay outside `check` and remain enumerated: `jacocoChangedFileCoverageVerification` (needs a base ref), buildSrc checks (separate Gradle build), integration tests (see ADR 0004), and the pre-commit hook's fix-first subset (`spotlessApply` fixes, `check` only rejects).

--- a/docs/adr/0003-standardize-on-gradle-check-and-verify-lifecycles.md
+++ b/docs/adr/0003-standardize-on-gradle-check-and-verify-lifecycles.md
@@ -17,5 +17,5 @@ Make targets become thin quiet-output wrappers that forward to one lifecycle tas
 
 - `make check` grows from a 5s lint pass to the full gate (~5s clean, ~60s when core changed, PIT dominating).
 - Merge-to-main and release CI gain PIT (~3 minutes on runner hardware); both previously shipped without mutation testing.
-- The pre-push hook runs `gradlew check` before the changed-file coverage check. Up-to-date checking makes it ~6s when `make check` already ran, and the full cost lands exactly on pushes that skipped it. One human-only bypass, `SKIP_PUSH_GATE=1`, replaces `SKIP_COVERAGE_HOOK`.
+- The pre-push hook runs `gradlew check` before the changed-file coverage check. Up-to-date checking makes it ~6s when `make check` already ran, and the full cost lands exactly on pushes that skipped it. One human-only bypass, `SKIP_PUSH_GATE=1`, is available for emergencies.
 - The deliberate exceptions stay outside `check` and remain enumerated: `jacocoChangedFileCoverageVerification` (needs a base ref), buildSrc checks (separate Gradle build), integration tests (see ADR 0004), and the pre-commit hook's fix-first subset (`spotlessApply` fixes, `check` only rejects).

--- a/docs/adr/0004-integration-tests-fail-loudly-and-gate-releases.md
+++ b/docs/adr/0004-integration-tests-fail-loudly-and-gate-releases.md
@@ -1,0 +1,18 @@
+# Integration tests fail loudly without credentials and gate releases
+
+Every `*IT` class is guarded by `@EnabledIfEnvironmentVariable(named = "CONTRAST_HOST_NAME", ...)`, and nothing loaded `.env.integration-test` automatically. The result: the release workflow invoked `integrationTest` with no credentials and went green having run zero tests, and a bare `make verify` in a fresh shell did the same. The repo's own testing standards forbid silent skips, and the build itself was the violator.
+
+We decided:
+
+- Gradle sources `.env.integration-test` itself when the file exists. Real environment variables win over file values, so CI and one-off shells can override without editing files.
+- `verify` (ADR 0003) fails loudly when no credentials are available from either source. A gate that can pass on zero integration tests is not a gate.
+- Bare `integrationTest` keeps the skip behavior, so forks and credential-less checkouts can still run the rest of the build.
+- Release CI runs `verify` with the five `CONTRAST_*` values as plain GitHub repository secrets, so integration tests genuinely gate releases. The secrets initially hold a maintainer's personal eval-org credentials to unblock the work; AIML-1408 (high priority) migrates them to a dedicated service account.
+- `verify` is the maintainer gate. Contributors without credentials run `check`; CI on the clean checkout stays authoritative.
+
+## Considered options
+
+- **Soften fail-loud to a warning** so `verify` passes without credentials. Rejected: that reintroduces the silent-skip disease in dilute form.
+- **Drop `integrationTest` from release validation** and keep `verify` local-only. Rejected: a release is precisely when the live TeamServer contract should be tested.
+- **A GitHub environment with protection rules** instead of plain repo secrets. Rejected: the release workflow is already gated on manual dispatch by maintainers, and fork PRs can never read repo secrets, so the extra layer duplicates an existing control.
+- **`verify` in a git hook.** Rejected: live-API tests are minutes long, network- and credential-dependent, and occasionally flaky for reasons unrelated to the change. Hooks that fail spuriously teach people to bypass hooks.

--- a/scripts/git-hooks/README.md
+++ b/scripts/git-hooks/README.md
@@ -22,9 +22,12 @@ so. Merge the two by hand if both are wanted.
   (re-staging any reformatted files), runs unit tests, and runs Checkstyle. Skips entirely
   when no Java files are staged.
 
-* `pre-push` runs `jacocoChangedFileCoverageVerification`, which fails when a changed
-  `src/main/java` file has less than the line coverage required by
+* `pre-push` runs the Gradle `check` lifecycle, then `jacocoChangedFileCoverageVerification`,
+  which fails when a changed `src/main/java` file has less than the line coverage required by
   `changedFileCoverageMinimum` in the root `build.gradle`.
+
+  `check` runs once per push against the working tree. Gradle's up-to-date checking makes it
+  a few seconds when `make check` already ran; the full cost lands on pushes that skipped it.
 
   It compares against the remote ref being pushed when there is one, then
   `COVERAGE_BASE_REF` when explicitly set, the pushed branch's own upstream, and finally
@@ -49,7 +52,8 @@ so. Merge the two by hand if both are wanted.
   files do not produce a warning. Refs that change no Java files skip Gradle entirely, since
   Gradle startup is most of the hook's cost.
 
-  Set `SKIP_COVERAGE_HOOK=1` to bypass the gate for a push.
+  Set `SKIP_PUSH_GATE=1` to bypass the whole gate for a push (humans only, emergencies only).
+  `SKIP_COVERAGE_HOOK=1` still works as a deprecated alias.
 
 ## Running the gate by hand
 

--- a/scripts/git-hooks/README.md
+++ b/scripts/git-hooks/README.md
@@ -53,7 +53,6 @@ so. Merge the two by hand if both are wanted.
   Gradle startup is most of the hook's cost.
 
   Set `SKIP_PUSH_GATE=1` to bypass the whole gate for a push (humans only, emergencies only).
-  `SKIP_COVERAGE_HOOK=1` still works as a deprecated alias.
 
 ## Running the gate by hand
 

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -141,11 +141,8 @@ main() {
   local -a remote_refs=()
   local -a remote_shas=()
 
-  # Umbrella bypass, humans only. SKIP_COVERAGE_HOOK is honored as a deprecated alias.
-  if [[ "${SKIP_PUSH_GATE:-}" == "1" || "${SKIP_COVERAGE_HOOK:-}" == "1" ]]; then
-    if [[ "${SKIP_COVERAGE_HOOK:-}" == "1" ]]; then
-      printf "SKIP_COVERAGE_HOOK is deprecated; use SKIP_PUSH_GATE=1.\n" >&2
-    fi
+  # Umbrella bypass, humans only.
+  if [[ "${SKIP_PUSH_GATE:-}" == "1" ]]; then
     printf "SKIP_PUSH_GATE set; skipping the pre-push gate (check + changed-file coverage).\n" >&2
     return
   fi

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Pre-push hook to block changed-file coverage failures before review.
+# Pre-push hook: runs the Gradle check lifecycle, then changed-file coverage verification.
 
 set -euo pipefail
 
@@ -141,8 +141,12 @@ main() {
   local -a remote_refs=()
   local -a remote_shas=()
 
-  if [[ "${SKIP_COVERAGE_HOOK:-}" == "1" ]]; then
-    printf "SKIP_COVERAGE_HOOK=1 set; skipping changed-file coverage verification.\n" >&2
+  # Umbrella bypass, humans only. SKIP_COVERAGE_HOOK is honored as a deprecated alias.
+  if [[ "${SKIP_PUSH_GATE:-}" == "1" || "${SKIP_COVERAGE_HOOK:-}" == "1" ]]; then
+    if [[ "${SKIP_COVERAGE_HOOK:-}" == "1" ]]; then
+      printf "SKIP_COVERAGE_HOOK is deprecated; use SKIP_PUSH_GATE=1.\n" >&2
+    fi
+    printf "SKIP_PUSH_GATE set; skipping the pre-push gate (check + changed-file coverage).\n" >&2
     return
   fi
 
@@ -160,9 +164,12 @@ main() {
 
   # If every stdin row was a deletion, there are no pushed commits to analyze.
   if (( ${#local_refs[@]} == 0 )); then
-    printf "No pushed commit refs; skipping changed-file coverage verification.\n"
+    printf "No pushed commit refs; skipping the pre-push gate.\n"
     return
   fi
+
+  # Once per push. Verifies the working tree, not the pushed commits; CI stays authoritative.
+  perform_check "running the Gradle check lifecycle" ./gradlew -q check
 
   head_sha=$(git rev-parse HEAD)
 


### PR DESCRIPTION
<!-- pr-tools:stacked:v1 -->
<!-- pr-tools:parent-pr=239 -->
<!-- pr-tools:parent-branch=AIML-1227-add-crap-metrics -->
<!-- pr-tools:parent-base=main -->
<!-- pr-tools:boundary-commit=d6f760d21ee5b46415dbcfe44c5c3066e1d657a2 -->
<!-- pr-tools:managed:start -->
<!-- pr-tools:managed:end -->

**Jira:** [AIML-1407](https://contrast.atlassian.net/browse/AIML-1407)

## Summary

Make targets, CI workflows, and the pre-push hook each enumerated Gradle task names by hand, so every new verification had to be added to every invoker separately. The crap4j gate (AIML-1227) proved the failure mode: `crapCheck` was registered but no gate ran it, pitest ran on PRs but not releases, and the release workflow invoked `integrationTest` with no credentials so every IT silently skipped. This PR standardizes on two Gradle lifecycle tasks as the single source of truth, eliminating enumeration drift and making integration tests actually gate releases for the first time.

## Why This Change Exists

The crap4j work (AIML-1227) exposed a structural problem: adding a new verification step to Gradle meant hunting down every place that enumerated task names and updating each one independently. The invokers had already drifted from each other. PIT mutation testing ran on PR CI but not release CI. The release workflow called `integrationTest` but never set credentials, so it went green having run zero tests. The repo's own testing standards forbid silent skips, and the build itself was the violator.

The pre-push hook only checked changed-file coverage, not the full gate, so a developer who skipped `make check-test` before pushing could land code that failed CI. The Makefile had grown to seven overlapping targets (`check`, `test`, `coverage`, `test-coverage`, `check-test`, `mutation`, `verify`) that each defined their own version of "verified," and none of them matched what CI actually ran.

## The Big Picture

```mermaid
flowchart LR
    subgraph "Before: enumerated task lists"
        M1["make check-test<br/>(4 sub-makes)"] --> G1["spotlessCheck<br/>checkstyleMain/Test<br/>test<br/>jacocoVerify<br/>pitest"]
        CI1["build.yml"] --> G2["spotlessCheck<br/>checkstyleMain/Test<br/>jacocoVerify<br/>bootJar"]
        CI1 --> G3["pitest (PR only)"]
        REL1["gradle-release.yml"] --> G4["spotlessCheck<br/>check<br/>integrationTest<br/>(no creds)"]
    end

    subgraph "After: lifecycle tasks"
        M2["make check"] --> GC["gradlew check<br/>(all repo-local verification)"]
        M3["make verify"] --> GV["gradlew verify<br/>(check + ITs w/ creds)"]
        CI2["build.yml"] --> GC
        REL2["gradle-release.yml"] --> GV
        HOOK["pre-push"] --> GC
    end
```

Key decisions:

- **PIT inside `check`**, not carved out as a slow-path extra. A full PIT run is 38s locally and cached by Gradle up-to-date checks when core is unchanged. Carving it out recreates the enumeration disease for one task.
- **`make check` is the full gate, not the fast loop.** A make target named `check` that does less than `gradlew check` is the ambiguity this decision removes. The fast inner-loop path gets its own name (`lint`).
- **`verify` fails loudly without credentials.** A gate that can pass on zero integration tests is not a gate. Bare `integrationTest` keeps skip behavior for forks and credential-less checkouts.
- **`verify` in no hook.** Live-API tests are minutes long, network-dependent, and occasionally flaky for reasons unrelated to the change. Hooks that fail spuriously teach people to bypass hooks.
- **Gradle sources `.env.integration-test` itself.** Real environment variables win over file values, so CI secrets and one-off shells override without editing the file. No `source` step needed.

## Review Guide

### 1. ADRs and glossary — **Focus**
The decision records capture the full rationale. ADR 0003 covers the check/verify standardization; ADR 0004 covers the integration-test fail-loud policy. CONTEXT.md gains glossary entries for Check, Verify, and Lint so the ubiquitous language is pinned.

- `docs/adr/0003-standardize-on-gradle-check-and-verify-lifecycles.md` (new)
- `docs/adr/0004-integration-tests-fail-loudly-and-gate-releases.md` (new)
- `CONTEXT.md` — new Build verification section

### 2. Gradle lifecycle wiring — **Focus**
The core of the change: `crap4j { attachToCheck = true }` in root `build.gradle`, PIT wired into `check` in `contrast-mcp-core/build.gradle`, and the new root `verify` task plus credential sourcing/guarding in `contrast-mcp-stdio-app/build.gradle`.

- `build.gradle` — crap4j attachToCheck, new `verify` task
- `contrast-mcp-core/build.gradle` — `check.dependsOn pitest`
- `contrast-mcp-stdio-app/build.gradle` — `.env.integration-test` parser, `resolveIntegrationTestCredentials`, `requireIntegrationTestCredentials` task

### 3. CI workflows — **Focus**
PR CI collapses its enumerated task list to `gradlew check` plus `bootJar`. The separate PIT step is removed (folded into `check`). Release CI switches from the drifted list to `gradlew clean verify bootJar` with the five `CONTRAST_*` secrets wired in as environment variables.

- `.github/workflows/build.yml` — simplified to `check` + `bootJar`
- `.github/workflows/gradle-release.yml` — `verify` with credential env vars

### 4. Makefile — **Focus**
Seven overlapping targets collapse to thin lifecycle wrappers. `check` and `verify` each delegate to one Gradle lifecycle, with `spotlessApply` prepended and `coverageSummary` appended. `lint` is the new fast inner loop (format + checkstyle). Deleted: `check-test`, `test`, `test-coverage`, `coverage`, `mutation`.

- `Makefile`

### 5. Pre-push hook — **Skim**
Gains `gradlew check` (up-to-date checking makes it a few seconds when `make check` already ran). `SKIP_PUSH_GATE=1` replaces the old `SKIP_COVERAGE_HOOK` as the umbrella bypass.

- `scripts/git-hooks/pre-push`
- `scripts/git-hooks/README.md`

<details>
<summary>Documentation updates (10 files)</summary>

References to the old targets (`make check-test`, `make test`, `make coverage`, `make mutation`) updated throughout:
- `CLAUDE.md` — build commands, coverage, mutation testing, integration tests, testing requirements
- `REPO-CONTEXT.md` — quick-reference commands
- `CONTRIBUTING.md` — common commands, test coverage section
- `INTEGRATION_TESTS.md` — simplified setup (no `source` step), reordered commands, updated behavior notes
- `RELEASING.md` — validation gate description
- `.claude/commands/improve-harness.md` — `check-test` → `check`
- `.claude/settings.json` — allowlist entries
- `.claude/skills/archunit/SKILL.md` — `check-test` → `check`
- `.claude/skills/bead-workflow/SKILL.md` — `check-test` → `check`
- `.claude/skills/test-mcp-server/SKILL.md` — `check-test` → `check`

</details>

## Testing

Verified locally:
- `make check` passes (1196 tests, includes static analysis, coverage floors, CRAP gate, PIT mutation testing)
- `make verify` passes (1430 tests, including 234 live integration tests against eval org, 112s total)
- `requireIntegrationTestCredentials` fails loudly when credentials are removed (tested by unsetting env vars)
- Gradle `--dry-run` on `check` confirms `crapCheck` and `pitest` are in the task graph
- Pre-push hook ran `gradlew check` successfully on push (visible in push output above)

## Risks / Rollout / Follow-ups

- **Main-branch CI gains ~3 minutes** from PIT (previously PR-only). Accepted as the cost of consistent gating.
- **Release CI credentials** are initially a maintainer's personal eval-org credentials. AIML-1408 (high priority, blocked on this PR) migrates them to a dedicated service account.
- **Pre-push hook is slower** on first push (~60s cold when core changed, ~6s warm). `SKIP_PUSH_GATE=1` is the emergency bypass.


[AIML-1407]: https://contrast.atlassian.net/browse/AIML-1407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
