### PR TITLE
AIML-1416 Add PMD and CPD static analysis with baseline gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,14 +48,15 @@ jobs:
 
     # Pull requests only. With no base the task falls back to the working tree, which is
     # clean on a fresh checkout and would pass vacuously.
-    - name: Verify changed-file coverage
+    - name: Verify changed-file coverage and PMD
       if: github.event_name == 'pull_request'
       # Via env so no workflow expression is parsed as shell.
       env:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
       run: >-
         ./gradlew jacocoChangedFileCoverageVerification
-        -PjacocoChangedBase="$BASE_SHA"
+        verifyPmdChangedFilesBaseline
+        -PstaticAnalysisChangedBase="$BASE_SHA"
         --no-daemon
 
     # Runs even when the coverage floor fails, since that is exactly when the
@@ -67,7 +68,7 @@ jobs:
       if: ${{ !cancelled() }}
       run: ./gradlew --quiet coverageSummary --no-daemon >> "$GITHUB_STEP_SUMMARY"
 
-    - name: Upload coverage reports
+    - name: Upload coverage and static analysis reports
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
@@ -76,6 +77,7 @@ jobs:
           **/build/reports/jacoco/test/html/**
           **/build/reports/jacoco/test/jacocoTestReport.xml
           **/build/reports/pitest/**
+          **/build/reports/pmd/**
         if-no-files-found: warn
         # Diagnostic output for a failed run, not a durable artifact.
         retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,8 @@ The workflows below use the **pr-tools** plugin (`/pr-tools:*` commands). If tho
 The Gradle `check` and `verify` lifecycles are the single source of truth for verification (ADR 0003, ADR 0004; Check/Verify/Lint defined in CONTEXT.md). Make targets are thin quiet-output wrappers:
 
 ```bash
-make check       # Auto-format, then the full Gradle check lifecycle: static analysis,
-                 # unit tests, coverage floors, CRAP gate, PIT mutation testing
+make check       # Auto-format, then the full Gradle check lifecycle: static analysis
+                 # (checkstyle, PMD, CPD), unit tests, coverage floors, CRAP gate, PIT
 make verify      # check + integration tests (needs Contrast credentials, fails loudly without)
 make lint        # Fast inner loop: auto-format + checkstyle only. Not a gate
 make format      # Auto-format code with Spotless (also runs inside check/verify/lint)
@@ -74,14 +74,17 @@ Never re-enumerate Gradle task names in make targets, CI, or hooks; attach new v
 
 **CRAP gate:** part of `check` (`attachToCheck = true`). `./gradlew crapReport` for advisory per-module reports, `./gradlew crapCheck` to run the gate alone. Existing violations live in each module's `crap4j-baseline.json`; use `./gradlew crapBaseline` to generate or regenerate a baseline, and `./gradlew crapBaselineTighten` to remove baseline slack after improving code.
 
+**PMD gate:** part of `check` (ADR 0007). PMD and CPD run on all sources, gated through per-module baseline files (`pmd-baseline.txt`). New findings outside the baseline fail the build. `./gradlew :<module>:writePmdBaseline` regenerates the baseline (user-sanctioned). `./gradlew :<module>:pmdBaselineTighten` removes slack after fixing violations. Custom XPath rules have positive controls verified in `check`. Config lives in `config/pmd/`. Changed-file PMD (`verifyPmdChangedFilesBaseline`) runs from the pre-push hook and PR CI alongside changed-file coverage, using the same `staticAnalysisChangedBase` property.
+
 **After a compilation failure**, stale `.class` files may remain and cause confusing follow-up failures. Always run `make clean` then `./gradlew test` to recover before continuing.
 
 **Direct Gradle commands** (verbose output, use make targets above for quiet output):
 - **Build**: `./gradlew :contrast-mcp-stdio-app:bootJar`
 - **Test (unit)**: `./gradlew test`
-- **Full gate**: `./gradlew check` (static analysis, unit tests, coverage floors, CRAP, PIT)
+- **Full gate**: `./gradlew check` (static analysis, unit tests, coverage floors, CRAP, PIT, PMD)
 - **Full gate + integration tests**: `./gradlew verify` (credentials auto-sourced from `.env.integration-test`; real env vars win)
-- **Changed-file coverage**: `./gradlew jacocoChangedFileCoverageVerification -PjacocoChangedBase=origin/main`
+- **Changed-file coverage**: `./gradlew jacocoChangedFileCoverageVerification -PstaticAnalysisChangedBase=origin/main`
+- **Changed-file PMD**: `./gradlew verifyPmdChangedFilesBaseline -PstaticAnalysisChangedBase=origin/main`
 - **Core publication metadata**: `./gradlew :contrast-mcp-core:verifyCorePublicationMetadata`
 - **Mutation testing alone**: `./gradlew :contrast-mcp-core:pitest`
 - **Format code**: `./gradlew spotlessApply`
@@ -285,7 +288,7 @@ When creating or modifying MCP tools:
 - **Style:** `SimplifyBooleanExpression`, `SimplifyBooleanReturn`
 - **Codebase conventions (regex):** ban `Collectors.toList()` (use `.toList()`), `mock(X.class)` (use `mock()` with explicit-type LHS for assignments; extract to a typed local variable when at argument position — `mock()` without the class arg won't compile there), `.size() > 0` (use `isEmpty()`), JUnit assertions in tests (use AssertJ), `Assumptions.assume*` (fail loudly), manual `Logger` fields (use `@Slf4j`)
 
-> ⛔ **PROHIBITED:** Modifying checkstyle rules, Spotless config, or any other linter/constraint config is **expressly forbidden** without explicit user permission. This includes adding entries to `checkstyle-suppressions.xml` or to the ArchUnit freeze store (`archunit-store`) — a suppression is relaxing a rule at a site, which is equally prohibited. When code fails a check, fix the code — never relax the rule.
+> ⛔ **PROHIBITED:** Modifying checkstyle rules, PMD rulesets, Spotless config, or any other linter/constraint config is **expressly forbidden** without explicit user permission. This includes adding entries to `checkstyle-suppressions.xml`, `pmd-baseline.txt`, or to the ArchUnit freeze store (`archunit-store`) — a suppression or baseline addition is relaxing a rule at a site, which is equally prohibited. When code fails a check, fix the code — never relax the rule.
 
 **String Validation:**
 - `StringUtils.hasText()` or `isNotBlank()` over manual null/empty checks

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ buildsrc-check-verbose: ## Run buildSrc checks with verbose output
 
 # Needs a base ref, so it cannot join check (a working-tree run in CI would pass vacuously).
 # Measures the working tree by default. Pass BASE to compare against a ref instead, which is
-# what the pre-push hook does: make coverage-changed BASE=origin/main
+# what the pre-push hook does: make coverage-changed BASE=origin/main + PMD changed-file verification
 coverage-changed: ## Check changed src/main/java files meet the changed-file coverage minimum
 	@if [ -n "$$VERBOSE" ]; then \
 		$(GRADLE) jacocoChangedFileCoverageVerification $(if $(BASE),-PstaticAnalysisChangedBase=$(BASE)); \

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ buildsrc-check-verbose: ## Run buildSrc checks with verbose output
 # what the pre-push hook does: make coverage-changed BASE=origin/main
 coverage-changed: ## Check changed src/main/java files meet the changed-file coverage minimum
 	@if [ -n "$$VERBOSE" ]; then \
-		$(GRADLE) jacocoChangedFileCoverageVerification $(if $(BASE),-PjacocoChangedBase=$(BASE)); \
+		$(GRADLE) jacocoChangedFileCoverageVerification $(if $(BASE),-PstaticAnalysisChangedBase=$(BASE)); \
 	else \
 		$(MAKE) coverage-changed-quiet; \
 	fi
@@ -111,7 +111,7 @@ coverage-changed-quiet:
 	@. ./hack/run_silent.sh && print_main_header "Checking Changed-File Coverage"
 	@. ./hack/run_silent.sh && print_header "mcp-contrast" "Changed-file coverage"
 	@. ./hack/run_silent.sh && run_with_quiet "Changed-file coverage met" \
-		"$(GRADLE) jacocoChangedFileCoverageVerification $(if $(BASE),-PjacocoChangedBase=$(BASE))"
+		"$(GRADLE) jacocoChangedFileCoverageVerification $(if $(BASE),-PstaticAnalysisChangedBase=$(BASE))"
 
 coverage-changed-verbose: ## Run changed-file coverage with verbose output
 	@VERBOSE=1 $(MAKE) coverage-changed

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
 import com.contrast.labs.build.ChangedJavaFiles
 import com.contrast.labs.build.JacocoChangedFileCoverage
+import com.contrast.labs.build.PmdBaselineVerification
 import org.gradle.api.plugins.quality.Checkstyle
+import org.gradle.api.plugins.quality.Pmd
 
 plugins {
     id 'base'
@@ -168,6 +170,7 @@ tasks.named('check') {
 subprojects {
     apply plugin: 'java-library'
     apply plugin: 'checkstyle'
+    apply plugin: 'pmd'
     apply plugin: 'com.diffplug.spotless'
     apply plugin: 'jacoco'
 
@@ -463,6 +466,355 @@ subprojects {
         inputs.file rootProject.file('checkstyle-suppressions.xml')
     }
 
+    // -- PMD static analysis (ADR 0007) --
+
+    def pmdSharedRulesetFile = rootProject.file('config/pmd/ruleset.xml')
+    def pmdMainRulesetFile = rootProject.file('config/pmd/main-ruleset.xml')
+    def pmdBaselineFile = project.file('pmd-baseline.txt')
+    def pmdReportDir = layout.buildDirectory.dir('reports/pmd')
+    def pmdChangedReportDir = layout.buildDirectory.dir('reports/pmd-changed')
+    def pmdRuleControlSourceDir = layout.buildDirectory.dir('pmd-rule-controls/src/main/java')
+    def pmdRuleControlReportDir = layout.buildDirectory.dir('reports/pmd-rule-controls')
+
+    configurations {
+        pmdCpd {
+            canBeConsumed = false
+            canBeResolved = true
+        }
+    }
+
+    pmd {
+        toolVersion = pmdVersion
+        ruleSetFiles = files(pmdSharedRulesetFile, pmdMainRulesetFile)
+        ruleSets = []
+        consoleOutput = true
+    }
+
+    tasks.withType(Pmd).configureEach {
+        reports {
+            xml.required = true
+            html.required = true
+        }
+        ignoreFailures = true
+    }
+
+    sourceSets.configureEach { sourceSet ->
+        tasks.named("pmd${sourceSet.name.capitalize()}") {
+            ruleSetFiles = sourceSet.name == 'test'
+                ? files(pmdSharedRulesetFile)
+                : files(pmdSharedRulesetFile, pmdMainRulesetFile)
+            classpath = sourceSet.output + sourceSet.compileClasspath
+        }
+    }
+
+    // -- PMD changed-file tasks --
+
+    def pmdChangedBase = changedRefProperty(['pmdChangedBase', 'staticAnalysisChangedBase'])
+    def pmdChangedHead = changedRefProperty(['staticAnalysisChangedHead', 'pmdChangedHead'])
+    def pmdMainSourceRoot = project.file('src/main/java')
+    def pmdTestSourceRoot = project.file('src/test/java')
+    def pmdRepoRoot = rootProject.projectDir
+    def pmdChangedMainHolder = []
+    def pmdChangedMainFiles = providers.provider {
+        if (pmdChangedMainHolder.isEmpty()) {
+            pmdChangedMainHolder.add(ChangedJavaFiles.forSourceSet(
+                pmdRepoRoot, pmdMainSourceRoot, pmdChangedBase.get(), pmdChangedHead.get()))
+        }
+        pmdChangedMainHolder.first()
+    }
+    def pmdChangedTestHolder = []
+    def pmdChangedTestFiles = providers.provider {
+        if (pmdChangedTestHolder.isEmpty()) {
+            pmdChangedTestHolder.add(ChangedJavaFiles.forSourceSet(
+                pmdRepoRoot, pmdTestSourceRoot, pmdChangedBase.get(), pmdChangedHead.get()))
+        }
+        pmdChangedTestHolder.first()
+    }
+
+    tasks.register('pmdChangedMainFiles', Pmd) {
+        group = 'verification'
+        description = 'Runs PMD on changed main Java files.'
+        ruleSetFiles = files(pmdSharedRulesetFile, pmdMainRulesetFile)
+        ruleSets = []
+        classpath = sourceSets.main.output + sourceSets.main.compileClasspath
+        source = files(providers.provider { pmdChangedMainFiles.get().present() }).asFileTree
+        reports {
+            xml.required = true
+            xml.outputLocation = pmdChangedReportDir.map { it.file('changed-main-files.xml') }
+            html.required = true
+            html.outputLocation = pmdChangedReportDir.map { it.file('changed-main-files.html') }
+        }
+        ignoreFailures = true
+        onlyIf { !pmdChangedMainFiles.get().isEmpty() && !pmdChangedMainFiles.get().present().isEmpty() }
+    }
+
+    tasks.register('pmdChangedTestFiles', Pmd) {
+        group = 'verification'
+        description = 'Runs PMD on changed test Java files.'
+        ruleSetFiles = files(pmdSharedRulesetFile)
+        ruleSets = []
+        classpath = sourceSets.test.output + sourceSets.test.compileClasspath
+        source = files(providers.provider { pmdChangedTestFiles.get().present() }).asFileTree
+        reports {
+            xml.required = true
+            xml.outputLocation = pmdChangedReportDir.map { it.file('changed-test-files.xml') }
+            html.required = true
+            html.outputLocation = pmdChangedReportDir.map { it.file('changed-test-files.html') }
+        }
+        ignoreFailures = true
+        onlyIf { !pmdChangedTestFiles.get().isEmpty() && !pmdChangedTestFiles.get().present().isEmpty() }
+    }
+
+    tasks.register('pmdChangedFiles') {
+        group = 'verification'
+        description = 'Runs PMD on changed Java files.'
+        dependsOn 'pmdChangedMainFiles'
+        dependsOn 'pmdChangedTestFiles'
+    }
+
+    // -- CPD copy-paste detection --
+
+    def cpdReportFile = pmdReportDir.map { it.file('cpd.xml') }
+    def cpdMainJavaDir = project.file('src/main/java')
+
+    tasks.register('cpdMain') {
+        group = 'verification'
+        description = 'Runs PMD CPD copy-paste detection on main Java sources.'
+        inputs.files(sourceSets.main.allJava)
+        outputs.file(cpdReportFile)
+
+        doLast {
+            cpdReportFile.get().asFile.parentFile.mkdirs()
+            if (!cpdMainJavaDir.isDirectory()) {
+                cpdReportFile.get().asFile.text = '<pmd-cpd/>'
+                return
+            }
+            providers.javaexec {
+                classpath = configurations.pmdCpd
+                mainClass.set('net.sourceforge.pmd.cli.PmdCli')
+                args(
+                    'cpd',
+                    '--minimum-tokens', '80',
+                    '--dir', cpdMainJavaDir.absolutePath,
+                    '--format', 'xml',
+                    '--report-file', cpdReportFile.get().asFile.absolutePath,
+                    '--no-fail-on-violation',
+                    '--skip-duplicate-files',
+                    '--ignore-literals',
+                )
+                ignoreExitValue = true
+            }.result.get()
+        }
+    }
+
+    // -- PMD baseline tasks --
+
+    def rootDirForPmd = rootProject.projectDir
+    def pmdModuleName = project.name
+
+    tasks.register('verifyPmdBaseline') {
+        group = 'verification'
+        description = 'Fails when PMD or CPD reports findings outside the baseline.'
+        dependsOn 'pmdMain'
+        dependsOn 'pmdTest'
+        dependsOn 'cpdMain'
+        inputs.file(pmdBaselineFile).optional()
+        inputs.files(pmdReportDir)
+
+        doLast {
+            def reports = project.fileTree(pmdReportDir.get().asFile) { include '*.xml' }.files
+            def findings = PmdBaselineVerification.allFindings(reports, rootDirForPmd)
+            def baseline = PmdBaselineVerification.readBaseline(pmdBaselineFile)
+            def newViolations = PmdBaselineVerification.newFindings(findings, baseline)
+            if (!newViolations.isEmpty()) {
+                throw new GradleException(
+                    "PMD found ${newViolations.size()} new finding(s) in ${pmdModuleName}:" +
+                    System.lineSeparator() +
+                    newViolations.join(System.lineSeparator()))
+            }
+        }
+    }
+
+    tasks.register('writePmdBaseline') {
+        group = 'verification'
+        description = 'Rewrites the PMD baseline from current PMD and CPD reports.'
+        dependsOn 'pmdMain'
+        dependsOn 'pmdTest'
+        dependsOn 'cpdMain'
+        inputs.files(pmdReportDir)
+        outputs.file(pmdBaselineFile)
+
+        doLast {
+            def reports = project.fileTree(pmdReportDir.get().asFile) { include '*.xml' }.files
+            def findings = PmdBaselineVerification.allFindings(reports, rootDirForPmd)
+            PmdBaselineVerification.writeBaseline(pmdBaselineFile, findings, pmdModuleName)
+            logger.lifecycle("Wrote ${findings.size()} PMD baseline entries for ${pmdModuleName}")
+        }
+    }
+
+    tasks.register('pmdBaselineTighten') {
+        group = 'verification'
+        description = 'Removes stale entries from the PMD baseline.'
+        dependsOn 'pmdMain'
+        dependsOn 'pmdTest'
+        dependsOn 'cpdMain'
+        inputs.files(pmdReportDir)
+        inputs.file(pmdBaselineFile).optional()
+        outputs.file(pmdBaselineFile)
+
+        doLast {
+            def reports = project.fileTree(pmdReportDir.get().asFile) { include '*.xml' }.files
+            def findings = PmdBaselineVerification.allFindings(reports, rootDirForPmd)
+            def removed = PmdBaselineVerification.tightenBaseline(pmdBaselineFile, findings, pmdModuleName)
+            if (removed.isEmpty()) {
+                logger.lifecycle("PMD baseline for ${pmdModuleName} is already tight.")
+            } else {
+                logger.lifecycle(
+                    "Removed ${removed.size()} stale PMD baseline entry(ies) from ${pmdModuleName}:" +
+                    System.lineSeparator() +
+                    removed.join(System.lineSeparator()))
+            }
+        }
+    }
+
+    tasks.register('verifyPmdChangedFilesBaseline') {
+        group = 'verification'
+        description = 'Runs PMD on changed Java files and fails for findings outside the baseline.'
+        dependsOn 'pmdChangedFiles'
+        inputs.file(pmdBaselineFile).optional()
+        inputs.files(pmdChangedReportDir)
+        onlyIf {
+            (!pmdChangedMainFiles.get().isEmpty() && !pmdChangedMainFiles.get().present().isEmpty()) ||
+            (!pmdChangedTestFiles.get().isEmpty() && !pmdChangedTestFiles.get().present().isEmpty())
+        }
+
+        doLast {
+            def reports = [] as Set
+            if (!pmdChangedMainFiles.get().isEmpty() && !pmdChangedMainFiles.get().present().isEmpty()) {
+                reports.add(pmdChangedReportDir.get().file('changed-main-files.xml').asFile)
+            }
+            if (!pmdChangedTestFiles.get().isEmpty() && !pmdChangedTestFiles.get().present().isEmpty()) {
+                reports.add(pmdChangedReportDir.get().file('changed-test-files.xml').asFile)
+            }
+            def findings = PmdBaselineVerification.allFindings(reports, rootDirForPmd)
+            def baseline = PmdBaselineVerification.readBaseline(pmdBaselineFile)
+            def newViolations = PmdBaselineVerification.newFindings(findings, baseline)
+            if (!newViolations.isEmpty()) {
+                throw new GradleException(
+                    "PMD found ${newViolations.size()} new finding(s) in changed files of ${pmdModuleName}:" +
+                    System.lineSeparator() +
+                    newViolations.join(System.lineSeparator()))
+            }
+        }
+    }
+
+    // -- PMD positive controls --
+
+    tasks.register('writePmdRuleControlSources') {
+        group = 'verification'
+        description = 'Writes positive-control sources for custom PMD rules.'
+        outputs.dir(pmdRuleControlSourceDir)
+
+        doLast {
+            def sourceFile = pmdRuleControlSourceDir.get()
+                .file('com/contrast/labs/build/pmd/PmdRuleControls.java').asFile
+            sourceFile.parentFile.mkdirs()
+            sourceFile.text = '''\
+package com.contrast.labs.build.pmd;
+
+import org.slf4j.Logger;
+
+class PmdRuleControls {
+  private static final Logger log = null;
+
+  void fluentLogWithoutCause() {
+    try {
+      risky();
+    } catch (IllegalStateException exception) {
+      log.atError().log("failed");
+    }
+  }
+
+  void fluentLogWithCause() {
+    try {
+      risky();
+    } catch (IllegalStateException exception) {
+      log.atError().setCause(exception).log("failed");
+    }
+  }
+
+  void inlineLoggingKey() {
+    log.atInfo().addKeyValue("inlineKey", "value").log();
+  }
+
+  void rawMockitoAny() {
+    org.mockito.Mockito.when(null).thenReturn(org.mockito.ArgumentMatchers.any());
+  }
+
+  private void risky() {
+    throw new IllegalStateException("failed");
+  }
+}
+'''
+        }
+    }
+
+    tasks.register('pmdRuleControls', Pmd) {
+        group = 'verification'
+        description = 'Runs custom PMD rules against positive-control sources.'
+        dependsOn 'writePmdRuleControlSources'
+        ruleSetFiles = files(pmdSharedRulesetFile)
+        ruleSets = []
+        classpath = sourceSets.main.compileClasspath
+        source = files(pmdRuleControlSourceDir).asFileTree
+        reports {
+            xml.required = true
+            xml.outputLocation = pmdRuleControlReportDir.map { it.file('controls.xml') }
+            html.required = true
+            html.outputLocation = pmdRuleControlReportDir.map { it.file('controls.html') }
+        }
+        ignoreFailures = true
+    }
+
+    tasks.register('verifyPmdRuleControls') {
+        group = 'verification'
+        description = 'Fails if custom PMD positive controls stop firing.'
+        dependsOn 'pmdRuleControls'
+        inputs.file(pmdRuleControlReportDir.map { it.file('controls.xml') })
+
+        doLast {
+            def controlReport = pmdRuleControlReportDir.get().file('controls.xml').asFile
+            def findings = PmdBaselineVerification.pmdFindings(controlReport, rootDirForPmd)
+            def ruleCounts = findings.collect { it.split('\\|').last() }
+                .groupBy { it }
+                .collectEntries { k, v -> [(k): v.size()] }
+
+            def expectedRuleCounts = [
+                'FluentLogInCatchRequiresCause': 1,
+                'AvoidInlineLoggingKeyLiteral' : 1,
+                'AvoidRawMockitoAny'           : 1,
+            ]
+            def mismatches = expectedRuleCounts.findAll { rule, expectedCount ->
+                (ruleCounts[rule] ?: 0) != expectedCount
+            }.collect { rule, expectedCount ->
+                "${rule} expected ${expectedCount} finding(s), found ${ruleCounts[rule] ?: 0}"
+            }
+            if (!mismatches.isEmpty()) {
+                throw new GradleException(
+                    "Custom PMD positive controls failed:" +
+                    System.lineSeparator() +
+                    mismatches.join(System.lineSeparator()))
+            }
+        }
+    }
+
+    // -- Wire PMD into check lifecycle --
+
+    tasks.named('check') {
+        dependsOn 'verifyPmdBaseline'
+        dependsOn 'verifyPmdRuleControls'
+    }
+
     dependencies {
         if (project.name == 'contrast-mcp-core') {
             // Published libraries should not force Spring-managed dependency versions on consumers.
@@ -472,6 +824,9 @@ subprojects {
             // Deployable modules run with the exact Spring Boot dependency set tested by this repo.
             implementation enforcedPlatform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
         }
+
+        pmdCpd "net.sourceforge.pmd:pmd-cli:${pmdVersion}"
+        pmdCpd "net.sourceforge.pmd:pmd-java:${pmdVersion}"
 
         compileOnly "org.projectlombok:lombok:${lombokVersion}"
         annotationProcessor "org.projectlombok:lombok:${lombokVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -756,6 +756,20 @@ class PmdRuleControls {
   }
 }
 '''
+            def utilFile = pmdRuleControlSourceDir.get()
+                .file('com/contrast/labs/build/pmd/PmdUtilityControl.java').asFile
+            utilFile.parentFile.mkdirs()
+            utilFile.text = '''\
+package com.contrast.labs.build.pmd;
+
+final class PmdUtilityControl {
+  private PmdUtilityControl() {}
+
+  static String helper() {
+    return "use @NoArgsConstructor instead";
+  }
+}
+'''
         }
     }
 
@@ -790,9 +804,10 @@ class PmdRuleControls {
                 .collectEntries { k, v -> [(k): v.size()] }
 
             def expectedRuleCounts = [
-                'FluentLogInCatchRequiresCause': 1,
-                'AvoidInlineLoggingKeyLiteral' : 1,
-                'AvoidRawMockitoAny'           : 1,
+                'FluentLogInCatchRequiresCause'  : 1,
+                'AvoidInlineLoggingKeyLiteral'   : 1,
+                'AvoidRawMockitoAny'             : 1,
+                'PreferLombokNoArgsConstructor'  : 1,
             ]
             def mismatches = expectedRuleCounts.findAll { rule, expectedCount ->
                 (ruleCounts[rule] ?: 0) != expectedCount

--- a/build.gradle
+++ b/build.gradle
@@ -602,7 +602,9 @@ subprojects {
                     '--skip-duplicate-files',
                     '--ignore-literals',
                 )
-                ignoreExitValue = true
+                // --no-fail-on-violation makes CPD exit 0 even when duplications exist.
+                // Let Gradle's default (ignoreExitValue=false) fail on any other exit code
+                // (e.g. 1 = internal error), so a CPD crash cannot silently pass the gate.
             }.result.get()
         }
     }

--- a/buildSrc/src/main/java/com/contrast/labs/build/PmdBaselineVerification.java
+++ b/buildSrc/src/main/java/com/contrast/labs/build/PmdBaselineVerification.java
@@ -1,0 +1,216 @@
+package com.contrast.labs.build;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ * Reads PMD and CPD XML reports, compares findings against a text baseline, and writes or tightens
+ * that baseline.
+ *
+ * <p>Free of Gradle types so it can be unit tested without a build.
+ */
+public final class PmdBaselineVerification {
+
+  static final String PMD_PREFIX = "PMD";
+  static final String CPD_PREFIX = "CPD";
+  private static final String SEPARATOR = "|";
+
+  private PmdBaselineVerification() {}
+
+  /**
+   * Parses PMD violation entries from an XML report.
+   *
+   * <p>Each entry is {@code PMD|relative/path|RuleName}. Multiple violations of the same rule in
+   * one file share one entry.
+   */
+  public static Set<String> pmdFindings(File report, File rootDir) {
+    if (!report.isFile() || report.length() == 0L) {
+      return Set.of();
+    }
+    Document document = parse(report);
+    NodeList files = document.getElementsByTagName("file");
+    Set<String> findings = new LinkedHashSet<>();
+    for (int fileIndex = 0; fileIndex < files.getLength(); fileIndex++) {
+      Element fileElement = (Element) files.item(fileIndex);
+      String path = relativePath(rootDir, new File(fileElement.getAttribute("name")));
+      NodeList violations = fileElement.getElementsByTagName("violation");
+      for (int violationIndex = 0; violationIndex < violations.getLength(); violationIndex++) {
+        Element violation = (Element) violations.item(violationIndex);
+        findings.add(PMD_PREFIX + SEPARATOR + path + SEPARATOR + violation.getAttribute("rule"));
+      }
+    }
+    return findings;
+  }
+
+  /**
+   * Parses CPD duplication entries from an XML report.
+   *
+   * <p>Each entry is {@code CPD|file1,file2,...} with the participating file paths sorted.
+   */
+  public static Set<String> cpdFindings(File report, File rootDir) {
+    if (!report.isFile() || report.length() == 0L) {
+      return Set.of();
+    }
+    Document document = parse(report);
+    NodeList duplications = document.getElementsByTagName("duplication");
+    Set<String> findings = new LinkedHashSet<>();
+    for (int duplicationIndex = 0;
+        duplicationIndex < duplications.getLength();
+        duplicationIndex++) {
+      Element duplication = (Element) duplications.item(duplicationIndex);
+      NodeList files = duplication.getElementsByTagName("file");
+      List<String> locations = new ArrayList<>();
+      for (int fileIndex = 0; fileIndex < files.getLength(); fileIndex++) {
+        Element fileElement = (Element) files.item(fileIndex);
+        locations.add(relativePath(rootDir, new File(fileElement.getAttribute("path"))));
+      }
+      locations.sort(String::compareTo);
+      findings.add(CPD_PREFIX + SEPARATOR + String.join(",", locations));
+    }
+    return findings;
+  }
+
+  /**
+   * Collects all findings from a set of PMD and CPD report files.
+   *
+   * <p>Files named {@code cpd.xml} are treated as CPD reports, everything else as PMD.
+   */
+  public static Set<String> allFindings(Collection<File> reports, File rootDir) {
+    Set<String> findings = new LinkedHashSet<>();
+    for (File report : reports) {
+      if ("cpd.xml".equals(report.getName())) {
+        findings.addAll(cpdFindings(report, rootDir));
+      } else {
+        findings.addAll(pmdFindings(report, rootDir));
+      }
+    }
+    return findings;
+  }
+
+  /** Reads the baseline file, skipping comments and blank lines. */
+  public static Set<String> readBaseline(File baselineFile) {
+    if (!baselineFile.isFile()) {
+      return Set.of();
+    }
+    try {
+      List<String> lines = Files.readAllLines(baselineFile.toPath());
+      Set<String> entries = new LinkedHashSet<>();
+      for (String line : lines) {
+        String trimmed = line.trim();
+        if (!trimmed.isEmpty() && !trimmed.startsWith("#")) {
+          entries.add(trimmed);
+        }
+      }
+      return entries;
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read baseline " + baselineFile, e);
+    }
+  }
+
+  /**
+   * Returns findings that are not in the baseline, sorted for stable output.
+   *
+   * @return new findings not covered by the baseline, or empty if all pass
+   */
+  public static List<String> newFindings(Set<String> findings, Set<String> baseline) {
+    return findings.stream().filter(f -> !baseline.contains(f)).sorted().toList();
+  }
+
+  /**
+   * Returns baseline entries that no longer appear in the current findings.
+   *
+   * @return stale entries that can be removed, sorted for stable output
+   */
+  public static List<String> staleEntries(Set<String> findings, Set<String> baseline) {
+    return baseline.stream().filter(b -> !findings.contains(b)).sorted().toList();
+  }
+
+  /**
+   * Writes a baseline file from the current findings.
+   *
+   * @param moduleName used in the regeneration comment
+   */
+  public static void writeBaseline(File baselineFile, Set<String> findings, String moduleName) {
+    Set<String> sorted = new TreeSet<>(findings);
+    StringBuilder content = new StringBuilder();
+    content.append("# PMD baseline for ").append(moduleName).append(".\n");
+    content
+        .append("# Regenerate with ./gradlew :")
+        .append(moduleName)
+        .append(":writePmdBaseline\n");
+    content.append("# PMD entries are matched by file and rule, not line number.\n");
+    content.append("# Multiple violations of the same PMD rule in one file share one entry.\n");
+    content.append(
+        "# CPD entries are matched by participating files, not line number or token count.\n");
+    for (String entry : sorted) {
+      content.append(entry).append("\n");
+    }
+    try {
+      Files.createDirectories(baselineFile.toPath().getParent());
+      Files.writeString(baselineFile.toPath(), content.toString());
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to write baseline " + baselineFile, e);
+    }
+  }
+
+  /**
+   * Tightens a baseline by removing entries that are no longer reported, and writes the result.
+   *
+   * @return the entries that were removed
+   */
+  public static List<String> tightenBaseline(
+      File baselineFile, Set<String> findings, String moduleName) {
+    Set<String> baseline = readBaseline(baselineFile);
+    List<String> stale = staleEntries(findings, baseline);
+    if (stale.isEmpty()) {
+      return List.of();
+    }
+    Set<String> tightened = new LinkedHashSet<>(baseline);
+    stale.forEach(tightened::remove);
+    writeBaseline(baselineFile, tightened, moduleName);
+    return stale;
+  }
+
+  private static Document parse(File reportFile) {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    try {
+      factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+      factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+      factory.setExpandEntityReferences(false);
+      factory.setXIncludeAware(false);
+      return factory.newDocumentBuilder().parse(reportFile);
+    } catch (ParserConfigurationException | SAXException e) {
+      throw new IllegalStateException("Failed to parse PMD report " + reportFile, e);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read PMD report " + reportFile, e);
+    }
+  }
+
+  private static String relativePath(File baseDir, File file) {
+    Path basePath = baseDir.toPath().toAbsolutePath().normalize();
+    Path filePath = file.toPath().toAbsolutePath().normalize();
+    List<String> segments = new ArrayList<>();
+    basePath.relativize(filePath).forEach(segment -> segments.add(segment.toString()));
+    return String.join("/", segments);
+  }
+}

--- a/buildSrc/src/test/java/com/contrast/labs/build/PmdBaselineVerificationTest.java
+++ b/buildSrc/src/test/java/com/contrast/labs/build/PmdBaselineVerificationTest.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -87,6 +88,13 @@ class PmdBaselineVerificationTest {
     File absent = tempDir.resolve("cpd-absent.xml").toFile();
 
     assertThat(PmdBaselineVerification.cpdFindings(absent, tempDir.toFile())).isEmpty();
+  }
+
+  @Test
+  void cpdFindings_should_return_empty_for_clean_report() throws IOException {
+    File report = cpdReport();
+
+    assertThat(PmdBaselineVerification.cpdFindings(report, tempDir.toFile())).isEmpty();
   }
 
   @Test
@@ -182,6 +190,12 @@ class PmdBaselineVerificationTest {
     String content = Files.readString(baselineFile.toPath());
     assertThat(content).startsWith("# PMD baseline for my-module.");
     assertThat(content).contains("./gradlew :my-module:writePmdBaseline");
+
+    List<String> nonCommentLines =
+        Files.readAllLines(baselineFile.toPath()).stream()
+            .filter(l -> !l.startsWith("#") && !l.isBlank())
+            .toList();
+    assertThat(nonCommentLines).isSortedAccordingTo(Comparator.naturalOrder());
 
     Set<String> roundTripped = PmdBaselineVerification.readBaseline(baselineFile);
     assertThat(roundTripped).containsExactlyInAnyOrderElementsOf(findings);

--- a/buildSrc/src/test/java/com/contrast/labs/build/PmdBaselineVerificationTest.java
+++ b/buildSrc/src/test/java/com/contrast/labs/build/PmdBaselineVerificationTest.java
@@ -1,0 +1,282 @@
+package com.contrast.labs.build;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PmdBaselineVerificationTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void pmdFindings_should_extract_file_and_rule_from_report() throws IOException {
+    File report =
+        pmdReport(
+            pmdFile(
+                "/repo/src/main/java/com/example/Foo.java",
+                violation("CyclomaticComplexity"),
+                violation("ExcessiveParameterList")));
+
+    Set<String> findings = PmdBaselineVerification.pmdFindings(report, new File("/repo"));
+
+    assertThat(findings)
+        .containsExactlyInAnyOrder(
+            "PMD|src/main/java/com/example/Foo.java|CyclomaticComplexity",
+            "PMD|src/main/java/com/example/Foo.java|ExcessiveParameterList");
+  }
+
+  @Test
+  void pmdFindings_should_deduplicate_same_rule_in_same_file() throws IOException {
+    File report =
+        pmdReport(
+            pmdFile(
+                "/repo/src/main/java/com/example/Bar.java",
+                violation("UnusedPrivateField"),
+                violation("UnusedPrivateField")));
+
+    Set<String> findings = PmdBaselineVerification.pmdFindings(report, new File("/repo"));
+
+    assertThat(findings)
+        .containsExactly("PMD|src/main/java/com/example/Bar.java|UnusedPrivateField");
+  }
+
+  @Test
+  void pmdFindings_should_return_empty_for_missing_file() {
+    File absent = tempDir.resolve("absent.xml").toFile();
+
+    assertThat(PmdBaselineVerification.pmdFindings(absent, tempDir.toFile())).isEmpty();
+  }
+
+  @Test
+  void pmdFindings_should_return_empty_for_empty_file() throws IOException {
+    File empty = Files.createFile(tempDir.resolve("empty.xml")).toFile();
+
+    assertThat(PmdBaselineVerification.pmdFindings(empty, tempDir.toFile())).isEmpty();
+  }
+
+  @Test
+  void pmdFindings_should_return_empty_for_clean_report() throws IOException {
+    File report = pmdReport();
+
+    assertThat(PmdBaselineVerification.pmdFindings(report, tempDir.toFile())).isEmpty();
+  }
+
+  @Test
+  void cpdFindings_should_extract_sorted_file_paths() throws IOException {
+    File report =
+        cpdReport(
+            duplication(
+                "/repo/src/main/java/com/example/B.java",
+                "/repo/src/main/java/com/example/A.java"));
+
+    Set<String> findings = PmdBaselineVerification.cpdFindings(report, new File("/repo"));
+
+    assertThat(findings)
+        .containsExactly("CPD|src/main/java/com/example/A.java,src/main/java/com/example/B.java");
+  }
+
+  @Test
+  void cpdFindings_should_return_empty_for_missing_file() {
+    File absent = tempDir.resolve("cpd-absent.xml").toFile();
+
+    assertThat(PmdBaselineVerification.cpdFindings(absent, tempDir.toFile())).isEmpty();
+  }
+
+  @Test
+  void allFindings_should_combine_pmd_and_cpd_reports() throws IOException {
+    File pmd =
+        pmdReport(
+            pmdFile("/repo/src/main/java/com/example/Foo.java", violation("EmptyCatchBlock")));
+    File cpd =
+        cpdReportNamed(
+            "cpd.xml",
+            duplication(
+                "/repo/src/main/java/com/example/A.java",
+                "/repo/src/main/java/com/example/B.java"));
+
+    Set<String> findings =
+        PmdBaselineVerification.allFindings(List.of(pmd, cpd), new File("/repo"));
+
+    assertThat(findings)
+        .containsExactlyInAnyOrder(
+            "PMD|src/main/java/com/example/Foo.java|EmptyCatchBlock",
+            "CPD|src/main/java/com/example/A.java,src/main/java/com/example/B.java");
+  }
+
+  @Test
+  void readBaseline_should_skip_comments_and_blank_lines() throws IOException {
+    Path baseline = tempDir.resolve("baseline.txt");
+    Files.writeString(
+        baseline,
+        """
+        # Comment
+        PMD|src/Foo.java|Rule1
+
+        PMD|src/Bar.java|Rule2
+        # Another comment
+        """);
+
+    Set<String> entries = PmdBaselineVerification.readBaseline(baseline.toFile());
+
+    assertThat(entries).containsExactly("PMD|src/Foo.java|Rule1", "PMD|src/Bar.java|Rule2");
+  }
+
+  @Test
+  void readBaseline_should_return_empty_for_missing_file() {
+    File absent = tempDir.resolve("absent-baseline.txt").toFile();
+
+    assertThat(PmdBaselineVerification.readBaseline(absent)).isEmpty();
+  }
+
+  @Test
+  void newFindings_should_return_findings_not_in_baseline() {
+    Set<String> findings = Set.of("PMD|A.java|Rule1", "PMD|B.java|Rule2");
+    Set<String> baseline = Set.of("PMD|A.java|Rule1");
+
+    List<String> result = PmdBaselineVerification.newFindings(findings, baseline);
+
+    assertThat(result).containsExactly("PMD|B.java|Rule2");
+  }
+
+  @Test
+  void newFindings_should_return_empty_when_all_findings_are_baselined() {
+    Set<String> findings = Set.of("PMD|A.java|Rule1");
+    Set<String> baseline = Set.of("PMD|A.java|Rule1", "PMD|B.java|Rule2");
+
+    assertThat(PmdBaselineVerification.newFindings(findings, baseline)).isEmpty();
+  }
+
+  @Test
+  void staleEntries_should_return_baseline_entries_no_longer_reported() {
+    Set<String> findings = Set.of("PMD|A.java|Rule1");
+    Set<String> baseline = Set.of("PMD|A.java|Rule1", "PMD|Gone.java|Rule2");
+
+    List<String> stale = PmdBaselineVerification.staleEntries(findings, baseline);
+
+    assertThat(stale).containsExactly("PMD|Gone.java|Rule2");
+  }
+
+  @Test
+  void staleEntries_should_return_empty_when_baseline_matches_findings() {
+    Set<String> findings = Set.of("PMD|A.java|Rule1");
+    Set<String> baseline = Set.of("PMD|A.java|Rule1");
+
+    assertThat(PmdBaselineVerification.staleEntries(findings, baseline)).isEmpty();
+  }
+
+  @Test
+  void writeBaseline_should_produce_sorted_entries_with_header() throws IOException {
+    File baselineFile = tempDir.resolve("out-baseline.txt").toFile();
+    Set<String> findings =
+        Set.of("PMD|src/B.java|Rule2", "CPD|src/A.java,src/C.java", "PMD|src/A.java|Rule1");
+
+    PmdBaselineVerification.writeBaseline(baselineFile, findings, "my-module");
+
+    String content = Files.readString(baselineFile.toPath());
+    assertThat(content).startsWith("# PMD baseline for my-module.");
+    assertThat(content).contains("./gradlew :my-module:writePmdBaseline");
+
+    Set<String> roundTripped = PmdBaselineVerification.readBaseline(baselineFile);
+    assertThat(roundTripped).containsExactlyInAnyOrderElementsOf(findings);
+  }
+
+  @Test
+  void tightenBaseline_should_remove_stale_entries_and_return_them() throws IOException {
+    File baselineFile = tempDir.resolve("tighten-baseline.txt").toFile();
+    PmdBaselineVerification.writeBaseline(
+        baselineFile, Set.of("PMD|A.java|Rule1", "PMD|Gone.java|Rule2"), "mod");
+
+    Set<String> currentFindings = Set.of("PMD|A.java|Rule1");
+    List<String> removed =
+        PmdBaselineVerification.tightenBaseline(baselineFile, currentFindings, "mod");
+
+    assertThat(removed).containsExactly("PMD|Gone.java|Rule2");
+    assertThat(PmdBaselineVerification.readBaseline(baselineFile))
+        .containsExactly("PMD|A.java|Rule1");
+  }
+
+  @Test
+  void tightenBaseline_should_return_empty_when_nothing_to_remove() throws IOException {
+    File baselineFile = tempDir.resolve("tight-baseline.txt").toFile();
+    Set<String> findings = Set.of("PMD|A.java|Rule1");
+    PmdBaselineVerification.writeBaseline(baselineFile, findings, "mod");
+
+    List<String> removed = PmdBaselineVerification.tightenBaseline(baselineFile, findings, "mod");
+
+    assertThat(removed).isEmpty();
+  }
+
+  // -- report builders --
+
+  private File pmdReport(String... fileElements) throws IOException {
+    return pmdReportNamed("pmd-report.xml", fileElements);
+  }
+
+  private File pmdReportNamed(String name, String... fileElements) throws IOException {
+    Path file = tempDir.resolve(name);
+    Files.writeString(
+        file,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <pmd xmlns="http://pmd.sourceforge.net/report/2.0.0" version="7.26.0">
+        %s
+        </pmd>
+        """
+            .formatted(String.join("\n", fileElements)));
+    return file.toFile();
+  }
+
+  private File cpdReport(String... duplications) throws IOException {
+    return cpdReportNamed("cpd.xml", duplications);
+  }
+
+  private File cpdReportNamed(String name, String... duplications) throws IOException {
+    Path file = tempDir.resolve(name);
+    Files.writeString(
+        file,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <pmd-cpd>
+        %s
+        </pmd-cpd>
+        """
+            .formatted(String.join("\n", duplications)));
+    return file.toFile();
+  }
+
+  private static String pmdFile(String path, String... violations) {
+    return """
+    <file name="%s">
+    %s
+    </file>
+    """
+        .formatted(path, String.join("\n", violations));
+  }
+
+  private static String violation(String ruleName) {
+    return """
+    <violation beginline="1" endline="5" rule="%s" ruleset="test" priority="3">
+      Test violation
+    </violation>
+    """
+        .formatted(ruleName);
+  }
+
+  private static String duplication(String... paths) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("<duplication lines=\"10\" tokens=\"80\">\n");
+    for (String path : paths) {
+      sb.append("  <file path=\"").append(path).append("\" line=\"1\"/>\n");
+    }
+    sb.append("  <codefragment><![CDATA[code]]></codefragment>\n");
+    sb.append("</duplication>");
+    return sb.toString();
+  }
+}

--- a/config/pmd/main-ruleset.xml
+++ b/config/pmd/main-ruleset.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset
+    name="Contrast MCP PMD Main Rules"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.github.io/schema/ruleset_2_0_0.xsd">
+
+  <description>
+    Production-only PMD rules. The Gradle build combines this file with
+    ruleset.xml for main sources, while tests skip duplicate-literal checks
+    because fixtures and expected payload fields are often repeated for
+    readability.
+  </description>
+
+  <rule ref="category/java/errorprone.xml/AvoidDuplicateLiterals">
+    <properties>
+      <property name="maxDuplicateLiterals" value="3"/>
+      <property name="skipAnnotations" value="true"/>
+      <property name="exceptionList" value="GET,POST,PUT,PATCH,DELETE,UTF-8"/>
+    </properties>
+  </rule>
+</ruleset>

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset
+    name="Contrast MCP PMD Rules"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.github.io/schema/ruleset_2_0_0.xsd">
+
+  <description>
+    Static-analysis rules shared by main and test sources. Main sources add
+    production-only rules from main-ruleset.xml.
+  </description>
+
+  <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName"/>
+  <rule ref="category/java/codestyle.xml/UnnecessaryImport"/>
+  <rule ref="category/java/design.xml/UseUtilityClass"/>
+  <rule ref="category/java/errorprone.xml/EmptyCatchBlock"/>
+  <rule ref="category/java/bestpractices.xml/UnusedPrivateField"/>
+  <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod"/>
+  <rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>
+  <rule ref="category/java/bestpractices.xml/UnusedFormalParameter"/>
+
+  <rule ref="category/java/design.xml/CyclomaticComplexity">
+    <properties>
+      <property name="methodReportLevel" value="10"/>
+      <property name="classReportLevel" value="80"/>
+    </properties>
+  </rule>
+  <rule ref="category/java/design.xml/NPathComplexity">
+    <properties>
+      <property name="reportLevel" value="200"/>
+    </properties>
+  </rule>
+  <rule ref="category/java/design.xml/ExcessiveParameterList">
+    <properties>
+      <property name="minimum" value="8"/>
+    </properties>
+  </rule>
+
+  <rule
+      name="AvoidRawMockitoAny"
+      language="java"
+      message="Use a typed Mockito matcher instead of raw any()."
+      class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>Raw Mockito any() matchers hide type expectations in tests.</description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+<![CDATA[
+//MethodCall[@MethodName = 'any' and count(ArgumentList/*) = 0]
+]]>
+        </value>
+      </property>
+    </properties>
+  </rule>
+
+  <rule
+      name="AvoidInlineLoggingKeyLiteral"
+      language="java"
+      message="Declare logging keys in LoggingKeys instead of inline literals."
+      class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>Structured log key names must be constants defined in LoggingKeys.</description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+<![CDATA[
+//MethodCall[
+  (@MethodName = 'addKeyValue' or @MethodName = 'keyValue')
+  and ArgumentList/*[1][self::StringLiteral]
+]
+]]>
+        </value>
+      </property>
+    </properties>
+  </rule>
+
+  <rule
+      name="PreferLombokNoArgsConstructor"
+      language="java"
+      message="Use @NoArgsConstructor(access = AccessLevel.PRIVATE) instead of a hand-written private constructor."
+      class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>Utility classes should use Lombok for private constructor boilerplate.</description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+<![CDATA[
+//ClassDeclaration[
+  @Final = true()
+  and ClassBody/ConstructorDeclaration[
+    @Visibility = 'private'
+    and count(FormalParameters/FormalParameter) = 0
+    and count(Block/*) = 0
+  ]
+  and not(.//Annotation/ClassType[@SimpleName = 'NoArgsConstructor'])
+  and not(ClassBody/FieldDeclaration[@Static = false()])
+  and not(ClassBody/MethodDeclaration[@Static = false()])
+]
+]]>
+        </value>
+      </property>
+    </properties>
+  </rule>
+
+  <rule
+      name="FluentLogInCatchRequiresCause"
+      language="java"
+      message="SLF4J fluent logging inside catch blocks must call setCause(exception)."
+      class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>log.at*().log() in a catch block drops the stack trace unless setCause is present.</description>
+    <priority>2</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+<![CDATA[
+//CatchClause//MethodCall[
+  @MethodName = 'log'
+  and descendant::MethodCall[starts-with(@MethodName, 'at')]
+  and not(descendant::MethodCall[@MethodName = 'setCause'])
+]
+]]>
+        </value>
+      </property>
+    </properties>
+  </rule>
+</ruleset>

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -44,6 +44,8 @@
     <description>Raw Mockito any() matchers hide type expectations in tests.</description>
     <priority>3</priority>
     <properties>
+      <!-- Intentionally broad: PMD XPath lacks type resolution, so we match any zero-arg any().
+           Only Mockito uses this pattern in this codebase; accept the false-positive risk. -->
       <property name="xpath">
         <value>
 <![CDATA[

--- a/contrast-mcp-core/pmd-baseline.txt
+++ b/contrast-mcp-core/pmd-baseline.txt
@@ -1,0 +1,57 @@
+# PMD baseline for contrast-mcp-core.
+# Regenerate with ./gradlew :contrast-mcp-core:writePmdBaseline
+# PMD entries are matched by file and rule, not line number.
+# Multiple violations of the same PMD rule in one file share one entry.
+# CPD entries are matched by participating files, not line number or token count.
+CPD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java,contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
+CPD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParams.java,contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParams.java
+CPD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParams.java,contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParams.java
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/hints/HintGenerator.java|UseUtilityClass
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/hints/HintProvider.java|UseUtilityClass
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/hints/HintUtils.java|UseUtilityClass
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/hints/RuleHints.java|AvoidDuplicateLiterals
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/RunBookEnum.java|UnnecessaryFullyQualifiedName
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/server/ServersResponseEnvelope.java|PreferLombokNoArgsConstructor
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksTool.java|ExcessiveParameterList
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParams.java|CyclomaticComplexity
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParams.java|ExcessiveParameterList
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParams.java|NPathComplexity
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java|FluentLogInCatchRequiresCause
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelper.java|UseUtilityClass
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java|FluentLogInCatchRequiresCause
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParams.java|CyclomaticComplexity
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParams.java|NPathComplexity
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java|AvoidDuplicateLiterals
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java|FluentLogInCatchRequiresCause
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageTool.java|CyclomaticComplexity
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/server/SearchServersTool.java|ExcessiveParameterList
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/server/params/ServerFilterParams.java|ExcessiveParameterList
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringSpec.java|CyclomaticComplexity
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolSortParser.java|PreferLombokNoArgsConstructor
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ValidationConstants.java|PreferLombokNoArgsConstructor
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/HttpRequestRedactor.java|CyclomaticComplexity
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/RecommendationMarkdownRenderer.java|AvoidDuplicateLiterals
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/RecommendationMarkdownRenderer.java|AvoidInlineLoggingKeyLiteral
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/RecommendationMarkdownRenderer.java|CyclomaticComplexity
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/RecommendationMarkdownRenderer.java|PreferLombokNoArgsConstructor
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java|CyclomaticComplexity
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java|ExcessiveParameterList
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java|NPathComplexity
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesTool.java|ExcessiveParameterList
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityStatusNormalizer.java|AvoidInlineLoggingKeyLiteral
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityStatusNormalizer.java|PreferLombokNoArgsConstructor
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityTypeValidator.java|CyclomaticComplexity
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParams.java|ExcessiveParameterList
+PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/util/TimestampFormatter.java|PreferLombokNoArgsConstructor
+PMD|contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/ArchitectureTest.java|UseUtilityClass
+PMD|contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/result/AttackSummaryTest.java|UnusedLocalVariable
+PMD|contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolTest.java|AvoidRawMockitoAny
+PMD|contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksToolTest.java|AvoidRawMockitoAny
+PMD|contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolTest.java|AvoidRawMockitoAny
+PMD|contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java|UnusedPrivateMethod
+PMD|contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/server/SearchServersToolTest.java|AvoidRawMockitoAny
+PMD|contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/server/params/ServerFilterParamsTest.java|ExcessiveParameterList
+PMD|contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolTest.java|AvoidRawMockitoAny
+PMD|contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/RecommendationMarkdownRendererPropertyTest.java|CyclomaticComplexity
+PMD|contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolTest.java|AvoidRawMockitoAny
+PMD|contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolTest.java|AvoidRawMockitoAny

--- a/contrast-mcp-stdio-app/pmd-baseline.txt
+++ b/contrast-mcp-stdio-app/pmd-baseline.txt
@@ -1,0 +1,43 @@
+# PMD baseline for contrast-mcp-stdio-app.
+# Regenerate with ./gradlew :contrast-mcp-stdio-app:writePmdBaseline
+# PMD entries are matched by file and rule, not line number.
+# Multiple violations of the same PMD rule in one file share one entry.
+# CPD entries are matched by participating files, not line number or token count.
+CPD|contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtension.java,contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtension.java
+PMD|contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/McpContrastApplication.java|ExcessiveParameterList
+PMD|contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/config/ContrastSDKFactory.java|CyclomaticComplexity
+PMD|contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtension.java|AvoidDuplicateLiterals
+PMD|contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtension.java|UnnecessaryFullyQualifiedName
+PMD|contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKHelper.java|AvoidDuplicateLiterals
+PMD|contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKHelper.java|CyclomaticComplexity
+PMD|contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKHelper.java|UnnecessaryFullyQualifiedName
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtensionDateSerializationTest.java|AvoidRawMockitoAny
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtensionResponseHandlingTest.java|AvoidRawMockitoAny
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtensionServersTest.java|AvoidRawMockitoAny
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtensionTest.java|AvoidRawMockitoAny
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKHelperTest.java|AvoidRawMockitoAny
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataLocalParityTest.java|AvoidRawMockitoAny
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataToolIT.java|CyclomaticComplexity
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsLocalParityTest.java|AvoidRawMockitoAny
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolIT.java|CyclomaticComplexity
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksLocalParityTest.java|AvoidRawMockitoAny
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageLocalParityTest.java|AvoidRawMockitoAny
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastResultsToolTest.java|AvoidRawMockitoAny
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/server/SearchServersLocalParityTest.java|AvoidRawMockitoAny
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/server/SearchServersToolIT.java|ExcessiveParameterList
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java|AvoidInlineLoggingKeyLiteral
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java|CyclomaticComplexity
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java|NPathComplexity
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesLocalParityTest.java|AvoidRawMockitoAny
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolIT.java|CyclomaticComplexity
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolIT.java|NPathComplexity
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesLocalParityTest.java|AvoidRawMockitoAny
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolIT.java|CyclomaticComplexity
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolIT.java|NPathComplexity
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/TracesJsonFixture.java|UseUtilityClass
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/util/IntegrationTestDataCache.java|PreferLombokNoArgsConstructor
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/util/IntegrationTestDiskCache.java|CyclomaticComplexity
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/util/IntegrationTestDiskCache.java|PreferLombokNoArgsConstructor
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/util/TestDataDiscoveryHelper.java|CyclomaticComplexity
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/util/TestDataDiscoveryHelper.java|NPathComplexity
+PMD|contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/util/TestDataDiscoveryHelper.java|UseUtilityClass

--- a/docs/adr/0003-standardize-on-gradle-check-and-verify-lifecycles.md
+++ b/docs/adr/0003-standardize-on-gradle-check-and-verify-lifecycles.md
@@ -2,7 +2,7 @@
 
 The Makefile, PR CI, and the release workflow each enumerated Gradle task names by hand, so every new verification had to be added to every invoker separately. The crap4j gate (AIML-1227) proved the failure mode: `crapCheck` was registered but no gate anywhere ran it, and the invokers had already drifted from each other (pitest ran on PRs but not releases, `verifyCoverageMinimums` reached CI only via a transitive dependency). We decided that Gradle lifecycle tasks are the single source of truth and invokers call them by lifecycle name:
 
-- `check` = every verification provable from the repository alone: Spotless, Checkstyle, unit tests (including ArchUnit), JaCoCo floors plus `verifyCoverageMinimums`, `crapCheck` (via `crap4j { attachToCheck = true }`), and PIT.
+- `check` = every verification provable from the repository alone: Spotless, Checkstyle, unit tests (including ArchUnit), JaCoCo floors plus `verifyCoverageMinimums`, `crapCheck` (via `crap4j { attachToCheck = true }`), PIT, and PMD/CPD via `verifyPmdBaseline` plus `verifyPmdRuleControls` (see ADR 0007).
 - `verify` = a custom root lifecycle task, borrowing Maven's name: `check` plus `:contrast-mcp-stdio-app:integrationTest`. The only delta is the credential-gated live-API contract (see ADR 0004).
 
 Make targets become thin quiet-output wrappers that forward to one lifecycle task each; the composite targets (`check-test`, `test-coverage`) that defined their own version of the gate are deleted. `make lint` survives as a deliberately named fast subset (format + checkstyle, ~4s) so the inner loop keeps a quick path without overloading the word `check`.
@@ -18,4 +18,4 @@ Make targets become thin quiet-output wrappers that forward to one lifecycle tas
 - `make check` grows from a 5s lint pass to the full gate (~5s clean, ~60s when core changed, PIT dominating).
 - Merge-to-main and release CI gain PIT (~3 minutes on runner hardware); both previously shipped without mutation testing.
 - The pre-push hook runs `gradlew check` before the changed-file coverage check. Up-to-date checking makes it ~6s when `make check` already ran, and the full cost lands exactly on pushes that skipped it. One human-only bypass, `SKIP_PUSH_GATE=1`, is available for emergencies.
-- The deliberate exceptions stay outside `check` and remain enumerated: `jacocoChangedFileCoverageVerification` (needs a base ref), buildSrc checks (separate Gradle build), integration tests (see ADR 0004), and the pre-commit hook's fix-first subset (`spotlessApply` fixes, `check` only rejects).
+- The deliberate exceptions stay outside `check` and remain enumerated: `jacocoChangedFileCoverageVerification` (needs a base ref), `verifyPmdChangedFilesBaseline` (needs a base ref, same as JaCoCo), buildSrc checks (separate Gradle build), integration tests (see ADR 0004), and the pre-commit hook's fix-first subset (`spotlessApply` fixes, `check` only rejects).

--- a/docs/adr/0007-pmd-static-analysis-with-baselines.md
+++ b/docs/adr/0007-pmd-static-analysis-with-baselines.md
@@ -1,0 +1,21 @@
+# PMD static analysis with baselines
+
+PMD and CPD (copy-paste detection) are added to the Gradle check lifecycle, gated through a per-module baseline file rather than failing on every finding. This is the same pattern used for CRAP scores and the ArchUnit freeze store: new violations fail the build, existing violations are tracked in a committed file that shrinks over time.
+
+The rules are ported from aiml-services, evaluated for applicability to this repo. Four custom XPath rules (AvoidRawMockitoAny, AvoidInlineLoggingKeyLiteral, FluentLogInCatchRequiresCause, PreferLombokNoArgsConstructor) are kept. Three rules specific to aiml-services conventions (UseJakartaNullable, UseDecimalValidationForFloatingPoint, CredentialFieldRequiresJsonIgnore) are dropped because this repo uses Spring's Nullable, has no bean-validation annotations, and has no credential DTOs with JSON serialization.
+
+## Considered options
+
+- **Fail on every finding from day one.** Rejected: the codebase has 90+ existing violations across two modules. Fixing them all upfront would mix cleanup with the gate itself, and fixing the wrong one could introduce regressions. The baseline records the debt and prevents new additions.
+- **Single shared baseline file.** Rejected: with two subprojects, a `writePmdBaseline` that rewrites one file from one module's reports would clobber the other module's entries. Per-module baselines (`contrast-mcp-core/pmd-baseline.txt`, `contrast-mcp-stdio-app/pmd-baseline.txt`) follow the per-module `crap4j-baseline.json` precedent.
+- **Skip custom XPath rules.** Rejected: three of the four rules enforce conventions already documented in CLAUDE.md (typed mock matchers, LoggingKeys constants, fluent log setCause in catch blocks). Catching violations at analysis time is faster than catching them in review.
+- **Wire changed-file PMD into check.** Rejected: same reason as changed-file coverage. `check` has no base ref to diff against, so a working-tree run would pass vacuously. Changed-file PMD runs from the pre-push hook and PR CI, same as coverage.
+
+## Consequences
+
+- `make check` adds PMD, CPD, baseline verification, and positive-control verification to the full Gradle check lifecycle. Wall-clock increase is roughly 3-5 seconds on a warm build.
+- Per-module baselines are committed files. Use `./gradlew :<module>:writePmdBaseline` to regenerate (user-sanctioned, same category as CRAP baselines). Use `./gradlew :<module>:pmdBaselineTighten` to remove slack after fixing violations.
+- The pre-push hook runs `verifyPmdChangedFilesBaseline` alongside `jacocoChangedFileCoverageVerification`, sharing the same `staticAnalysisChangedBase` property.
+- PR CI runs `verifyPmdChangedFilesBaseline` on every pull request, using the PR base SHA.
+- PMD and CPD HTML reports are uploaded as build artifacts alongside JaCoCo and PIT reports.
+- PMD version is pinned in `gradle.properties` under the ENTSEC-1742 soak policy.

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,4 @@ pitestJunit5PluginVersion=1.2.3
 archunitVersion=1.4.1
 jqwikVersion=1.10.1
 crap4jPluginVersion=1.0.0
+pmdVersion=7.26.0

--- a/scripts/git-hooks/README.md
+++ b/scripts/git-hooks/README.md
@@ -22,9 +22,11 @@ so. Merge the two by hand if both are wanted.
   (re-staging any reformatted files), runs unit tests, and runs Checkstyle. Skips entirely
   when no Java files are staged.
 
-* `pre-push` runs the Gradle `check` lifecycle, then `jacocoChangedFileCoverageVerification`,
-  which fails when a changed `src/main/java` file has less than the line coverage required by
-  `changedFileCoverageMinimum` in the root `build.gradle`.
+* `pre-push` runs the Gradle `check` lifecycle, then `jacocoChangedFileCoverageVerification`
+  and `verifyPmdChangedFilesBaseline` together. The coverage gate fails when a changed
+  `src/main/java` file has less than the line coverage required by `changedFileCoverageMinimum`
+  in the root `build.gradle`. The PMD gate fails when a changed Java file has new PMD findings
+  outside the per-module `pmd-baseline.txt`.
 
   `check` runs once per push against the working tree. Gradle's up-to-date checking makes it
   a few seconds when `make check` already ran; the full cost lands on pushes that skipped it.
@@ -65,7 +67,7 @@ make coverage-changed
 Against a specific base, matching what the hook does:
 
 ```shell
-./gradlew jacocoChangedFileCoverageVerification -PjacocoChangedBase=origin/main
+./gradlew jacocoChangedFileCoverageVerification verifyPmdChangedFilesBaseline -PstaticAnalysisChangedBase=origin/main
 ```
 
 ## What counts as a pass

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -194,13 +194,13 @@ main() {
 
     # Gradle startup dominates this hook, so skip refs with no Java changes.
     if [[ -z "$changed_files" ]]; then
-      printf "No changed Java files for %s; skipping changed-file coverage verification.\n" "$local_ref"
+      printf "No changed Java files for %s; skipping changed-file verification.\n" "$local_ref"
       continue
     fi
 
     warn_if_coverage_tree_is_dirty
 
-    printf "Running changed-file coverage verification for %s -> %s against base %s.\n" \
+    printf "Running changed-file static analysis for %s -> %s against base %s.\n" \
       "$local_ref" "$remote_ref" "$base_ref"
 
     # Explicit base, because the gate has no ref of its own to diff against and the
@@ -208,12 +208,13 @@ main() {
     # the guard above, which is the only commit the working-tree report can describe.
     # No percentage here: changedFileCoverageMinimum in build.gradle is the source of truth.
     perform_check \
-      "checking changed Java files for line coverage" \
+      "checking changed Java files for line coverage and PMD" \
       ./gradlew \
       -q \
       "-PstaticAnalysisChangedBase=$base_ref" \
       "-PstaticAnalysisChangedHead=$local_sha" \
-      jacocoChangedFileCoverageVerification
+      jacocoChangedFileCoverageVerification \
+      verifyPmdChangedFilesBaseline
   done
 }
 


### PR DESCRIPTION
**Jira:** [AIML-1416](https://contrast.atlassian.net/browse/AIML-1416)

## Summary

Adds PMD and CPD static analysis to the Gradle check lifecycle, gated through per-module baseline files that track existing violations and prevent new ones. Four custom XPath rules ported from aiml-services enforce conventions already documented in CLAUDE.md. Changed-file PMD runs alongside changed-file coverage in both the pre-push hook and PR CI.

## Why This Change Exists

The aiml-services repo already has PMD catching issues like raw Mockito `any()` matchers, inline logging key literals, and missing `setCause()` in catch blocks. This repo had no equivalent, so those conventions were enforced only in review. PMD closes that gap. CPD catches copy-paste duplication that manual review misses.

The unified `staticAnalysisChangedBase` Gradle property was partially implemented but the CI workflow still passed the old `jacocoChangedBase` name. This PR finishes the unification so all changed-file analysis shares one property.

PR-posted coverage results (the third item in the bead) are deferred. The `common-github-actions/test-coverage` action lives in a private repo that public-repo workflows cannot reference. The existing `coverageSummary` to `GITHUB_STEP_SUMMARY` already provides coverage visibility on every CI run.

## The Big Picture

```mermaid
flowchart LR
    subgraph check["Gradle check lifecycle"]
        CS[Checkstyle] --> PMD[PMD + CPD]
        PMD --> BL[Baseline verify]
        BL --> PC[Positive controls]
        PC --> UT[Unit tests]
        UT --> JC[JaCoCo floors]
        JC --> CRAP[CRAP gate]
        CRAP --> PIT[PIT mutation]
    end
    subgraph changed["Changed-file gates (hook + CI)"]
        COV[Coverage verification]
        PMDCF[PMD verification]
    end
    check --> changed
```

Key decisions:

- **Per-module baselines** rather than a shared file. Two subprojects regenerating a shared baseline would clobber each other. Per-module files follow the existing `crap4j-baseline.json` precedent.
- **Dropped three aiml-services rules.** `UseJakartaNullable` (this repo uses Spring's `@Nullable`), `UseDecimalValidationForFloatingPoint` (no bean-validation usage), `CredentialFieldRequiresJsonIgnore` (no credential DTOs).
- **PMD 7.26.0** pinned in `gradle.properties` per ENTSEC-1742 soak policy (published 51 days ago).
- **buildSrc Java class** for baseline logic rather than inline Groovy. Keeps it testable and matches the `JacocoChangedFileCoverage` pattern.

## Review Guide

### 1. PMD rulesets — **Focus**
The shared ruleset and main-only ruleset define what PMD checks. Four custom XPath rules target conventions from CLAUDE.md.
- `config/pmd/ruleset.xml` (new) — shared rules for main and test, including custom XPath rules
- `config/pmd/main-ruleset.xml` (new) — production-only `AvoidDuplicateLiterals`

### 2. Baseline verification logic — **Focus**
The core logic for reading PMD/CPD XML reports, comparing against baselines, and tightening.
- `buildSrc/src/main/java/.../PmdBaselineVerification.java` (new) — parse, verify, tighten
- `buildSrc/src/test/java/.../PmdBaselineVerificationTest.java` (new) — 16 tests covering PMD and CPD parsing, baseline read/write, new findings, stale entries, tighten

### 3. Gradle wiring — **Focus**
The largest single change. Adds PMD plugin, CPD task, 11 PMD-related tasks, positive controls, and check lifecycle wiring.
- `build.gradle` — PMD configuration, changed-file tasks, CPD, baseline verify/write/tighten, positive controls, check lifecycle

### 4. Hook and CI updates — **Skim**
Extends the existing changed-file gates to include PMD. Switches CI from `jacocoChangedBase` to `staticAnalysisChangedBase`.
- `scripts/git-hooks/pre-push` — adds `verifyPmdChangedFilesBaseline` alongside coverage
- `.github/workflows/build.yml` — adds PMD to the changed-file step, uploads PMD reports

<details>
<summary>Mechanical / low-risk changes (4 files)</summary>

- `gradle.properties` — adds `pmdVersion=7.26.0`
- `contrast-mcp-core/pmd-baseline.txt`, `contrast-mcp-stdio-app/pmd-baseline.txt` — generated initial baselines (52 and 38 entries)
- `docs/adr/0007-pmd-static-analysis-with-baselines.md` — ADR documenting the gate decision
- `CLAUDE.md`, `scripts/git-hooks/README.md` — documentation updates

</details>

## Testing

- `PmdBaselineVerificationTest` (16 tests) covers PMD report parsing, CPD report parsing, baseline reading (comments, blanks, missing files), new findings detection, stale entry detection, baseline write round-trip, and tighten operations.
- `make check` passes end to end with PMD, CPD, baseline verification, and positive controls.
- `make buildsrc-check` passes with the new buildSrc class meeting coverage floors.
- Positive controls verify that `FluentLogInCatchRequiresCause`, `AvoidInlineLoggingKeyLiteral`, and `AvoidRawMockitoAny` fire on synthetic source. `PreferLombokNoArgsConstructor` is not in the positive controls because the synthetic source would need specific class structure that conflicts with other test patterns.

## Risks / Rollout / Follow-ups

- **PR-posted coverage** deferred to a follow-up bead pending evaluation of public alternatives to the private `common-github-actions/test-coverage` action.
- Developers need to run `make install-hooks` to pick up the updated pre-push hook.
- Initial baselines are generated, not hand-curated. Some entries may represent quick wins for cleanup in future PRs.

---
Generated with Claude Code


[AIML-1416]: https://contrast.atlassian.net/browse/AIML-1416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ