### PR TITLE
AIML-1157 Run integration tests on the PR merge path

### DIFF
--- a/.claude/skills/bead-workflow/SKILL.md
+++ b/.claude/skills/bead-workflow/SKILL.md
@@ -84,7 +84,9 @@ This atomically sets the assignee and status to `in_progress`. Record the branch
 
 ## 5. Closing a bead
 
-**Always ask the user before closing a bead.** Parent beads cannot close while children are open, and typically stay `in_progress` (with `in-review`) until the PR merges.
+**Finding beads by Jira key.** `br list --all | grep` is unreliable for matching Jira keys. Use `br list --status in_progress` to find active beads, then grep. When closing beads for merged PRs, always search by status first.
+
+**Always ask the user before closing a bead.** Parent beads cannot close while children are open, and typically stay `in_progress` (with `in-review`) until the PR merges. Close children before parents.
 
 Closing follows a strict sequence:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,3 +79,36 @@ jobs:
         if-no-files-found: warn
         # Diagnostic output for a failed run, not a durable artifact.
         retention-days: 7
+
+  # Run integration tests against a live TeamServer on internal PRs only.
+  # Fork PRs never receive secrets, so the guard prevents a noisy failure.
+  integration-test:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true
+    needs: build
+
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+      with:
+        egress-policy: audit
+
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Run integration tests
+      env:
+        CONTRAST_HOST_NAME: ${{ secrets.CONTRAST_HOST_NAME }}
+        CONTRAST_API_KEY: ${{ secrets.CONTRAST_API_KEY }}
+        CONTRAST_SERVICE_KEY: ${{ secrets.CONTRAST_SERVICE_KEY }}
+        CONTRAST_USERNAME: ${{ secrets.CONTRAST_USERNAME }}
+        CONTRAST_ORG_ID: ${{ secrets.CONTRAST_ORG_ID }}
+      run: ./gradlew :contrast-mcp-stdio-app:integrationTest --no-daemon

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,8 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
+    - name: Validate Gradle wrapper
+      uses: gradle/actions/wrapper-validation@889dc537cf3672c0c060560c9ead940a2b8b7077 # v6
 
     - name: Set up JDK 21
       uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
@@ -111,4 +113,4 @@ jobs:
         CONTRAST_SERVICE_KEY: ${{ secrets.CONTRAST_SERVICE_KEY }}
         CONTRAST_USERNAME: ${{ secrets.CONTRAST_USERNAME }}
         CONTRAST_ORG_ID: ${{ secrets.CONTRAST_ORG_ID }}
-      run: ./gradlew :contrast-mcp-stdio-app:integrationTest --no-daemon
+      run: ./gradlew :contrast-mcp-stdio-app:requireIntegrationTestCredentials :contrast-mcp-stdio-app:integrationTest --no-daemon

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,11 +81,19 @@ jobs:
         retention-days: 7
 
   # Run integration tests against a live TeamServer on internal PRs only.
-  # Fork PRs never receive secrets, so the guard prevents a noisy failure.
+  # Fork PRs never receive secrets, and Dependabot PRs only change dependency
+  # versions (no application code), so both are skipped to avoid unnecessary
+  # load on the test org.
   integration-test:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true
+    if: >-
+      github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.fork != true
+      && github.actor != 'dependabot[bot]'
     needs: build
+    concurrency:
+      group: integration-test-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
 
     steps:
     - name: Harden the runner (Audit all outbound calls)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ Never re-enumerate Gradle task names in make targets, CI, or hooks; attach new v
 
 The gate fails closed. A changed file absent from the JaCoCo report fails unless it is listed in `ext.coverageExcludedClassFiles`; a missing or empty report fails. A file that is in the report with no `LINE` counter has nothing countable to measure, so it passes and is named in the output. That covers roughly 49 of the 128 `contrast-mcp-core` sources, mostly interfaces and Lombok-only types.
 
-**Integration Tests:** Require Contrast credentials. Gradle sources `.env.integration-test` itself (copy from `.env.integration-test.template`); real environment variables override file values. `verify` fails loudly when no credentials are available; bare `integrationTest` skips instead, so forks and credential-less checkouts still build. `verify` is the maintainer gate — contributors without credentials run `check` and rely on CI. Release CI runs `verify` with credentials from repo secrets. See INTEGRATION_TESTS.md and ADR 0004.
+**Integration Tests:** Require Contrast credentials. Gradle sources `.env.integration-test` itself (copy from `.env.integration-test.template`); real environment variables override file values. `verify` fails loudly when no credentials are available; bare `integrationTest` skips instead, so forks and credential-less checkouts still build. `verify` is the maintainer gate — contributors without credentials run `check` and rely on CI. PR builds run `integrationTest` with credentials on every internal PR (fork PRs skipped). Release CI runs `verify` with credentials from repo secrets. See INTEGRATION_TESTS.md and ADR 0004.
 
 ### Docker Commands
 - **Build Docker image**: `docker build -t mcp-contrast .`

--- a/INTEGRATION_TESTS.md
+++ b/INTEGRATION_TESTS.md
@@ -53,26 +53,10 @@ For GitHub Actions, add these secrets to your repository:
 - `CONTRAST_USERNAME`
 - `CONTRAST_ORG_ID`
 
-Example GitHub Actions workflow:
+Integration tests run in two CI contexts:
 
-```yaml
-- name: Run integration tests
-  run: ./gradlew :contrast-mcp-stdio-app:integrationTest
-  env:
-    CONTRAST_HOST_NAME: ${{ secrets.CONTRAST_HOST_NAME }}
-    CONTRAST_API_KEY: ${{ secrets.CONTRAST_API_KEY }}
-    CONTRAST_SERVICE_KEY: ${{ secrets.CONTRAST_SERVICE_KEY }}
-    CONTRAST_USERNAME: ${{ secrets.CONTRAST_USERNAME }}
-    CONTRAST_ORG_ID: ${{ secrets.CONTRAST_ORG_ID }}
-```
-
-## Current Integration Tests
-
-### EnvironmentsIT.java
-
-Tests that environments and tags are properly populated from TeamServer API:
-- `testEnvironmentsAndTagsArePopulated()` - Verifies vulnerability responses include environments and tags
-- `testVulnerabilitiesHaveBasicFields()` - Verifies basic vulnerability fields are present
+- **PR builds** (`build.yml`): The `integration-test` job runs on every internal PR (fork PRs are skipped because they have no access to secrets). It runs after the `build` job passes.
+- **Release builds** (`gradle-release.yml`): The `verify` lifecycle runs integration tests as part of the release validation build.
 
 ## Adding New Integration Tests
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -119,7 +119,7 @@ test -f contrast-mcp-stdio-app/build/libs/mcp-contrast-X.Y.Z.jar
 
 Then create a GitHub release for the tag and attach `contrast-mcp-stdio-app/build/libs/mcp-contrast-X.Y.Z.jar`. Note that these manual instructions do not publish to Artifactory, sign the Docker image, generate SBOMs, or create attestations. Use the workflow whenever possible.
 
-**Validation gate:** the release runs `verify`, which is the full `check` lifecycle (static analysis, unit tests, coverage floors, CRAP gate, PIT) plus the integration tests against the org named by the `CONTRAST_*` repo secrets. Because releases only run from `main`, and `check` already gated the commit in `build.yml`, only the integration tests are genuinely new here. If a floor fires anyway, run `make check` locally for the per-module numbers, or read the `test-reports` artifact from that commit's build run.
+**Validation gate:** the release runs `verify`, which is the full `check` lifecycle (static analysis, unit tests, coverage floors, CRAP gate, PIT) plus the integration tests against the org named by the `CONTRAST_*` repo secrets. Because releases only run from `main`, and `check` plus integration tests already gated the commit in `build.yml` for internal PRs, release verify mainly re-confirms the same contract and covers the fork-PR case where CI never ran integration tests before merge. If a floor fires anyway, run `make check` locally for the per-module numbers, or read the `test-reports` artifact from that commit's build run.
 
 ## Verify the Release
 

--- a/docs/adr/0004-integration-tests-fail-loudly-and-gate-releases.md
+++ b/docs/adr/0004-integration-tests-fail-loudly-and-gate-releases.md
@@ -16,3 +16,7 @@ We decided:
 - **Drop `integrationTest` from release validation** and keep `verify` local-only. Rejected: a release is precisely when the live TeamServer contract should be tested.
 - **A GitHub environment with protection rules** instead of plain repo secrets. Rejected: the release workflow is already gated on manual dispatch by maintainers, and fork PRs can never read repo secrets, so the extra layer duplicates an existing control.
 - **`verify` in a git hook.** Rejected: live-API tests are minutes long, network- and credential-dependent, and occasionally flaky for reasons unrelated to the change. Hooks that fail spuriously teach people to bypass hooks.
+
+## Update
+
+ADR 0006 extends this decision to run integration tests on the PR merge path, not just at release time.

--- a/docs/adr/0006-merge-path-integration-tests.md
+++ b/docs/adr/0006-merge-path-integration-tests.md
@@ -1,0 +1,20 @@
+# Run integration tests on the PR merge path
+
+Extends ADR 0004. Previously, integration tests ran only during manual release dispatches (`gradle-release.yml`) and local `make verify`. PRs merged on `check` alone, which excludes `*IT.class`. Whether a filter narrows, a sort orders, or live JSON maps to the right fields was unverified until release.
+
+We decided:
+
+- A separate `integration-test` job in `build.yml` runs `integrationTest` on every internal pull request, after the `build` job passes.
+- The job runs `requireIntegrationTestCredentials` before `integrationTest` so it fails loudly when secrets are missing, matching the `verify` behavior from ADR 0004 rather than silently skipping.
+- Fork PRs are excluded (`github.event.pull_request.head.repo.fork != true`) because they have no access to repo secrets.
+- Dependabot PRs are excluded (`github.actor != 'dependabot[bot]'`) because they only change dependency versions and do not need live TeamServer verification. This avoids unnecessary load on the test org.
+- A per-PR concurrency group with `cancel-in-progress: true` prevents rapid pushes from stacking up concurrent runs against the same org.
+- The job does not run on push to `main`. Release `verify` already covers that path.
+
+## Considered options
+
+- **Run `verify` instead of bare `integrationTest`.** Rejected: `verify` reruns `check` (static analysis, unit tests, coverage, CRAP, PIT), which the `build` job already completed. Running only `requireIntegrationTestCredentials` + `integrationTest` avoids the redundant work.
+- **Run on all PRs including Dependabot.** Rejected: Dependabot PRs change dependency versions only. Running live API tests for every dependency bump consumes test-org capacity without verifying application behavior.
+- **Run on push to `main` as a heartbeat.** Not adopted in this change. Release `verify` covers main, and a scheduled heartbeat could be added later if external API drift becomes a problem.
+- **Label-gated trigger (only run when a label is applied).** Rejected: adds manual friction to every PR. The concurrency group and Dependabot exclusion are enough to keep load manageable.
+- **`pull_request_target` instead of `pull_request`.** Rejected: `pull_request_target` runs the workflow from the base branch, not the PR branch, so it would test the wrong code. The fork exclusion on `pull_request` achieves the same secret-protection goal.


### PR DESCRIPTION
**Jira:** [AIML-1157](https://contrast.atlassian.net/browse/AIML-1157)

## Summary
Add an `integration-test` job to PR CI so every internal pull request runs the integration suite against a live TeamServer before merging. Previously, integration tests only ran during manual release dispatches, so PRs merged without any live API verification.

- Internal PRs now run integration tests automatically after the build job passes
- Fork and Dependabot PRs are skipped to protect secrets and limit test-org load
- Per-PR concurrency group cancels in-flight runs on new pushes
- Credential guard fails loudly when secrets are missing instead of silently passing

## Why This Change Exists
Every PR was merging on proof of compilation and unit tests alone. Whether a filter narrows results, a sort orders correctly, or live JSON maps to the right fields was unverified until a manual release dispatch. The docs also referenced a deleted test class and described CI paths inaccurately.

## Approach
The new job runs `requireIntegrationTestCredentials` + `integrationTest` rather than `verify` to avoid redundant work (`check` already ran in the build job). Three guards limit when and how often the job runs: fork exclusion (no secret access), Dependabot exclusion (dependency-only PRs don't need live API tests), and a per-PR concurrency group with `cancel-in-progress` (rapid pushes cancel the prior run). See ADR 0006 for the full decision record and rejected alternatives.

## What Changed
### CI workflow
- `.github/workflows/build.yml` — new `integration-test` job with credential guard, fork/Dependabot exclusion, and per-PR concurrency group

### Documentation
- `INTEGRATION_TESTS.md` — replaced stale `EnvironmentsIT.java` section with accurate two-context CI description
- `CLAUDE.md` — updated Integration Tests section to mention PR-path coverage
- `RELEASING.md` — qualified the validation gate description now that ITs run pre-merge for internal PRs

### Architecture decisions
- `docs/adr/0006-merge-path-integration-tests.md` (new) — documents the merge-path IT decisions and rejected alternatives
- `docs/adr/0004-...md` — added update pointer to ADR 0006

## Testing
- This PR's own CI run exercises the new `integration-test` job
- No application code changes to test


[AIML-1157]: https://contrast.atlassian.net/browse/AIML-1157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ