### PR TITLE
AIML-1410 Pilot property-based testing with jqwik

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ todos/
 .bv/
 
 .orca/
+
+# jqwik failure-recording database
+.jqwik-database

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,6 +347,15 @@ When creating or modifying MCP tools:
 - Manual loop for sort/filter verification (e.g., `for (int i=1; i<list.size(); i++)`) — use `isSortedAccordingTo` / `allSatisfy` for clearer failure messages
 - `_populate_*` or `_return_*` test using `isNotNull()` on the claimed field — asserts shape, not content; use `isNotBlank` / `isNotEmpty` / content-level check
 
+**Property-based testing (jqwik, ADR 0005):**
+- Naming: `XxxPropertyTest` alongside existing `XxxTest`, same package. Never `*IT` / `*IntegrationTest` suffixes.
+- Each `@Property` method tests one invariant that holds for all inputs (e.g. "output is always in [min, max]"). Use `@Provide` methods for custom generators.
+- Default tries budget is 100 (`junit-platform.properties`). Keep it modest because PIT reruns tests per mutant.
+- Use `Assume.that(...)` to narrow generators to documented preconditions (e.g. `min <= max`), not to skip inconvenient failures.
+- A failing property is a bug until proven otherwise. Fix the bug, or narrow the generator to documented bounds with a WHY comment and a filed bead.
+- Property tests complement example-based tests. Do not replace existing `XxxTest` classes.
+- `.jqwik-database` is gitignored (jqwik writes a local failure-recording database).
+
 ### Security Considerations
 
 This codebase handles sensitive vulnerability data. The README contains critical warnings about data privacy when using with AI models. Never expose Contrast credentials or vulnerability data to untrusted AI services.

--- a/contrast-mcp-core/build.gradle
+++ b/contrast-mcp-core/build.gradle
@@ -180,7 +180,7 @@ pitest {
     junit5PluginVersion = pitestJunit5PluginVersion
     targetClasses = ['com.contrast.labs.ai.mcp.contrast.*']
     targetTests = ['com.contrast.labs.ai.mcp.contrast.*']
-    testStrengthThreshold = 92
+    testStrengthThreshold = 93
     outputFormats = ['HTML', 'XML']
     timestampedReports = false
     threads = Runtime.runtime.availableProcessors()

--- a/contrast-mcp-core/build.gradle
+++ b/contrast-mcp-core/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'ch.qos.logback:logback-classic'
+    testImplementation "net.jqwik:jqwik:${jqwikVersion}"
 }
 
 def publicMavenReleaseRepositoryName = 'contrastPublicRelease'

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
@@ -66,7 +66,7 @@ public abstract class PaginatedTool<P extends ToolParams, R> extends BaseTool {
    * for tool-specific logic. This method is FINAL to enforce consistent processing.
    *
    * @param page requested page number (1-based), null defaults to 1
-   * @param pageSize requested page size, null defaults to 50
+   * @param pageSize requested page size, null defaults to 50 unless getMaxPageSize() is narrower
    * @param paramsSupplier lazy supplier of tool-specific parameters
    * @return paginated response with items or errors
    */

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParams.java
@@ -78,12 +78,18 @@ public record PaginationParams(
       actualSize = maxPageSize;
     }
 
+    // Cap page so (page-1)*pageSize never overflows int
+    int maxPage = Integer.MAX_VALUE / actualSize;
+    if (actualPage > maxPage) {
+      notices.add(
+          String.format(
+              "Page %d exceeds maximum %d for pageSize %d, capped",
+              actualPage, maxPage, actualSize));
+      actualPage = maxPage;
+    }
+
     return new PaginationParams(
-        actualPage,
-        actualSize,
-        (actualPage - 1) * actualSize, // 0-based offset
-        actualSize, // limit
-        List.copyOf(notices));
+        actualPage, actualSize, (actualPage - 1) * actualSize, actualSize, List.copyOf(notices));
   }
 
   /**

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParams.java
@@ -26,7 +26,7 @@ import java.util.List;
  * graceful degradation (soft failures only).
  *
  * @param page Validated 1-based page number (min: 1)
- * @param pageSize Validated page size (range: 1-100, default: 50)
+ * @param pageSize Validated page size (range: 1-maxPageSize, default: min(50, maxPageSize))
  * @param offset Calculated 0-based offset for SDK
  * @param limit Same as pageSize, for SDK clarity
  * @param notices Validation notices (soft failures - execution continues with corrected values)
@@ -51,12 +51,13 @@ public record PaginationParams(
    * to acceptable defaults with notices.
    *
    * @param page Requested page number (1-based), null defaults to 1
-   * @param pageSize Requested page size, null defaults to 50
+   * @param pageSize Requested page size, null defaults to 50 unless maxPageSize is narrower
    * @param maxPageSize Tool-specific maximum page size (e.g., 50 for APIs with stricter limits)
    * @return PaginationParams with validated values and notices
    */
   public static PaginationParams of(Integer page, Integer pageSize, int maxPageSize) {
     List<String> notices = new ArrayList<>();
+    maxPageSize = Math.max(1, maxPageSize);
 
     // Soft failure: invalid page → clamp to 1
     int actualPage = page != null && page > 0 ? page : 1;
@@ -78,8 +79,9 @@ public record PaginationParams(
       actualSize = maxPageSize;
     }
 
-    // Cap page so (page-1)*pageSize never overflows int
-    int maxPage = Integer.MAX_VALUE / actualSize;
+    // Cap page so (page-1)*pageSize never overflows int.
+    // Use long to avoid +1 overflow when actualSize is 1.
+    int maxPage = (int) Math.min((long) Integer.MAX_VALUE / actualSize + 1L, Integer.MAX_VALUE);
     if (actualPage > maxPage) {
       notices.add(
           String.format(

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParams.java
@@ -65,11 +65,11 @@ public record PaginationParams(
     }
 
     // Soft failure: invalid pageSize → clamp to range with tool-specific max
-    int actualSize = pageSize != null && pageSize > 0 ? pageSize : DEFAULT_PAGE_SIZE;
+    int defaultSize = Math.min(DEFAULT_PAGE_SIZE, maxPageSize);
+    int actualSize = pageSize != null && pageSize > 0 ? pageSize : defaultSize;
     if (pageSize != null && pageSize < 1) {
-      notices.add(
-          String.format("Invalid pageSize %d, using default %d", pageSize, DEFAULT_PAGE_SIZE));
-      actualSize = DEFAULT_PAGE_SIZE;
+      notices.add(String.format("Invalid pageSize %d, using default %d", pageSize, defaultSize));
+      actualSize = defaultSize;
     } else if (pageSize != null && pageSize > maxPageSize) {
       notices.add(
           String.format(

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParamsPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParamsPropertyTest.java
@@ -1,0 +1,114 @@
+package com.contrast.labs.ai.mcp.contrast.tool.base;
+
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.DEFAULT_PAGE_SIZE;
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.MAX_PAGE_SIZE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.IntRange;
+import net.jqwik.api.constraints.StringLength;
+
+class CursorPaginationParamsPropertyTest {
+
+  @Property
+  void pageSize_should_always_be_in_valid_range(@ForAll String cursor, @ForAll Integer pageSize) {
+    var params = CursorPaginationParams.of(cursor, pageSize);
+
+    assertThat(params.pageSize()).isBetween(1, MAX_PAGE_SIZE);
+  }
+
+  @Property
+  void pageSize_should_respect_custom_max(
+      @ForAll String cursor,
+      @ForAll Integer pageSize,
+      @ForAll @IntRange(min = 1, max = MAX_PAGE_SIZE) int maxPageSize) {
+    var params = CursorPaginationParams.of(cursor, pageSize, maxPageSize);
+
+    assertThat(params.pageSize()).isBetween(1, maxPageSize);
+  }
+
+  @Property
+  void limit_should_always_equal_pageSize(@ForAll String cursor, @ForAll Integer pageSize) {
+    var params = CursorPaginationParams.of(cursor, pageSize);
+
+    assertThat(params.limit()).isEqualTo(params.pageSize());
+  }
+
+  @Property
+  void defaultSize_should_be_min_of_default_and_max(
+      @ForAll @IntRange(min = 1, max = MAX_PAGE_SIZE) int maxPageSize) {
+    var params = CursorPaginationParams.of(null, null, maxPageSize);
+    int expectedDefault = Math.min(DEFAULT_PAGE_SIZE, maxPageSize);
+
+    assertThat(params.pageSize()).isEqualTo(expectedDefault);
+  }
+
+  @Property
+  void blank_cursor_should_normalize_to_null(@ForAll @StringLength(max = 10) String whitespace) {
+    var blanked = whitespace.replaceAll("\\S", " ");
+    var params = CursorPaginationParams.of(blanked, null);
+
+    assertThat(params.cursor()).isNull();
+  }
+
+  @Property
+  void cursor_normalization_should_be_idempotent(@ForAll String cursor) {
+    var first = CursorPaginationParams.of(cursor, null);
+    var second = CursorPaginationParams.of(first.cursor(), null);
+
+    assertThat(second.cursor()).isEqualTo(first.cursor());
+  }
+
+  @Property
+  void cursorPresence_should_be_total(@ForAll String cursor, @ForAll Integer pageSize) {
+    var params = CursorPaginationParams.of(cursor, pageSize);
+    var presence = params.cursorPresence();
+
+    assertThat(presence).isIn("present", "absent");
+    if (params.cursor() != null) {
+      assertThat(presence).isEqualTo("present");
+    } else {
+      assertThat(presence).isEqualTo("absent");
+    }
+  }
+
+  @Property
+  void notices_should_be_empty_when_inputs_valid(
+      @ForAll @IntRange(min = 1, max = MAX_PAGE_SIZE) int pageSize) {
+    var params = CursorPaginationParams.of(null, pageSize);
+
+    assertThat(params.notices()).isEmpty();
+  }
+
+  @Property
+  void notices_should_be_nonempty_when_pageSize_below_one(
+      @ForAll @IntRange(min = Integer.MIN_VALUE, max = 0) int pageSize) {
+    var params = CursorPaginationParams.of(null, pageSize);
+
+    assertThat(params.notices()).isNotEmpty();
+  }
+
+  @Property
+  void notices_should_be_nonempty_when_pageSize_above_max(
+      @ForAll @IntRange(min = MAX_PAGE_SIZE + 1) int pageSize) {
+    var params = CursorPaginationParams.of(null, pageSize);
+
+    assertThat(params.notices()).isNotEmpty();
+    assertThat(params.pageSize()).isEqualTo(MAX_PAGE_SIZE);
+  }
+
+  @Property
+  void isValid_should_always_return_true(@ForAll String cursor, @ForAll Integer pageSize) {
+    assertThat(CursorPaginationParams.of(cursor, pageSize).isValid()).isTrue();
+  }
+
+  @Property
+  void notices_should_be_immutable(@ForAll String cursor, @ForAll Integer pageSize) {
+    var params = CursorPaginationParams.of(cursor, pageSize);
+
+    assertThatThrownBy(() -> params.notices().add("boom"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+}

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsPropertyTest.java
@@ -10,8 +10,6 @@ import net.jqwik.api.constraints.IntRange;
 
 class PaginationParamsPropertyTest {
 
-  private static final int SAFE_MAX_PAGE = 10_000;
-
   @Property
   void page_should_always_be_at_least_one(@ForAll Integer page, @ForAll Integer pageSize) {
     var params = PaginationParams.of(page, pageSize);
@@ -38,11 +36,11 @@ class PaginationParamsPropertyTest {
 
   @Property
   void offset_should_equal_page_minus_one_times_pageSize(
-      @ForAll @IntRange(min = 1, max = SAFE_MAX_PAGE) int page,
+      @ForAll @IntRange(min = 1) int page,
       @ForAll @IntRange(min = 1, max = MAX_PAGE_SIZE) int pageSize) {
     var params = PaginationParams.of(page, pageSize);
 
-    assertThat(params.offset()).isEqualTo((page - 1) * pageSize);
+    assertThat(params.offset()).isEqualTo((params.page() - 1) * params.pageSize());
   }
 
   @Property
@@ -54,7 +52,7 @@ class PaginationParamsPropertyTest {
 
   @Property
   void of_should_be_idempotent_with_no_extra_notices(
-      @ForAll @IntRange(min = 1, max = SAFE_MAX_PAGE) int page,
+      @ForAll @IntRange(min = 1, max = Integer.MAX_VALUE / MAX_PAGE_SIZE) int page,
       @ForAll @IntRange(min = 1, max = MAX_PAGE_SIZE) int pageSize) {
     var first = PaginationParams.of(page, pageSize);
     var second = PaginationParams.of(first.page(), first.pageSize());
@@ -67,7 +65,7 @@ class PaginationParamsPropertyTest {
 
   @Property
   void notices_should_be_empty_when_inputs_are_valid(
-      @ForAll @IntRange(min = 1, max = SAFE_MAX_PAGE) int page,
+      @ForAll @IntRange(min = 1, max = Integer.MAX_VALUE / MAX_PAGE_SIZE) int page,
       @ForAll @IntRange(min = 1, max = MAX_PAGE_SIZE) int pageSize) {
     var params = PaginationParams.of(page, pageSize);
 
@@ -99,6 +97,13 @@ class PaginationParamsPropertyTest {
 
     assertThat(params.notices()).isNotEmpty();
     assertThat(params.pageSize()).isEqualTo(MAX_PAGE_SIZE);
+  }
+
+  @Property
+  void offset_should_never_overflow(@ForAll @IntRange(min = 1) int page, @ForAll Integer pageSize) {
+    var params = PaginationParams.of(page, pageSize);
+
+    assertThat(params.offset()).isGreaterThanOrEqualTo(0);
   }
 
   @Property

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsPropertyTest.java
@@ -27,9 +27,9 @@ class PaginationParamsPropertyTest {
   }
 
   @Property
-  void pageSize_should_respect_custom_max_when_explicitly_provided(
+  void pageSize_should_respect_custom_max(
       @ForAll Integer page,
-      @ForAll @IntRange(min = 1) int pageSize,
+      @ForAll Integer pageSize,
       @ForAll @IntRange(min = 1, max = MAX_PAGE_SIZE) int maxPageSize) {
     var params = PaginationParams.of(page, pageSize, maxPageSize);
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsPropertyTest.java
@@ -1,0 +1,116 @@
+package com.contrast.labs.ai.mcp.contrast.tool.base;
+
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.DEFAULT_PAGE_SIZE;
+import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.MAX_PAGE_SIZE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.IntRange;
+
+class PaginationParamsPropertyTest {
+
+  private static final int SAFE_MAX_PAGE = 10_000;
+
+  @Property
+  void page_should_always_be_at_least_one(@ForAll Integer page, @ForAll Integer pageSize) {
+    var params = PaginationParams.of(page, pageSize);
+
+    assertThat(params.page()).isGreaterThanOrEqualTo(1);
+  }
+
+  @Property
+  void pageSize_should_always_be_in_valid_range(@ForAll Integer page, @ForAll Integer pageSize) {
+    var params = PaginationParams.of(page, pageSize);
+
+    assertThat(params.pageSize()).isBetween(1, MAX_PAGE_SIZE);
+  }
+
+  @Property
+  void pageSize_should_respect_custom_max_when_explicitly_provided(
+      @ForAll Integer page,
+      @ForAll @IntRange(min = 1) int pageSize,
+      @ForAll @IntRange(min = 1, max = MAX_PAGE_SIZE) int maxPageSize) {
+    var params = PaginationParams.of(page, pageSize, maxPageSize);
+
+    assertThat(params.pageSize()).isBetween(1, maxPageSize);
+  }
+
+  @Property
+  void offset_should_equal_page_minus_one_times_pageSize(
+      @ForAll @IntRange(min = 1, max = SAFE_MAX_PAGE) int page,
+      @ForAll @IntRange(min = 1, max = MAX_PAGE_SIZE) int pageSize) {
+    var params = PaginationParams.of(page, pageSize);
+
+    assertThat(params.offset()).isEqualTo((page - 1) * pageSize);
+  }
+
+  @Property
+  void limit_should_always_equal_pageSize(@ForAll Integer page, @ForAll Integer pageSize) {
+    var params = PaginationParams.of(page, pageSize);
+
+    assertThat(params.limit()).isEqualTo(params.pageSize());
+  }
+
+  @Property
+  void of_should_be_idempotent_with_no_extra_notices(
+      @ForAll @IntRange(min = 1, max = SAFE_MAX_PAGE) int page,
+      @ForAll @IntRange(min = 1, max = MAX_PAGE_SIZE) int pageSize) {
+    var first = PaginationParams.of(page, pageSize);
+    var second = PaginationParams.of(first.page(), first.pageSize());
+
+    assertThat(second.page()).isEqualTo(first.page());
+    assertThat(second.pageSize()).isEqualTo(first.pageSize());
+    assertThat(second.offset()).isEqualTo(first.offset());
+    assertThat(second.notices()).isEmpty();
+  }
+
+  @Property
+  void notices_should_be_empty_when_inputs_are_valid(
+      @ForAll @IntRange(min = 1, max = SAFE_MAX_PAGE) int page,
+      @ForAll @IntRange(min = 1, max = MAX_PAGE_SIZE) int pageSize) {
+    var params = PaginationParams.of(page, pageSize);
+
+    assertThat(params.notices()).isEmpty();
+  }
+
+  @Property
+  void notices_should_be_nonempty_when_page_corrected(
+      @ForAll @IntRange(min = Integer.MIN_VALUE, max = 0) int page) {
+    var params = PaginationParams.of(page, null);
+
+    assertThat(params.notices()).isNotEmpty();
+    assertThat(params.page()).isEqualTo(1);
+  }
+
+  @Property
+  void notices_should_be_nonempty_when_pageSize_below_one(
+      @ForAll @IntRange(min = Integer.MIN_VALUE, max = 0) int pageSize) {
+    var params = PaginationParams.of(null, pageSize);
+
+    assertThat(params.notices()).isNotEmpty();
+    assertThat(params.pageSize()).isEqualTo(DEFAULT_PAGE_SIZE);
+  }
+
+  @Property
+  void notices_should_be_nonempty_when_pageSize_above_max(
+      @ForAll @IntRange(min = MAX_PAGE_SIZE + 1) int pageSize) {
+    var params = PaginationParams.of(null, pageSize);
+
+    assertThat(params.notices()).isNotEmpty();
+    assertThat(params.pageSize()).isEqualTo(MAX_PAGE_SIZE);
+  }
+
+  @Property
+  void isValid_should_always_return_true(@ForAll Integer page, @ForAll Integer pageSize) {
+    assertThat(PaginationParams.of(page, pageSize).isValid()).isTrue();
+  }
+
+  @Property
+  void notices_should_be_immutable(@ForAll Integer page, @ForAll Integer pageSize) {
+    var params = PaginationParams.of(page, pageSize);
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> params.notices().add("boom"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+}

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsPropertyTest.java
@@ -3,6 +3,7 @@ package com.contrast.labs.ai.mcp.contrast.tool.base;
 import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.DEFAULT_PAGE_SIZE;
 import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.MAX_PAGE_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
@@ -115,7 +116,7 @@ class PaginationParamsPropertyTest {
   void notices_should_be_immutable(@ForAll Integer page, @ForAll Integer pageSize) {
     var params = PaginationParams.of(page, pageSize);
 
-    org.assertj.core.api.Assertions.assertThatThrownBy(() -> params.notices().add("boom"))
+    assertThatThrownBy(() -> params.notices().add("boom"))
         .isInstanceOf(UnsupportedOperationException.class);
   }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsTest.java
@@ -204,6 +204,15 @@ class PaginationParamsTest {
   }
 
   @Test
+  void testPageCappedToPreventOffsetOverflow() {
+    var params = PaginationParams.of(Integer.MAX_VALUE, 100);
+
+    assertThat(params.page()).isEqualTo(Integer.MAX_VALUE / 100);
+    assertThat(params.offset()).isGreaterThanOrEqualTo(0);
+    assertThat(params.notices()).anyMatch(n -> n.contains("exceeds maximum"));
+  }
+
+  @Test
   void testCustomMaxPageSizeBelowDefaultClampsDefault() {
     var params = PaginationParams.of(1, null, 25);
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsTest.java
@@ -207,7 +207,7 @@ class PaginationParamsTest {
   void testPageCappedToPreventOffsetOverflow() {
     var params = PaginationParams.of(Integer.MAX_VALUE, 100);
 
-    assertThat(params.page()).isEqualTo(Integer.MAX_VALUE / 100);
+    assertThat(params.page()).isEqualTo(Integer.MAX_VALUE / 100 + 1);
     assertThat(params.offset()).isGreaterThanOrEqualTo(0);
     assertThat(params.notices()).anyMatch(n -> n.contains("exceeds maximum"));
   }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsTest.java
@@ -202,4 +202,23 @@ class PaginationParamsTest {
     assertThat(params.pageSize()).isEqualTo(50);
     assertThat(params.notices()).isEmpty();
   }
+
+  @Test
+  void testCustomMaxPageSizeBelowDefaultClampsDefault() {
+    var params = PaginationParams.of(1, null, 25);
+
+    assertThat(params.page()).isEqualTo(1);
+    assertThat(params.pageSize()).isEqualTo(25);
+    assertThat(params.notices()).isEmpty();
+  }
+
+  @Test
+  void testCustomMaxPageSizeBelowDefaultClampsInvalidPageSize() {
+    var params = PaginationParams.of(1, -1, 25);
+
+    assertThat(params.page()).isEqualTo(1);
+    assertThat(params.pageSize()).isEqualTo(25);
+    assertThat(params.notices()).hasSize(1);
+    assertThat(params.notices().getFirst()).contains("Invalid pageSize -1, using default 25");
+  }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/EnumSetSpecPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/EnumSetSpecPropertyTest.java
@@ -1,0 +1,127 @@
+package com.contrast.labs.ai.mcp.contrast.tool.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+class EnumSetSpecPropertyTest {
+
+  enum Color {
+    RED,
+    GREEN,
+    BLUE,
+    YELLOW
+  }
+
+  @Property
+  void round_trip_should_preserve_identity(@ForAll("colorSubset") Set<Color> subset) {
+    var csv = subset.stream().map(Enum::name).collect(Collectors.joining(","));
+    var ctx = new ToolValidationContext();
+    var result = ctx.enumSetParam(csv, Color.class, "colors").get();
+
+    assertThat(result).containsExactlyInAnyOrderElementsOf(subset);
+    assertThat(ctx.isValid()).isTrue();
+  }
+
+  @Property
+  void case_insensitive_parsing(@ForAll("colorInRandomCase") String csv) {
+    var ctx = new ToolValidationContext();
+    var result = ctx.enumSetParam(csv, Color.class, "colors").get();
+
+    assertThat(result).isNotNull().isNotEmpty();
+    assertThat(ctx.isValid()).isTrue();
+  }
+
+  @Property
+  void unknown_tokens_should_produce_error_and_null(@ForAll("unknownColorToken") String token) {
+    var ctx = new ToolValidationContext();
+    var result = ctx.enumSetParam(token, Color.class, "colors").get();
+
+    assertThat(ctx.isValid()).isFalse();
+    assertThat(result).isNull();
+    assertThat(ctx.errors()).isNotEmpty();
+    assertThat(ctx.errors().getFirst())
+        .contains("Invalid colors")
+        .contains("RED, GREEN, BLUE, YELLOW");
+  }
+
+  @Property
+  void null_input_without_default_should_return_null() {
+    var ctx = new ToolValidationContext();
+    var result = ctx.enumSetParam(null, Color.class, "colors").get();
+
+    assertThat(result).isNull();
+    assertThat(ctx.isValid()).isTrue();
+  }
+
+  @Property
+  void null_input_with_default_should_return_default(@ForAll("colorSubset") Set<Color> subset) {
+    var defaultSet = EnumSet.copyOf(subset);
+    var ctx = new ToolValidationContext();
+    var result =
+        ctx.enumSetParam(null, Color.class, "colors").defaultTo(defaultSet, "using defaults").get();
+
+    assertThat(result).containsExactlyInAnyOrderElementsOf(subset);
+    assertThat(ctx.notices()).containsExactly("using defaults");
+  }
+
+  @Property
+  void deduplication_should_produce_set_semantics(@ForAll("colorSubset") Set<Color> subset) {
+    var duplicated =
+        subset.stream()
+            .flatMap(c -> java.util.stream.Stream.of(c.name(), c.name()))
+            .collect(Collectors.joining(","));
+    var ctx = new ToolValidationContext();
+    var result = ctx.enumSetParam(duplicated, Color.class, "colors").get();
+
+    assertThat(result).containsExactlyInAnyOrderElementsOf(subset);
+  }
+
+  @Property
+  void blank_input_without_default_should_return_null(@ForAll("blankString") String blank) {
+    var ctx = new ToolValidationContext();
+    var result = ctx.enumSetParam(blank, Color.class, "colors").get();
+
+    assertThat(result).isNull();
+    assertThat(ctx.isValid()).isTrue();
+  }
+
+  @Provide
+  Arbitrary<Set<Color>> colorSubset() {
+    return Arbitraries.of(Color.class).set().ofMinSize(1);
+  }
+
+  @Provide
+  Arbitrary<String> colorInRandomCase() {
+    return Arbitraries.of(Color.class)
+        .map(
+            c -> {
+              var name = c.name();
+              var sb = new StringBuilder();
+              for (int i = 0; i < name.length(); i++) {
+                sb.append(
+                    i % 2 == 0
+                        ? Character.toLowerCase(name.charAt(i))
+                        : Character.toUpperCase(name.charAt(i)));
+              }
+              return sb.toString();
+            });
+  }
+
+  @Provide
+  Arbitrary<String> unknownColorToken() {
+    return Arbitraries.of("PURPLE", "orange", "PINK", "Magenta");
+  }
+
+  @Provide
+  Arbitrary<String> blankString() {
+    return Arbitraries.of("", "   ", " \t ");
+  }
+}

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/EnumSetSpecPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/EnumSetSpecPropertyTest.java
@@ -31,11 +31,12 @@ class EnumSetSpecPropertyTest {
   }
 
   @Property
-  void case_insensitive_parsing(@ForAll("colorInRandomCase") String csv) {
+  void parsing_should_be_case_insensitive(@ForAll("colorInRandomCase") String csv) {
     var ctx = new ToolValidationContext();
     var result = ctx.enumSetParam(csv, Color.class, "colors").get();
 
-    assertThat(result).isNotNull().isNotEmpty();
+    assertThat(result).isNotNull().hasSize(1);
+    assertThat(result.iterator().next().name()).isEqualToIgnoringCase(csv);
     assertThat(ctx.isValid()).isTrue();
   }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/IntSpecPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/IntSpecPropertyTest.java
@@ -1,0 +1,101 @@
+package com.contrast.labs.ai.mcp.contrast.tool.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import net.jqwik.api.Assume;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.IntRange;
+
+class IntSpecPropertyTest {
+
+  @Property
+  void output_should_be_in_range_when_both_bounds_set(
+      @ForAll int value,
+      @ForAll @IntRange(min = -1000, max = 1000) int min,
+      @ForAll @IntRange(min = -1000, max = 1000) int max) {
+    Assume.that(min <= max);
+    var ctx = new ToolValidationContext();
+    var result = ctx.intParam(value, "x").range(min, max).get();
+
+    assertThat(result).isBetween(min, max);
+  }
+
+  @Property
+  void notice_count_should_be_zero_or_one(
+      @ForAll Integer value,
+      @ForAll @IntRange(min = -1000, max = 1000) int min,
+      @ForAll @IntRange(min = -1000, max = 1000) int max) {
+    Assume.that(min <= max);
+    var ctx = new ToolValidationContext();
+    ctx.intParam(value, "x").range(min, max).get();
+
+    assertThat(ctx.notices()).hasSizeLessThanOrEqualTo(1);
+  }
+
+  @Property
+  void no_notice_when_value_in_range(@ForAll @IntRange(min = 1, max = 100) int value) {
+    var ctx = new ToolValidationContext();
+    ctx.intParam(value, "x").range(1, 100).get();
+
+    assertThat(ctx.notices()).isEmpty();
+  }
+
+  @Property
+  void notice_emitted_when_value_below_min(
+      @ForAll @IntRange(min = Integer.MIN_VALUE, max = 0) int value) {
+    var ctx = new ToolValidationContext();
+    ctx.intParam(value, "x").range(1, 100).get();
+
+    assertThat(ctx.notices()).hasSize(1);
+    assertThat(ctx.notices().getFirst()).contains("clamped");
+  }
+
+  @Property
+  void notice_emitted_when_value_above_max(@ForAll @IntRange(min = 101) int value) {
+    var ctx = new ToolValidationContext();
+    ctx.intParam(value, "x").range(1, 100).get();
+
+    assertThat(ctx.notices()).hasSize(1);
+    assertThat(ctx.notices().getFirst()).contains("clamped");
+  }
+
+  @Property
+  void default_used_when_null(@ForAll int defaultVal) {
+    var ctx = new ToolValidationContext();
+    var result = ctx.intParam(null, "x").defaultTo(defaultVal, "fallback").get();
+
+    assertThat(result).isEqualTo(defaultVal);
+    assertThat(ctx.notices()).containsExactly("fallback");
+  }
+
+  @Property
+  void null_when_no_value_and_no_default() {
+    var ctx = new ToolValidationContext();
+    var result = ctx.intParam(null, "x").get();
+
+    assertThat(result).isNull();
+    assertThat(ctx.notices()).isEmpty();
+  }
+
+  @Property
+  void value_returned_unchanged_when_no_range(@ForAll int value) {
+    var ctx = new ToolValidationContext();
+    var result = ctx.intParam(value, "x").get();
+
+    assertThat(result).isEqualTo(value);
+    assertThat(ctx.notices()).isEmpty();
+  }
+
+  @Property
+  void no_errors_added_for_any_input(
+      @ForAll Integer value,
+      @ForAll @IntRange(min = -1000, max = 1000) int min,
+      @ForAll @IntRange(min = -1000, max = 1000) int max) {
+    Assume.that(min <= max);
+    var ctx = new ToolValidationContext();
+    ctx.intParam(value, "x").range(min, max).get();
+
+    assertThat(ctx.isValid()).isTrue();
+  }
+}

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/IntSpecPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/IntSpecPropertyTest.java
@@ -14,6 +14,8 @@ class IntSpecPropertyTest {
       @ForAll int value,
       @ForAll @IntRange(min = -1000, max = 1000) int min,
       @ForAll @IntRange(min = -1000, max = 1000) int max) {
+    // min <= max is a caller precondition: IntSpec.range() does not define behavior
+    // for inverted bounds. See bead for the inverted-bounds edge case.
     Assume.that(min <= max);
     var ctx = new ToolValidationContext();
     var result = ctx.intParam(value, "x").range(min, max).get();
@@ -26,7 +28,7 @@ class IntSpecPropertyTest {
       @ForAll Integer value,
       @ForAll @IntRange(min = -1000, max = 1000) int min,
       @ForAll @IntRange(min = -1000, max = 1000) int max) {
-    Assume.that(min <= max);
+    Assume.that(min <= max); // see output_should_be_in_range WHY comment
     var ctx = new ToolValidationContext();
     ctx.intParam(value, "x").range(min, max).get();
 
@@ -34,7 +36,7 @@ class IntSpecPropertyTest {
   }
 
   @Property
-  void no_notice_when_value_in_range(@ForAll @IntRange(min = 1, max = 100) int value) {
+  void notice_should_be_empty_when_value_in_range(@ForAll @IntRange(min = 1, max = 100) int value) {
     var ctx = new ToolValidationContext();
     ctx.intParam(value, "x").range(1, 100).get();
 
@@ -42,7 +44,7 @@ class IntSpecPropertyTest {
   }
 
   @Property
-  void notice_emitted_when_value_below_min(
+  void notice_should_be_emitted_when_value_below_min(
       @ForAll @IntRange(min = Integer.MIN_VALUE, max = 0) int value) {
     var ctx = new ToolValidationContext();
     ctx.intParam(value, "x").range(1, 100).get();
@@ -52,7 +54,7 @@ class IntSpecPropertyTest {
   }
 
   @Property
-  void notice_emitted_when_value_above_max(@ForAll @IntRange(min = 101) int value) {
+  void notice_should_be_emitted_when_value_above_max(@ForAll @IntRange(min = 101) int value) {
     var ctx = new ToolValidationContext();
     ctx.intParam(value, "x").range(1, 100).get();
 
@@ -61,7 +63,7 @@ class IntSpecPropertyTest {
   }
 
   @Property
-  void default_used_when_null(@ForAll int defaultVal) {
+  void default_should_be_used_when_null(@ForAll int defaultVal) {
     var ctx = new ToolValidationContext();
     var result = ctx.intParam(null, "x").defaultTo(defaultVal, "fallback").get();
 
@@ -70,7 +72,7 @@ class IntSpecPropertyTest {
   }
 
   @Property
-  void null_when_no_value_and_no_default() {
+  void result_should_be_null_when_no_value_and_no_default() {
     var ctx = new ToolValidationContext();
     var result = ctx.intParam(null, "x").get();
 
@@ -79,7 +81,7 @@ class IntSpecPropertyTest {
   }
 
   @Property
-  void value_returned_unchanged_when_no_range(@ForAll int value) {
+  void value_should_be_returned_unchanged_when_no_range(@ForAll int value) {
     var ctx = new ToolValidationContext();
     var result = ctx.intParam(value, "x").get();
 
@@ -88,11 +90,11 @@ class IntSpecPropertyTest {
   }
 
   @Property
-  void no_errors_added_for_any_input(
+  void errors_should_be_empty_for_any_input(
       @ForAll Integer value,
       @ForAll @IntRange(min = -1000, max = 1000) int min,
       @ForAll @IntRange(min = -1000, max = 1000) int max) {
-    Assume.that(min <= max);
+    Assume.that(min <= max); // see output_should_be_in_range WHY comment
     var ctx = new ToolValidationContext();
     ctx.intParam(value, "x").range(min, max).get();
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringListSpecPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringListSpecPropertyTest.java
@@ -1,0 +1,133 @@
+package com.contrast.labs.ai.mcp.contrast.tool.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+class StringListSpecPropertyTest {
+
+  private static final Set<String> ALLOWED = Set.of("Reported", "Confirmed", "Fixed");
+
+  @Property
+  void output_should_be_subset_of_allowed_values(@ForAll("csvOfAllowed") String csv) {
+    var ctx = new ToolValidationContext();
+    var result = ctx.stringListParam(csv, "statuses").allowedValues(ALLOWED).get();
+
+    if (result != null) {
+      assertThat(result).allSatisfy(item -> assertThat(ALLOWED).contains(item));
+    }
+  }
+
+  @Property
+  void case_insensitive_matching_should_normalize_to_canonical(
+      @ForAll("allowedValueInRandomCase") String item) {
+    var ctx = new ToolValidationContext();
+    var result = ctx.stringListParam(item, "statuses").allowedValues(ALLOWED).get();
+
+    assertThat(result).isNotNull().hasSize(1);
+    assertThat(ALLOWED).contains(result.getFirst());
+  }
+
+  @Property
+  void unknown_tokens_should_produce_error_and_null_result(@ForAll("unknownToken") String token) {
+    var ctx = new ToolValidationContext();
+    var result = ctx.stringListParam(token, "statuses").allowedValues(ALLOWED).get();
+
+    assertThat(ctx.isValid()).isFalse();
+    assertThat(result).isNull();
+    assertThat(ctx.errors()).isNotEmpty();
+  }
+
+  @Property
+  void null_input_with_default_should_return_default() {
+    var defaultVal = List.of("Reported", "Confirmed");
+    var ctx = new ToolValidationContext();
+    var result =
+        ctx.stringListParam(null, "statuses")
+            .allowedValues(ALLOWED)
+            .defaultTo(defaultVal, "using defaults")
+            .get();
+
+    assertThat(result).isEqualTo(defaultVal);
+    assertThat(ctx.notices()).containsExactly("using defaults");
+  }
+
+  @Property
+  void null_input_without_default_should_return_null() {
+    var ctx = new ToolValidationContext();
+    var result = ctx.stringListParam(null, "statuses").get();
+
+    assertThat(result).isNull();
+    assertThat(ctx.isValid()).isTrue();
+  }
+
+  @Property
+  void normalization_should_be_idempotent(@ForAll("csvOfAllowed") String csv) {
+    var ctx1 = new ToolValidationContext();
+    var first = ctx1.stringListParam(csv, "s").allowedValues(ALLOWED).get();
+    if (first == null) return;
+
+    var recombined = String.join(",", first);
+    var ctx2 = new ToolValidationContext();
+    var second = ctx2.stringListParam(recombined, "s").allowedValues(ALLOWED).get();
+
+    assertThat(second).isEqualTo(first);
+  }
+
+  @Property
+  void toUpperCase_should_uppercase_all_items(@ForAll("asciiAlpha") String csv) {
+    var ctx = new ToolValidationContext();
+    var result = ctx.stringListParam(csv, "tags").toUpperCase().get();
+
+    if (result != null) {
+      assertThat(result).allSatisfy(item -> assertThat(item).isEqualTo(item.toUpperCase()));
+    }
+  }
+
+  @Provide
+  Arbitrary<String> csvOfAllowed() {
+    return Arbitraries.of(ALLOWED.toArray(String[]::new))
+        .list()
+        .ofMinSize(1)
+        .ofMaxSize(3)
+        .map(list -> String.join(",", list));
+  }
+
+  @Provide
+  Arbitrary<String> allowedValueInRandomCase() {
+    return Arbitraries.of(ALLOWED.toArray(String[]::new))
+        .map(
+            s -> {
+              var chars = s.toCharArray();
+              var sb = new StringBuilder();
+              for (int i = 0; i < chars.length; i++) {
+                sb.append(
+                    i % 2 == 0 ? Character.toUpperCase(chars[i]) : Character.toLowerCase(chars[i]));
+              }
+              return sb.toString();
+            });
+  }
+
+  @Provide
+  Arbitrary<String> unknownToken() {
+    return Arbitraries.of("INVALID", "Unknown", "bad", "NotAStatus", "PENDING");
+  }
+
+  @Provide
+  Arbitrary<String> asciiAlpha() {
+    return Arbitraries.strings()
+        .alpha()
+        .ofMinLength(1)
+        .ofMaxLength(5)
+        .list()
+        .ofMinSize(1)
+        .ofMaxSize(3)
+        .map(list -> String.join(",", list));
+  }
+}

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringListSpecPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringListSpecPropertyTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Set;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Assume;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
@@ -19,9 +20,8 @@ class StringListSpecPropertyTest {
     var ctx = new ToolValidationContext();
     var result = ctx.stringListParam(csv, "statuses").allowedValues(ALLOWED).get();
 
-    if (result != null) {
-      assertThat(result).allSatisfy(item -> assertThat(ALLOWED).contains(item));
-    }
+    assertThat(result).as("valid CSV input should parse successfully").isNotNull();
+    assertThat(result).allSatisfy(item -> assertThat(ALLOWED).contains(item));
   }
 
   @Property
@@ -71,7 +71,7 @@ class StringListSpecPropertyTest {
   void normalization_should_be_idempotent(@ForAll("csvOfAllowed") String csv) {
     var ctx1 = new ToolValidationContext();
     var first = ctx1.stringListParam(csv, "s").allowedValues(ALLOWED).get();
-    if (first == null) return;
+    Assume.that(first != null);
 
     var recombined = String.join(",", first);
     var ctx2 = new ToolValidationContext();
@@ -85,9 +85,8 @@ class StringListSpecPropertyTest {
     var ctx = new ToolValidationContext();
     var result = ctx.stringListParam(csv, "tags").toUpperCase().get();
 
-    if (result != null) {
-      assertThat(result).allSatisfy(item -> assertThat(item).isEqualTo(item.toUpperCase()));
-    }
+    assertThat(result).as("valid CSV input should parse successfully").isNotNull();
+    assertThat(result).allSatisfy(item -> assertThat(item).isEqualTo(item.toUpperCase()));
   }
 
   @Provide

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolSortParserPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolSortParserPropertyTest.java
@@ -1,0 +1,151 @@
+package com.contrast.labs.ai.mcp.contrast.tool.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.Set;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+class ToolSortParserPropertyTest {
+
+  private static final Map<String, String> FIELDS =
+      Map.of("severity", "severityValue", "title", "vulnTitle", "lastSeen", "last_time_seen");
+  private static final String DEFAULT_SORT = "severityValue";
+  private static final Set<String> WIRE_VALUES = Set.copyOf(FIELDS.values());
+
+  @Property
+  void valid_asc_sort_should_return_wire_name(@ForAll("validProperty") String property) {
+    var ctx = new ToolValidationContext();
+    var sort = property + ",ASC";
+    var result = ToolSortParser.parse(ctx, sort, FIELDS, DEFAULT_SORT);
+
+    assertThat(result).isIn(WIRE_VALUES);
+    assertThat(result).isEqualTo(FIELDS.get(property));
+    assertThat(ctx.isValid()).isTrue();
+  }
+
+  @Property
+  void valid_desc_sort_should_return_prefixed_wire_name(@ForAll("validProperty") String property) {
+    var ctx = new ToolValidationContext();
+    var sort = property + ",DESC";
+    var result = ToolSortParser.parse(ctx, sort, FIELDS, DEFAULT_SORT);
+
+    assertThat(result).startsWith("-");
+    assertThat(result.substring(1)).isIn(WIRE_VALUES);
+    assertThat(ctx.isValid()).isTrue();
+  }
+
+  @Property
+  void case_insensitive_on_property(@ForAll("validPropertyRandomCase") String property) {
+    var ctx = new ToolValidationContext();
+    var sort = property + ",ASC";
+    var result = ToolSortParser.parse(ctx, sort, FIELDS, DEFAULT_SORT);
+
+    assertThat(result).isNotNull().isIn(WIRE_VALUES);
+    assertThat(ctx.isValid()).isTrue();
+  }
+
+  @Property
+  void case_insensitive_on_direction(
+      @ForAll("validProperty") String property, @ForAll("directionCase") String direction) {
+    var ctx = new ToolValidationContext();
+    var sort = property + "," + direction;
+    var result = ToolSortParser.parse(ctx, sort, FIELDS, DEFAULT_SORT);
+
+    assertThat(result).isNotNull();
+    assertThat(ctx.isValid()).isTrue();
+  }
+
+  @Property
+  void malformed_input_should_return_default_sort(@ForAll("malformedSort") String sort) {
+    var ctx = new ToolValidationContext();
+    var result = ToolSortParser.parse(ctx, sort, FIELDS, DEFAULT_SORT);
+
+    assertThat(result).isEqualTo(DEFAULT_SORT);
+  }
+
+  @Property
+  void null_or_blank_input_should_return_default_sort(@ForAll("blankOrNull") String sort) {
+    var ctx = new ToolValidationContext();
+    var result = ToolSortParser.parse(ctx, sort, FIELDS, DEFAULT_SORT);
+
+    assertThat(result).isEqualTo(DEFAULT_SORT);
+    assertThat(ctx.isValid()).isTrue();
+  }
+
+  @Property
+  void invalid_property_should_add_error(@ForAll("invalidProperty") String property) {
+    var ctx = new ToolValidationContext();
+    var sort = property + ",ASC";
+    ToolSortParser.parse(ctx, sort, FIELDS, DEFAULT_SORT);
+
+    assertThat(ctx.isValid()).isFalse();
+    assertThat(ctx.errors()).isNotEmpty();
+    assertThat(ctx.errors().getFirst()).contains("Invalid sort");
+  }
+
+  @Property
+  void output_wire_name_should_always_come_from_fields_values(
+      @ForAll("validSortString") String sort) {
+    var ctx = new ToolValidationContext();
+    var result = ToolSortParser.parse(ctx, sort, FIELDS, DEFAULT_SORT);
+
+    if (ctx.isValid() && result != null) {
+      var bare = result.startsWith("-") ? result.substring(1) : result;
+      assertThat(bare).isIn(WIRE_VALUES);
+    }
+  }
+
+  @Provide
+  Arbitrary<String> validProperty() {
+    return Arbitraries.of(FIELDS.keySet().toArray(String[]::new));
+  }
+
+  @Provide
+  Arbitrary<String> validPropertyRandomCase() {
+    return validProperty()
+        .map(
+            s -> {
+              var sb = new StringBuilder();
+              for (int i = 0; i < s.length(); i++) {
+                sb.append(
+                    i % 2 == 0
+                        ? Character.toUpperCase(s.charAt(i))
+                        : Character.toLowerCase(s.charAt(i)));
+              }
+              return sb.toString();
+            });
+  }
+
+  @Provide
+  Arbitrary<String> directionCase() {
+    return Arbitraries.of("asc", "ASC", "Asc", "desc", "DESC", "Desc", "aSc", "dEsC");
+  }
+
+  @Provide
+  Arbitrary<String> malformedSort() {
+    return Arbitraries.of(
+        "severity", "severity,ASC,extra", ",ASC", "severity,INVALID", ",,", "unknown,ASC");
+  }
+
+  @Provide
+  Arbitrary<String> blankOrNull() {
+    return Arbitraries.of(null, "", "   ", " \t ");
+  }
+
+  @Provide
+  Arbitrary<String> invalidProperty() {
+    return Arbitraries.of("unknown", "SEVERITY_WRONG", "foobar", "name");
+  }
+
+  @Provide
+  Arbitrary<String> validSortString() {
+    return Combinators.combine(validProperty(), Arbitraries.of("ASC", "DESC"))
+        .as((prop, dir) -> prop + "," + dir);
+  }
+}

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolSortParserPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolSortParserPropertyTest.java
@@ -41,7 +41,7 @@ class ToolSortParserPropertyTest {
   }
 
   @Property
-  void case_insensitive_on_property(@ForAll("validPropertyRandomCase") String property) {
+  void property_should_be_case_insensitive(@ForAll("validPropertyRandomCase") String property) {
     var ctx = new ToolValidationContext();
     var sort = property + ",ASC";
     var result = ToolSortParser.parse(ctx, sort, FIELDS, DEFAULT_SORT);
@@ -51,7 +51,7 @@ class ToolSortParserPropertyTest {
   }
 
   @Property
-  void case_insensitive_on_direction(
+  void direction_should_be_case_insensitive(
       @ForAll("validProperty") String property, @ForAll("directionCase") String direction) {
     var ctx = new ToolValidationContext();
     var sort = property + "," + direction;
@@ -67,6 +67,8 @@ class ToolSortParserPropertyTest {
     var result = ToolSortParser.parse(ctx, sort, FIELDS, DEFAULT_SORT);
 
     assertThat(result).isEqualTo(DEFAULT_SORT);
+    assertThat(ctx.isValid()).isFalse();
+    assertThat(ctx.errors()).isNotEmpty();
   }
 
   @Property

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContextPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContextPropertyTest.java
@@ -1,0 +1,169 @@
+package com.contrast.labs.ai.mcp.contrast.tool.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.UUID;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.constraints.IntRange;
+
+class ToolValidationContextPropertyTest {
+
+  @Property
+  void isValid_should_be_true_iff_errors_empty(
+      @ForAll @IntRange(min = 0, max = 5) int errorCount,
+      @ForAll @IntRange(min = 0, max = 5) int noticeCount) {
+    var ctx = new ToolValidationContext();
+    for (int i = 0; i < errorCount; i++) {
+      ctx.addError("error-" + i);
+    }
+    for (int i = 0; i < noticeCount; i++) {
+      ctx.addNotice("notice-" + i);
+    }
+
+    assertThat(ctx.isValid()).isEqualTo(errorCount == 0);
+  }
+
+  @Property
+  void errors_should_preserve_insertion_order(@ForAll @IntRange(min = 1, max = 10) int count) {
+    var ctx = new ToolValidationContext();
+    var expected = new ArrayList<String>();
+    for (int i = 0; i < count; i++) {
+      var msg = "error-" + i;
+      ctx.addError(msg);
+      expected.add(msg);
+    }
+
+    assertThat(ctx.errors()).containsExactlyElementsOf(expected);
+  }
+
+  @Property
+  void notices_should_preserve_insertion_order(@ForAll @IntRange(min = 1, max = 10) int count) {
+    var ctx = new ToolValidationContext();
+    var expected = new ArrayList<String>();
+    for (int i = 0; i < count; i++) {
+      var msg = "notice-" + i;
+      ctx.addNotice(msg);
+      expected.add(msg);
+    }
+
+    assertThat(ctx.notices()).containsExactlyElementsOf(expected);
+  }
+
+  @Property
+  void requireUuid_should_accept_uuid_toString(@ForAll("randomUuid") String uuid) {
+    var ctx = new ToolValidationContext();
+    ctx.requireUuid(uuid, "id");
+
+    assertThat(ctx.isValid()).isTrue();
+    assertThat(ctx.errors()).isEmpty();
+  }
+
+  @Property
+  void requireUuid_should_reject_non_uuid(@ForAll("nonUuid") String value) {
+    var ctx = new ToolValidationContext();
+    ctx.requireUuid(value, "id");
+
+    assertThat(ctx.isValid()).isFalse();
+    assertThat(ctx.errors()).hasSize(1);
+  }
+
+  @Property
+  void requireUuid_should_reject_blank(@ForAll("blankString") String value) {
+    var ctx = new ToolValidationContext();
+    ctx.requireUuid(value, "id");
+
+    assertThat(ctx.isValid()).isFalse();
+    assertThat(ctx.errors()).hasSize(1);
+    assertThat(ctx.errors().getFirst()).contains("is required");
+  }
+
+  @Property
+  void errors_list_should_be_immutable(@ForAll @IntRange(min = 0, max = 3) int count) {
+    var ctx = new ToolValidationContext();
+    for (int i = 0; i < count; i++) {
+      ctx.addError("e" + i);
+    }
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> ctx.errors().add("injected"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Property
+  void notices_list_should_be_immutable(@ForAll @IntRange(min = 0, max = 3) int count) {
+    var ctx = new ToolValidationContext();
+    for (int i = 0; i < count; i++) {
+      ctx.addNotice("n" + i);
+    }
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> ctx.notices().add("injected"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Property
+  void require_should_reject_blank_or_null(@ForAll("blankOrNull") String value) {
+    var ctx = new ToolValidationContext();
+    ctx.require(value, "field");
+
+    assertThat(ctx.isValid()).isFalse();
+    assertThat(ctx.errors()).hasSize(1);
+    assertThat(ctx.errors().getFirst()).contains("is required");
+  }
+
+  @Property
+  void require_should_accept_non_blank(@ForAll("nonBlankString") String value) {
+    var ctx = new ToolValidationContext();
+    ctx.require(value, "field");
+
+    assertThat(ctx.isValid()).isTrue();
+  }
+
+  @Property
+  void noticeIf_should_add_notice_only_when_true(@ForAll boolean condition) {
+    var ctx = new ToolValidationContext();
+    ctx.noticeIf(condition, "conditional notice");
+
+    if (condition) {
+      assertThat(ctx.notices()).containsExactly("conditional notice");
+    } else {
+      assertThat(ctx.notices()).isEmpty();
+    }
+  }
+
+  @Property
+  void errorIf_should_add_error_only_when_true(@ForAll boolean condition) {
+    var ctx = new ToolValidationContext();
+    ctx.errorIf(condition, "conditional error");
+
+    assertThat(ctx.isValid()).isEqualTo(!condition);
+  }
+
+  @Provide
+  Arbitrary<String> randomUuid() {
+    return Arbitraries.longs().tuple2().map(t -> new UUID(t.get1(), t.get2()).toString());
+  }
+
+  @Provide
+  Arbitrary<String> nonUuid() {
+    return Arbitraries.of("not-a-uuid", "12345", "abc", "550e8400-ZZZZ-41d4-a716-446655440000");
+  }
+
+  @Provide
+  Arbitrary<String> blankString() {
+    return Arbitraries.of("", "   ", " \t\n ");
+  }
+
+  @Provide
+  Arbitrary<String> blankOrNull() {
+    return Arbitraries.of(null, "", "   ", " \t ");
+  }
+
+  @Provide
+  Arbitrary<String> nonBlankString() {
+    return Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(20);
+  }
+}

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContextPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContextPropertyTest.java
@@ -1,11 +1,14 @@
 package com.contrast.labs.ai.mcp.contrast.tool.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.UUID;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Assume;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
@@ -89,7 +92,7 @@ class ToolValidationContextPropertyTest {
       ctx.addError("e" + i);
     }
 
-    org.assertj.core.api.Assertions.assertThatThrownBy(() -> ctx.errors().add("injected"))
+    assertThatThrownBy(() -> ctx.errors().add("injected"))
         .isInstanceOf(UnsupportedOperationException.class);
   }
 
@@ -100,7 +103,7 @@ class ToolValidationContextPropertyTest {
       ctx.addNotice("n" + i);
     }
 
-    org.assertj.core.api.Assertions.assertThatThrownBy(() -> ctx.notices().add("injected"))
+    assertThatThrownBy(() -> ctx.notices().add("injected"))
         .isInstanceOf(UnsupportedOperationException.class);
   }
 
@@ -140,6 +143,67 @@ class ToolValidationContextPropertyTest {
     ctx.errorIf(condition, "conditional error");
 
     assertThat(ctx.isValid()).isEqualTo(!condition);
+  }
+
+  @Property
+  void validateDateRange_should_add_error_when_start_after_end(
+      @ForAll int endMillis, @ForAll @IntRange(min = 1) int gap) {
+    var end = new Date(endMillis);
+    var start = new Date((long) endMillis + gap);
+    var ctx = new ToolValidationContext();
+    ctx.validateDateRange(start, end, "startDate", "endDate");
+
+    assertThat(ctx.isValid()).isFalse();
+    assertThat(ctx.errors()).hasSize(1);
+    assertThat(ctx.errors().getFirst()).contains("startDate").contains("endDate");
+  }
+
+  @Property
+  void validateDateRange_should_accept_valid_range(
+      @ForAll int startMillis, @ForAll @IntRange(min = 0) int gap) {
+    var start = new Date(startMillis);
+    var end = new Date((long) startMillis + gap);
+    var ctx = new ToolValidationContext();
+    ctx.validateDateRange(start, end, "startDate", "endDate");
+
+    assertThat(ctx.isValid()).isTrue();
+    assertThat(ctx.errors()).isEmpty();
+  }
+
+  @Property
+  void validateDateRange_should_accept_nulls(@ForAll boolean startNull, @ForAll boolean endNull) {
+    Assume.that(startNull || endNull);
+    var start = startNull ? null : new Date(0);
+    var end = endNull ? null : new Date(0);
+    var ctx = new ToolValidationContext();
+    ctx.validateDateRange(start, end, "startDate", "endDate");
+
+    assertThat(ctx.isValid()).isTrue();
+  }
+
+  @Property
+  void validateTimestampRange_should_add_error_when_start_after_end(
+      @ForAll int endMillis, @ForAll @IntRange(min = 1) int gap) {
+    var end = new Date(endMillis);
+    var start = new Date((long) endMillis + gap);
+    var ctx = new ToolValidationContext();
+    ctx.validateTimestampRange(start, end, "startTs", "endTs");
+
+    assertThat(ctx.isValid()).isFalse();
+    assertThat(ctx.errors()).hasSize(1);
+    assertThat(ctx.errors().getFirst()).contains("startTs").contains("endTs");
+  }
+
+  @Property
+  void validateTimestampRange_should_accept_valid_range(
+      @ForAll int startMillis, @ForAll @IntRange(min = 0) int gap) {
+    var start = new Date(startMillis);
+    var end = new Date((long) startMillis + gap);
+    var ctx = new ToolValidationContext();
+    ctx.validateTimestampRange(start, end, "startTs", "endTs");
+
+    assertThat(ctx.isValid()).isTrue();
+    assertThat(ctx.errors()).isEmpty();
   }
 
   @Provide

--- a/contrast-mcp-core/src/test/resources/junit-platform.properties
+++ b/contrast-mcp-core/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+jqwik.tries.default=100

--- a/docs/adr/0005-adopt-jqwik-for-property-based-testing.md
+++ b/docs/adr/0005-adopt-jqwik-for-property-based-testing.md
@@ -1,0 +1,21 @@
+# Adopt jqwik for property-based testing
+
+The existing example-based tests verify chosen inputs thoroughly, but they can't cover the full input space of validation and pagination code that accepts arbitrary integers, strings, and enums. Property-based testing generates inputs automatically and checks invariants across hundreds of combinations, catching edge cases that hand-picked examples miss.
+
+We decided:
+
+- **Library: jqwik 1.10.1.** A spike verified it runs on this repo's JUnit Platform 6.0.3 stack. jqwik's own platform dependencies (1.14.4) get force-upgraded on the classpath and the engine still discovers and runs properties. This is binary compatibility, not an officially supported pairing. jqwik's future releases are uncertain (release notes say upcoming Platform 6 releases will happen "if ever realised"). Accepted risk because there is no mature Platform-6-native alternative.
+- **Location: ordinary test source set.** Property tests live in `contrast-mcp-core/src/test/java`, named `*PropertyTest`. The Gradle `check` lifecycle inherits them automatically (ADR 0003). They feed JaCoCo floors, the CRAP gate, and PIT test strength.
+- **Tries budget: 100 per property by default** (`jqwik.tries.default=100` in `junit-platform.properties`). Keeps PIT runtime manageable since PIT reruns tests per mutant.
+- **Pilot scope: `tool/validation` and `tool/base` pagination.** Covers `PaginationParams`, `CursorPaginationParams`, `IntSpec`, `StringListSpec`, `EnumSetSpec`, `ToolSortParser`, and `ToolValidationContext`.
+- **Bug policy:** a failing property never merges. Fix the bug when small. Otherwise narrow the generator to documented bounds, add a WHY comment citing the bug, and file a bead for the fix.
+
+## Considered options
+
+- **QuickCheck-style libraries (junit-quickcheck, quicktheories).** junit-quickcheck is unmaintained and does not support JUnit Platform 5+. quicktheories has limited shrinking and no JUnit Platform integration.
+- **Kotest property testing.** Requires Kotlin. This is a Java project.
+- **No property-based testing.** Status quo. Leaves the input-space coverage gap unaddressed. Rejected.
+
+## Maintenance risk
+
+jqwik is a single-maintainer project whose Platform 6 support is uncertain. If jqwik becomes unusable on a future JUnit Platform upgrade, the fallback is to convert property tests to parameterized JUnit tests with representative edge cases. The property tests are self-contained (no shared state, no custom lifecycle), so conversion is mechanical.

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,5 @@ pitestGradlePluginVersion=1.19.0
 pitestCoreVersion=1.25.8
 pitestJunit5PluginVersion=1.2.3
 archunitVersion=1.4.1
+jqwikVersion=1.10.1
 crap4jPluginVersion=1.0.0


### PR DESCRIPTION
<!-- pr-tools:stacked:v1 -->
<!-- pr-tools:parent-pr=241 -->
<!-- pr-tools:parent-branch=AIML-1407-standardize-gradle-check-verify -->
<!-- pr-tools:parent-base=AIML-1227-add-crap-metrics -->
<!-- pr-tools:boundary-commit=eb518e905f3e5e7ab36cf76f0b0995e2201961f9 -->
<!-- pr-tools:managed:start -->
<!-- pr-tools:managed:end -->

**Jira:** [AIML-1410](https://contrastsecurity.atlassian.net/browse/AIML-1410)

## Summary

Adds property-based testing to `contrast-mcp-core` using jqwik 1.10.1, piloted on the validation specs and pagination params. Seven `*PropertyTest` classes check invariants across generated inputs that example-based tests cannot cover. The property tests immediately found two real bugs in `PaginationParams`, both fixed in this PR.

- Two bugs found and fixed by property testing (see below)
- Property tests integrated into the ordinary `check` lifecycle (JaCoCo, CRAP, PIT)
- Core branch coverage rose to 91.3% (floor 87%)
- ADR 0005 records the jqwik adoption decision and Platform-6 compatibility risk

## Why This Change Exists

The validation and pagination code accepts arbitrary integers, strings, and enums. Example-based tests verify chosen inputs but cannot cover the full input space. Edge cases like integer overflow at pagination boundaries, mixed-case enum parsing, and `else-if` bound checking gaps are tedious to enumerate by hand. Property-based testing generates hundreds of input combinations automatically and checks that stated invariants hold for all of them.

## Approach

jqwik 1.10.1 was chosen because it is the only mature property-testing library for the JUnit Platform. A spike confirmed it runs on this repo's Platform 6.0.3 stack via binary compatibility (jqwik targets Platform 1.14.4, which gets force-upgraded). The maintenance risk (single maintainer, uncertain Platform 6 future) is accepted because the fallback is mechanical conversion to parameterized JUnit tests.

Property tests live in the ordinary test source set so the Gradle `check` lifecycle inherits them without enumerating task names (ADR 0003). The default tries budget is 100 per property (`junit-platform.properties`) to keep PIT runtime manageable.

## Bugs Found and Fixed

Property testing found two bugs in `PaginationParams` that existing example-based tests missed.

**1. Default pageSize ignores maxPageSize.** `PaginationParams.of(page, null, 25)` returned `pageSize=50` instead of 25. When `pageSize` was null, the code used `DEFAULT_PAGE_SIZE` (50) without checking `maxPageSize`. A tool with a stricter API limit (e.g. 25) would send an oversized request. The existing test `testCustomMaxPageSizeWithDefaultPageSize` passed by coincidence because it tested with `maxPageSize=50`, which equals `DEFAULT_PAGE_SIZE`. Fixed by using `Math.min(DEFAULT_PAGE_SIZE, maxPageSize)` for the default, matching `CursorPaginationParams` which already had the correct behavior.

**2. Offset integer overflow.** `(actualPage - 1) * actualSize` could overflow `int` for large page values (e.g. `page=50_000_000, pageSize=100` produces `4,999,999,900` which wraps negative). No existing test covered this because example-based tests used small page numbers. Fixed by capping `page` to `Integer.MAX_VALUE / pageSize` with a notice. Property test now proves `offset >= 0` for all inputs.

## What Changed

### Infrastructure
- `gradle.properties` — pinned `jqwikVersion=1.10.1` (released 2026-05-29, past soak window)
- `contrast-mcp-core/build.gradle` — added `testImplementation` for jqwik
- `junit-platform.properties` — created with `jqwik.tries.default=100`
- `.gitignore` — added `.jqwik-database` (jqwik's local failure-recording database)

### Bug fixes (`PaginationParams.java`)
- Default pageSize now clamped to `Math.min(DEFAULT_PAGE_SIZE, maxPageSize)`
- Page capped to `Integer.MAX_VALUE / pageSize` to prevent offset overflow

### Property tests (`tool/base`)
- `PaginationParamsPropertyTest` — clamping bounds, offset identity, offset non-negative, idempotence, notice-iff-corrected, immutability
- `CursorPaginationParamsPropertyTest` — clamping, blank-to-null normalization, cursor presence totality, default-size invariant

### Property tests (`tool/validation`)
- `IntSpecPropertyTest` — output in [min,max], notice count 0 or 1, default handling, no errors for any input
- `StringListSpecPropertyTest` — subset-of-allowed, case-insensitive normalization, idempotence, uppercase conversion
- `EnumSetSpecPropertyTest` — round-trip identity, case-insensitive parsing, deduplication, unknown tokens produce error+null
- `ToolSortParserPropertyTest` — wire-name round-trip, case-insensitive on both property and direction, malformed always yields default
- `ToolValidationContextPropertyTest` — isValid iff errors empty, append-only ordering, requireUuid accepts UUID.toString, immutability

### Documentation
- `docs/adr/0005-adopt-jqwik-for-property-based-testing.md` — records the adoption decision, Platform-6 pairing risk, and fallback plan
- `CLAUDE.md` — added property-testing conventions section

## Testing

All 79 property tests pass across seven `*PropertyTest` classes. `make check` green with 1267 total tests, 0 failures. Coverage floors, CRAP gate, and PIT mutation testing all pass.

Each `@Property` method states one invariant and jqwik generates 100 random inputs per property. The two bugs were caught by properties that would have been difficult to express as example-based tests: "pageSize is always within [1, maxPageSize] for any combination of inputs" and "offset is always non-negative for any page and pageSize."

---
Generated with Claude Code


[AIML-1410]: https://contrast.atlassian.net/browse/AIML-1410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ