### PR TITLE
AIML-1412 Simplify high-CRAP methods and clear baseline

### DIFF
--- a/.claude/skills/fix-crap/SKILL.md
+++ b/.claude/skills/fix-crap/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: fix-crap
+description: Fix methods that fail the CRAP metric gate. Use when crapCheck fails, when a method appears in the crap4j baseline, when the user asks to reduce a method's CRAP score, or when make check fails with a CRAP violation. Covers diagnosis, the test-or-simplify decision, and baseline management.
+---
+
+# Fixing CRAP Violations
+
+CRAP (Change Risk Anti-Patterns) flags methods that are both complex and under-tested. The formula is `cc^2 * (1 - coverage)^3 + cc` where `cc` is cyclomatic complexity and `coverage` is branch coverage (0 to 1). A method fails at CRAP > 15 with complexity capped at 15.
+
+## When this skill applies
+
+- `crapCheck` fails during `make check`
+- A method appears in a module's `crap4j-baseline.json`
+- The user asks to reduce a CRAP score or clear the baseline
+
+## Diagnosis
+
+Run the advisory report first to see all flagged methods and their scores:
+
+```
+./gradlew :<module>:crapReport
+```
+
+For each flagged method, open the JaCoCo HTML report at `<module>/build/reports/jacoco/test/html/` and find the method. Lines marked `pc bpc` (partial branch coverage) or `nc` (not covered) are the missed branches. Count them. This tells you whether the fix is testing, simplification, or both.
+
+## The decision: test, simplify, or both
+
+CRAP has two levers: complexity and coverage. Pick the right one.
+
+### Test when the method is readable as-is
+
+A configuration method, a builder, or a mapping function may have moderate complexity from iteration and null guards, but no confusing control flow. The complexity is structural, not cognitive. Adding tests is the right fix because the method does not need to change.
+
+Indicators that testing is the right fix:
+- The method is a flat sequence of similar operations (registrations, field mappings, guard clauses)
+- The complexity comes from `forEach` loops, null checks, or switch/if chains over a known set
+- A reader can understand the method top to bottom without backtracking
+- Only a few branches are uncovered in JaCoCo
+
+Calculate the coverage needed: solve `cc^2 * (1 - cov)^3 + cc < 15` for your method's `cc`. For cc=14, you need >83% branch coverage. For cc=10, you need >68%. For cc=6, any coverage clears it.
+
+Write tests that verify real behavior. Each test should assert something meaningful about the method's output or side effects. Do not write tests that exist only to execute a branch without checking the result.
+
+### Simplify when the method is genuinely hard to follow
+
+A method with deeply nested conditionals, interleaved concerns, or multiple responsibilities should be split. Extraction makes each piece independently testable and reduces the complexity score.
+
+Indicators that simplification is the right fix:
+- The method mixes unrelated responsibilities (e.g., parameter resolution AND API calls AND response mapping)
+- Nested if/else chains three or more levels deep
+- You need to read the whole method to understand any single part of it
+- The method has both high complexity AND low coverage, and covering it would require elaborate test setup
+
+Good extractions:
+- Pull a self-contained phase into a private method (e.g., `buildFilterBody`, `resolveLatestSessionId`)
+- Extract a loop body that matches/transforms items into its own method
+- Separate guard-clause chains from the work they protect
+
+### Do not simplify just to satisfy the metric
+
+Never split a method solely because the CRAP score is high. If the method reads clearly top to bottom, testing is the fix. Splitting a readable method into fragments trades clarity for a number.
+
+Anti-patterns:
+- Extracting a 3-line null check into `handleNullCase()` to reduce branch count
+- Creating a helper that has exactly one caller and makes the flow harder to follow
+- Moving code to a new method without giving it a meaningful name and responsibility
+- Restructuring production code to eliminate equivalent-mutant sites (see CLAUDE.md PIT guidance)
+
+## Fixing the violation
+
+1. **Find the missed branches.** Open the JaCoCo HTML report. Identify which branches are `nc` or `pc bpc`.
+2. **Decide: test or simplify** using the criteria above. Often one test covering a missed branch is enough.
+3. **Write the fix.** Tests go in the existing `*Test.java` file for the class. Simplification stays in the production class.
+4. **Run the CRAP report** to confirm the method clears the threshold:
+   ```
+   ./gradlew :<module>:test :<module>:jacocoTestReport :<module>:crapReport
+   ```
+5. **Tighten the baseline** to lock in the progress:
+   ```
+   ./gradlew :<module>:crapBaselineTighten
+   ```
+6. **Run `make check`** to confirm everything passes.
+7. **Commit the tightened baseline** alongside the code and test changes.
+
+## Baseline management
+
+Each module has a `crap4j-baseline.json` that excuses known violations. The baseline is shrink-only.
+
+- `crapReport` shows baselined methods as "Baselined debt" and methods that improved past their allowance as "Slack."
+- `crapBaselineTighten` removes slack entries (methods that now pass on their own). Run it after fixing violations.
+- `crapBaseline` regenerates the baseline from scratch. Use only when adding a new baseline entry is unavoidable (rare).
+- Never inflate the baseline to absorb new violations. Fix the code or cover it with tests.
+
+## Quick reference: coverage needed by complexity
+
+| Complexity | Coverage needed for CRAP < 15      |
+|------------|------------------------------------|
+| 15         | 100% (simplification required)     |
+| 14         | > 83%                              |
+| 12         | > 72%                              |
+| 10         | > 63%                              |
+| 8          | > 52%                              |
+| 6          | > 37%                              |
+| 4          | > 12% (almost any test clears it)  |

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ allprojects {
 // Deliberately below those numbers to retain headroom. Flush against 622/698, one further
 // uncovered branch gives 0.88984 and reddens main on an unrelated PR.
 ext.coverageMinimums = [
-    'contrast-mcp-core'     : [line: 0.95, branch: 0.87],
+    'contrast-mcp-core'     : [line: 0.95, branch: 0.89],
     'contrast-mcp-stdio-app': [line: 0.95, branch: 0.94],
 ]
 

--- a/buildSrc/src/test/java/com/contrast/labs/build/EnvFileParserTest.java
+++ b/buildSrc/src/test/java/com/contrast/labs/build/EnvFileParserTest.java
@@ -121,6 +121,36 @@ class EnvFileParserTest {
   }
 
   @Test
+  void resolve_should_prefer_env_variable_over_file_value() throws IOException {
+    Path envFile = tmp.resolve("resolve.env");
+    Files.writeString(envFile, "HOME=file-value\n");
+    var result = EnvFileParser.resolve(envFile.toFile(), List.of("HOME"));
+    assertThat(result.get("HOME"))
+        .as("real env var should win over file value")
+        .isEqualTo(System.getenv("HOME"));
+  }
+
+  @Test
+  void resolve_should_fall_back_to_file_when_env_variable_absent() throws IOException {
+    Path envFile = tmp.resolve("resolve.env");
+    Files.writeString(envFile, "UNLIKELY_TEST_KEY_CE_42=from-file\n");
+    var result = EnvFileParser.resolve(envFile.toFile(), List.of("UNLIKELY_TEST_KEY_CE_42"));
+    assertThat(result.get("UNLIKELY_TEST_KEY_CE_42"))
+        .as("file value should be used when env var is absent")
+        .isEqualTo("from-file");
+  }
+
+  @Test
+  void resolve_should_return_null_when_absent_from_both() throws IOException {
+    Path envFile = tmp.resolve("resolve.env");
+    Files.writeString(envFile, "OTHER=value\n");
+    var result = EnvFileParser.resolve(envFile.toFile(), List.of("ABSENT_TEST_KEY_CE_42"));
+    assertThat(result.get("ABSENT_TEST_KEY_CE_42"))
+        .as("null when key is absent from both env and file")
+        .isNull();
+  }
+
+  @Test
   void parseLines_should_handle_template_format() {
     var result =
         EnvFileParser.parseLines(

--- a/contrast-mcp-core/crap4j-baseline.json
+++ b/contrast-mcp-core/crap4j-baseline.json
@@ -1,24 +1,9 @@
 {
   "formatVersion": 1,
-  "toolVersion": "0.1.0",
-  "generated": "2026-08-17T03:03:36.299849Z",
+  "toolVersion": "1.0.0",
+  "generated": "2026-08-19T03:59:40.794450Z",
   "coverageSelection": "branch-preferred",
   "threshold": 15.0,
   "complexityCap": 15,
-  "entries": [
-    {
-      "class": "com/contrast/labs/ai/mcp/contrast/tool/vulnerability/RecommendationMarkdownRenderer",
-      "method": "registerKnownTags",
-      "descriptor": "(Ljava/util/Map;)V",
-      "crap": 38.50,
-      "complexity": 14
-    },
-    {
-      "class": "com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool",
-      "method": "doExecute",
-      "descriptor": "(Lcom/contrast/labs/ai/mcp/contrast/tool/base/PaginationParams;Lcom/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParams;Lcom/contrast/labs/ai/mcp/contrast/tool/base/NoticeCollector;)Lcom/contrast/labs/ai/mcp/contrast/tool/base/ExecutionResult;",
-      "crap": 18.52,
-      "complexity": 15
-    }
-  ]
+  "entries": [  ]
 }

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
@@ -177,7 +177,6 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
       return;
     }
 
-    // Fetch libraries and match to stack frames
     var started = Instant.now();
     var libs = contrastApiClient.getAllLibraries(appId);
     var lobs = buildVulnerableLibraryObservations(libs, appId);
@@ -189,6 +188,14 @@ public class GetVulnerabilityTool extends SingleTool<GetVulnerabilityParams, Vul
         stackTraces.size(),
         Duration.between(started, Instant.now()).toMillis());
 
+    matchStackFramesToLibraries(stackTraces, lobs, stackLibs, libsToReturn);
+  }
+
+  private void matchStackFramesToLibraries(
+      List<String> stackTraces,
+      List<LibraryLibraryObservation> lobs,
+      List<StackLib> stackLibs,
+      HashSet<LibraryExtended> libsToReturn) {
     for (String stackTrace : stackTraces) {
       var matchingLlobOpt = findMatchingLibraryData(stackTrace, lobs);
       if (matchingLlobOpt.isPresent()) {

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java
@@ -20,6 +20,7 @@ import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConsta
 
 import com.contrast.labs.ai.mcp.contrast.client.ContrastApiClient;
 import com.contrast.labs.ai.mcp.contrast.result.VulnLight;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.ExtendedTraceFilterBody;
 import com.contrast.labs.ai.mcp.contrast.tool.base.ExecutionResult;
 import com.contrast.labs.ai.mcp.contrast.tool.base.NoticeCollector;
 import com.contrast.labs.ai.mcp.contrast.tool.base.PaginatedTool;
@@ -179,6 +180,32 @@ public class SearchAppVulnerabilitiesTool
       PaginationParams pagination, SearchAppVulnerabilitiesParams params, NoticeCollector collector)
       throws Exception {
 
+    var filterBody = buildFilterBody(params, collector);
+
+    var expand =
+        EnumSet.of(
+            TraceExpandValue.SESSION_METADATA,
+            TraceExpandValue.SERVER_ENVIRONMENTS,
+            TraceExpandValue.APPLICATION);
+
+    var traces =
+        contrastApiClient.searchAppVulnerabilities(
+            params.appId(), filterBody, pagination.limit(), pagination.offset(), expand);
+
+    if (traces == null || traces.getTraces() == null) {
+      collector.notice("API returned no trace data. Verify permissions and filters.");
+      return ExecutionResult.empty();
+    }
+
+    var vulnerabilities =
+        traces.getTraces().stream().map(vulnerabilityMapper::toVulnLight).toList();
+
+    return ExecutionResult.of(vulnerabilities, traces.getCount());
+  }
+
+  private ExtendedTraceFilterBody buildFilterBody(
+      SearchAppVulnerabilitiesParams params, NoticeCollector collector) throws Exception {
+
     List<String> canonicalVulnTypes = null;
     if (params.getVulnTypes() != null && !params.getVulnTypes().isEmpty()) {
       canonicalVulnTypes =
@@ -187,24 +214,11 @@ public class SearchAppVulnerabilitiesTool
 
     var appId = params.appId();
 
-    // Handle useLatestSession - fetch agent session ID
     String agentSessionId = null;
     if (Boolean.TRUE.equals(params.getUseLatestSession())) {
-      var latestSession = contrastApiClient.getLatestSessionMetadata(appId);
-      if (latestSession != null
-          && latestSession.getAgentSession() != null
-          && latestSession.getAgentSession().getAgentSessionId() != null) {
-        agentSessionId = latestSession.getAgentSession().getAgentSessionId();
-        log.debug("Using latest session ID: {}", agentSessionId);
-      } else {
-        collector.notice(
-            "No sessions found for this application. Results include all vulnerabilities across"
-                + " all sessions.");
-        log.warn("No sessions found for application: {}", appId);
-      }
+      agentSessionId = resolveLatestSessionId(appId, collector);
     }
 
-    // Handle sessionMetadataFilters - resolve field names to numeric IDs
     List<TraceMetadataFilter> resolvedFilters = null;
     var sessionMetadataFilters = params.getSessionMetadataFilters();
     if (sessionMetadataFilters != null && !sessionMetadataFilters.isEmpty()) {
@@ -212,7 +226,6 @@ public class SearchAppVulnerabilitiesTool
       log.debug("Resolved {} session metadata filters", resolvedFilters.size());
     }
 
-    // Build filter body and add session params if present
     var filterBody = params.toTraceFilterBody();
     if (canonicalVulnTypes != null) {
       filterBody.setVulnTypes(canonicalVulnTypes);
@@ -224,25 +237,23 @@ public class SearchAppVulnerabilitiesTool
       filterBody.setMetadataFilters(resolvedFilters);
     }
 
-    var expand =
-        EnumSet.of(
-            TraceExpandValue.SESSION_METADATA,
-            TraceExpandValue.SERVER_ENVIRONMENTS,
-            TraceExpandValue.APPLICATION);
+    return filterBody;
+  }
 
-    var traces =
-        contrastApiClient.searchAppVulnerabilities(
-            appId, filterBody, pagination.limit(), pagination.offset(), expand);
-
-    if (traces == null || traces.getTraces() == null) {
-      collector.notice("API returned no trace data. Verify permissions and filters.");
-      return ExecutionResult.empty();
+  private String resolveLatestSessionId(String appId, NoticeCollector collector) throws Exception {
+    var latestSession = contrastApiClient.getLatestSessionMetadata(appId);
+    if (latestSession != null
+        && latestSession.getAgentSession() != null
+        && latestSession.getAgentSession().getAgentSessionId() != null) {
+      var sessionId = latestSession.getAgentSession().getAgentSessionId();
+      log.debug("Using latest session ID: {}", sessionId);
+      return sessionId;
     }
-
-    var vulnerabilities =
-        traces.getTraces().stream().map(vulnerabilityMapper::toVulnLight).toList();
-
-    return ExecutionResult.of(vulnerabilities, traces.getCount());
+    collector.notice(
+        "No sessions found for this application. Results include all vulnerabilities across"
+            + " all sessions.");
+    log.warn("No sessions found for application: {}", appId);
+    return null;
   }
 
   /**

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParamsTest.java
@@ -339,6 +339,131 @@ class AttackFilterParamsTest {
     assertThat(filterBody.isIncludeSuppressed()).isFalse(); // Default
   }
 
+  @Nested
+  @DisplayName("toAttacksFilterBody optional field coverage")
+  class ToAttacksFilterBodyFieldTests {
+
+    @Test
+    void toAttacksFilterBody_should_set_quickFilter_when_provided() {
+      var params = AttackFilterParams.of("MANUAL", null, null, null, null, null, null, null);
+
+      var body = params.toAttacksFilterBody();
+
+      assertThat(body.getQuickFilter()).isEqualTo("MANUAL");
+    }
+
+    @Test
+    void toAttacksFilterBody_should_set_statusFilter_when_provided() {
+      var params =
+          AttackFilterParams.of(null, "EXPLOITED,PROBED", null, null, null, null, null, null);
+
+      var body = params.toAttacksFilterBody();
+
+      assertThat(body.getStatusFilter()).containsExactly("EXPLOITED", "PROBED");
+    }
+
+    @Test
+    void toAttacksFilterBody_should_leave_statusFilter_empty_when_null() {
+      var params = AttackFilterParams.of(null, null, null, null, null, null, null, null);
+
+      var body = params.toAttacksFilterBody();
+
+      assertThat(body.getStatusFilter()).isEmpty();
+    }
+
+    @Test
+    void toAttacksFilterBody_should_set_keyword_when_provided() {
+      var params = AttackFilterParams.of(null, null, "search term", null, null, null, null, null);
+
+      var body = params.toAttacksFilterBody();
+
+      assertThat(body.getKeyword()).isEqualTo("search term");
+    }
+
+    @Test
+    void toAttacksFilterBody_should_use_builder_default_keyword_when_blank() {
+      var params = AttackFilterParams.of(null, null, "  ", null, null, null, null, null);
+
+      var body = params.toAttacksFilterBody();
+
+      assertThat(body.getKeyword()).isEmpty();
+    }
+
+    @Test
+    void toAttacksFilterBody_should_set_includeSuppressed_true_when_provided() {
+      var params = AttackFilterParams.of(null, null, null, true, null, null, null, null);
+
+      var body = params.toAttacksFilterBody();
+
+      assertThat(body.isIncludeSuppressed()).isTrue();
+    }
+
+    @Test
+    void toAttacksFilterBody_should_set_includeSuppressed_false_when_null_defaults() {
+      var params = AttackFilterParams.of(null, null, null, null, null, null, null, null);
+
+      var body = params.toAttacksFilterBody();
+
+      assertThat(body.isIncludeSuppressed()).isFalse();
+    }
+
+    @Test
+    void toAttacksFilterBody_should_set_includeBotBlockers_true_when_provided() {
+      var params = AttackFilterParams.of(null, null, null, null, true, null, null, null);
+
+      var body = params.toAttacksFilterBody();
+
+      assertThat(body.isIncludeBotBlockers()).isTrue();
+    }
+
+    @Test
+    void toAttacksFilterBody_should_default_includeBotBlockers_false_when_null() {
+      var params = AttackFilterParams.of(null, null, null, null, null, null, null, null);
+
+      var body = params.toAttacksFilterBody();
+
+      assertThat(body.isIncludeBotBlockers()).isFalse();
+    }
+
+    @Test
+    void toAttacksFilterBody_should_set_includeIpBlacklist_true_when_provided() {
+      var params = AttackFilterParams.of(null, null, null, null, null, true, null, null);
+
+      var body = params.toAttacksFilterBody();
+
+      assertThat(body.isIncludeIpBlacklist()).isTrue();
+    }
+
+    @Test
+    void toAttacksFilterBody_should_default_includeIpBlacklist_false_when_null() {
+      var params = AttackFilterParams.of(null, null, null, null, null, null, null, null);
+
+      var body = params.toAttacksFilterBody();
+
+      assertThat(body.isIncludeIpBlacklist()).isFalse();
+    }
+
+    @Test
+    void toAttacksFilterBody_should_set_protectionRules_when_rules_provided() {
+      var params =
+          AttackFilterParams.of(
+              null, null, null, null, null, null, null, "sql-injection,reflected-xss");
+
+      var body = params.toAttacksFilterBody();
+
+      assertThat(body.getProtectionRules()).containsExactly("sql-injection", "reflected-xss");
+    }
+
+    @Test
+    void toAttacksFilterBody_should_leave_protectionRules_empty_when_rules_null() {
+      var params = AttackFilterParams.of(null, null, null, null, null, null, null, null);
+
+      var body = params.toAttacksFilterBody();
+
+      assertThat(body.getProtectionRules()).isEmpty();
+    }
+  }
+
   // ========== Keyword Encoding Tests ==========
 
   @Nested

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolSortParserPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolSortParserPropertyTest.java
@@ -97,10 +97,10 @@ class ToolSortParserPropertyTest {
     var ctx = new ToolValidationContext();
     var result = ToolSortParser.parse(ctx, sort, FIELDS, DEFAULT_SORT);
 
-    if (ctx.isValid() && result != null) {
-      var bare = result.startsWith("-") ? result.substring(1) : result;
-      assertThat(bare).isIn(WIRE_VALUES);
-    }
+    assertThat(ctx.isValid()).isTrue();
+    assertThat(result).isNotNull();
+    var bare = result.startsWith("-") ? result.substring(1) : result;
+    assertThat(bare).isIn(WIRE_VALUES);
   }
 
   @Provide

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/RecommendationMarkdownRendererTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/RecommendationMarkdownRendererTest.java
@@ -230,6 +230,17 @@ class RecommendationMarkdownRendererTest {
   }
 
   @Test
+  void render_should_render_block_tag_as_newline_delimited_text() {
+    var recommendation =
+        recommendation(
+            "fallback", "{{#paragraph}}Before{{#block}}block content{{/block}}After{{/paragraph}}");
+
+    var markdown = RecommendationMarkdownRenderer.render(recommendation);
+
+    assertThat(markdown).contains("block content").doesNotContain("{{");
+  }
+
+  @Test
   void render_should_render_risk_evidence_as_untyped_fenced_code() {
     var recommendation =
         recommendation(


### PR DESCRIPTION
<!-- pr-tools:stacked:v1 -->
<!-- pr-tools:parent-pr=245 -->
<!-- pr-tools:parent-branch=AIML-1411-tighten-checkstyle-fqcn-regex -->
<!-- pr-tools:parent-base=AIML-1410-add-more-property-tests -->
<!-- pr-tools:boundary-commit=505282d772de2961479c5e7b8f9b29f07b83062e -->
<!-- pr-tools:managed:start -->
<!-- pr-tools:managed:end -->

**Jira:** [AIML-1412](https://contrast.atlassian.net/browse/AIML-1412)

## Summary

Reduce CRAP scores on the two baselined methods, add test coverage for untested filter-body conversion paths, ratchet the core branch coverage floor, and add a `fix-crap` skill that teaches the model how to handle future CRAP violations. The CRAP baseline is now empty.

- Extracted helper methods from `SearchAppVulnerabilitiesTool.doExecute` and `GetVulnerabilityTool.buildStackTraceAndLibraryData` to reduce cyclomatic complexity
- Added isolated `toAttacksFilterBody` tests for every optional field path, including the previously untested `rules`-to-`protectionRules` conversion
- Covered the `block` tag branch in `RecommendationMarkdownRenderer.registerKnownTags` (CRAP 38.5 to 14.0)
- Raised core branch coverage floor from 87% to 89% (measured 91.8%, 2.8pt headroom)
- Added `fix-crap` skill with diagnosis workflow, test-vs-simplify decision framework, and baseline management

## Why This Change Exists

The GOAT review of the AIML-1410 property tests PR identified two baselined CRAP methods and a branch coverage floor that had drifted well below the measured value. The two baselined methods accounted for 18 of 74 missed branches. Clearing them and tightening the floor prevents quality regression on future PRs.

## What Changed

### Vulnerability tool refactoring
- `SearchAppVulnerabilitiesTool.java` -- Extracted `buildFilterBody()` and `resolveLatestSessionId()` from `doExecute`. The method now delegates filter assembly and calls the API. No behavior change.
- `GetVulnerabilityTool.java` -- Extracted `matchStackFramesToLibraries()` from `buildStackTraceAndLibraryData`. The guard-clause chain stays in the parent method. No behavior change.

### Test coverage
- `AttackFilterParamsTest.java` -- 13 new tests in a `ToAttacksFilterBodyFieldTests` nested class exercising each optional field's set/null path through `toAttacksFilterBody`.
- `RecommendationMarkdownRendererTest.java` -- One test for the `block` tag, covering the only missed branch in `registerKnownTags`.

### Coverage gates
- `build.gradle` -- Core branch floor 0.87 to 0.89.
- `crap4j-baseline.json` -- Both entries removed (empty baseline).

### New skill
- `.claude/skills/fix-crap/SKILL.md` -- Fires on `crapCheck` failures, baseline entries, or user requests to reduce CRAP scores. Teaches the test-or-simplify decision (test when the method reads clearly, simplify when it mixes concerns or nests deeply, never split just to satisfy a number). Includes JaCoCo branch diagnosis, the baseline tighten workflow, and a reference table mapping complexity to required coverage.

## Testing

- `make check` passes with 1316 tests, 0 failures
- Core branch coverage 91.8% (floor 89%), line coverage 98.0% (floor 95%)
- CRAP report shows 0 violations, 0 baselined methods
- PIT mutation testing passes within the test strength threshold

[AIML-1412]: https://contrast.atlassian.net/browse/AIML-1412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
