### PR TITLE
AIML-1416 Enable 38 additional PMD rules and fix surfaced violations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,8 @@ jobs:
           **/build/reports/jacoco/test/jacocoTestReport.xml
           **/build/reports/pitest/**
           **/build/reports/pmd/**
+          **/build/reports/pmd-changed/**
+          **/build/reports/pmd-rule-controls/**
         if-no-files-found: warn
         # Diagnostic output for a failed run, not a durable artifact.
         retention-days: 7

--- a/config/pmd/main-ruleset.xml
+++ b/config/pmd/main-ruleset.xml
@@ -7,9 +7,9 @@
 
   <description>
     Production-only PMD rules. The Gradle build combines this file with
-    ruleset.xml for main sources, while tests skip duplicate-literal checks
-    because fixtures and expected payload fields are often repeated for
-    readability.
+    ruleset.xml for main sources. Tests skip these rules because fixtures
+    repeat literals for readability and throw raw exceptions to stub
+    failures.
   </description>
 
   <rule ref="category/java/errorprone.xml/AvoidDuplicateLiterals">
@@ -19,4 +19,8 @@
       <property name="exceptionList" value="GET,POST,PUT,PATCH,DELETE,UTF-8"/>
     </properties>
   </rule>
+
+  <!-- Main-only: tests idiomatically throw new RuntimeException("boom") to stub
+       failures, so this rule applies to production sources only. -->
+  <rule ref="category/java/design.xml/AvoidThrowingRawExceptionTypes"/>
 </ruleset>

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -25,8 +25,12 @@
   <rule ref="category/java/errorprone.xml/MisplacedNullCheck"/>
   <rule ref="category/java/errorprone.xml/InvalidLogMessageFormat"/>
   <rule ref="category/java/errorprone.xml/UnnecessaryBooleanAssertion"/>
-  <rule ref="category/java/errorprone.xml/AvoidCatchingThrowable"/>
-  <rule ref="category/java/errorprone.xml/AvoidCatchingNPE"/>
+  <rule ref="category/java/errorprone.xml/AvoidCatchingGenericException">
+    <properties>
+      <property name="typesThatShouldNotBeCaught"
+                value="java.lang.NullPointerException,java.lang.Throwable"/>
+    </properties>
+  </rule>
   <rule ref="category/java/errorprone.xml/DoNotThrowExceptionInFinally"/>
   <rule ref="category/java/errorprone.xml/ConstructorCallsOverridableMethod"/>
   <rule ref="category/java/errorprone.xml/CloseResource"/>

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -19,6 +19,56 @@
   <rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>
   <rule ref="category/java/bestpractices.xml/UnusedFormalParameter"/>
 
+  <!-- Error-prone: latent bugs, broken null handling, and exception mishandling -->
+  <rule ref="category/java/errorprone.xml/CompareObjectsWithEquals"/>
+  <rule ref="category/java/errorprone.xml/BrokenNullCheck"/>
+  <rule ref="category/java/errorprone.xml/MisplacedNullCheck"/>
+  <rule ref="category/java/errorprone.xml/InvalidLogMessageFormat"/>
+  <rule ref="category/java/errorprone.xml/UnnecessaryBooleanAssertion"/>
+  <rule ref="category/java/errorprone.xml/AvoidCatchingThrowable"/>
+  <rule ref="category/java/errorprone.xml/AvoidCatchingNPE"/>
+  <rule ref="category/java/errorprone.xml/DoNotThrowExceptionInFinally"/>
+  <rule ref="category/java/errorprone.xml/ConstructorCallsOverridableMethod"/>
+  <rule ref="category/java/errorprone.xml/CloseResource"/>
+
+  <!-- Best practices: dead assignments, mutation of inputs, and modern idioms -->
+  <rule ref="category/java/bestpractices.xml/UnusedAssignment"/>
+  <rule ref="category/java/bestpractices.xml/AvoidReassigningLoopVariables"/>
+  <rule ref="category/java/bestpractices.xml/AvoidReassigningParameters"/>
+  <rule ref="category/java/bestpractices.xml/UseTryWithResources"/>
+  <rule ref="category/java/bestpractices.xml/UseCollectionIsEmpty"/>
+  <rule ref="category/java/bestpractices.xml/UseStandardCharsets"/>
+  <rule ref="category/java/bestpractices.xml/PrimitiveWrapperInstantiation"/>
+  <rule ref="category/java/bestpractices.xml/ForLoopCanBeForeach"/>
+  <rule ref="category/java/bestpractices.xml/SimplifiableTestAssertion"/>
+  <rule ref="category/java/bestpractices.xml/LiteralsFirstInComparisons"/>
+
+  <!-- Design: exception hygiene and needless structure -->
+  <rule ref="category/java/design.xml/AvoidRethrowingException"/>
+  <rule ref="category/java/design.xml/AvoidThrowingNullPointerException"/>
+  <rule ref="category/java/design.xml/CollapsibleIfStatements"/>
+  <rule ref="category/java/design.xml/SimplifyConditional"/>
+  <rule ref="category/java/design.xml/SingularField"/>
+
+  <!-- Performance: needless allocation and string handling -->
+  <rule ref="category/java/performance.xml/StringInstantiation"/>
+  <rule ref="category/java/performance.xml/OptimizableToArrayCall"/>
+  <rule ref="category/java/performance.xml/AddEmptyString"/>
+  <rule ref="category/java/performance.xml/InefficientStringBuffering"/>
+
+  <!-- Code style: redundant syntax -->
+  <rule ref="category/java/codestyle.xml/EmptyControlStatement"/>
+  <rule ref="category/java/codestyle.xml/UnnecessaryReturn"/>
+  <rule ref="category/java/codestyle.xml/UnnecessaryBoxing"/>
+  <rule ref="category/java/codestyle.xml/UnnecessaryCast"/>
+  <rule ref="category/java/codestyle.xml/UnnecessaryModifier"/>
+  <rule ref="category/java/codestyle.xml/IdenticalCatchBranches"/>
+
+  <!-- Multithreading: unsafe concurrency patterns -->
+  <rule ref="category/java/multithreading.xml/DoubleCheckedLocking"/>
+  <rule ref="category/java/multithreading.xml/DontCallThreadRun"/>
+  <rule ref="category/java/multithreading.xml/UnsynchronizedStaticFormatter"/>
+
   <rule ref="category/java/design.xml/CyclomaticComplexity">
     <properties>
       <!-- 13, not the PMD default 10: audited every method in the 10-12 band and all were

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParams.java
@@ -25,7 +25,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.Getter;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.StringUtils;
 
 /**

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/AuthenticationStrategy.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/AuthenticationStrategy.java
@@ -15,8 +15,8 @@
  */
 package com.contrast.labs.ai.mcp.contrast.tool.base;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.ai.chat.model.ToolContext;
-import org.springframework.lang.Nullable;
 
 /** Binds transport-specific authentication context for one tool execution. */
 @FunctionalInterface

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseTool.java
@@ -16,9 +16,9 @@
 package com.contrast.labs.ai.mcp.contrast.tool.base;
 
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.lang.Nullable;
 
 /**
  * Base class for all Contrast MCP tools. Provides common infrastructure shared across paginated and

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorExecutionResult.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorExecutionResult.java
@@ -16,7 +16,7 @@
 package com.contrast.labs.ai.mcp.contrast.tool.base;
 
 import java.util.List;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Intermediate result from cursor-backed tool execution before final response building.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java
@@ -86,9 +86,9 @@ public abstract class CursorPaginatedTool<P extends ToolParams, R> extends BaseT
       return handleException(e, pagination, requestId, RESOURCE_NOT_FOUND_MESSAGE);
     } catch (HttpResponseException e) {
       return handleHttpResponseException(e, pagination, requestId, collector);
-    } catch (ActionableToolErrorException e) {
-      return handleException(e, pagination, requestId, e.getMessage());
-    } catch (IllegalArgumentException e) {
+    } catch (ActionableToolErrorException | IllegalArgumentException e) {
+      // User-input rejection raised mid-execution. The exception message is the actionable user
+      // message.
       return handleException(e, pagination, requestId, e.getMessage());
     } catch (Exception e) {
       log.atError()

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java
@@ -25,8 +25,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
 import org.springframework.ai.chat.model.ToolContext;
-import org.springframework.lang.Nullable;
 
 /**
  * Abstract base class for cursor/keyset-backed MCP list tools. Subclasses must treat cursor values

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParams.java
@@ -20,7 +20,7 @@ import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConsta
 
 import java.util.ArrayList;
 import java.util.List;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.StringUtils;
 
 /**

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorToolResponse.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorToolResponse.java
@@ -16,7 +16,7 @@
 package com.contrast.labs.ai.mcp.contrast.tool.base;
 
 import java.util.List;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Response wrapper for cursor-backed MCP list tools. It intentionally exposes only cursor

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
@@ -116,11 +116,9 @@ public abstract class PaginatedTool<P extends ToolParams, R> extends BaseTool {
       return handleException(e, pagination, requestId, RESOURCE_NOT_FOUND_MESSAGE);
     } catch (HttpResponseException e) {
       return handleHttpResponseException(e, pagination, requestId, collector);
-    } catch (ActionableToolErrorException e) {
-      return handleException(e, pagination, requestId, e.getMessage());
-    } catch (IllegalArgumentException e) {
-      // User-input rejection raised mid-execution (e.g., resolveAppMetadataFilters when an
-      // unknown field name is supplied). The exception message is the actionable user message.
+    } catch (ActionableToolErrorException | IllegalArgumentException e) {
+      // User-input rejection raised mid-execution. The exception message is the actionable user
+      // message.
       return handleException(e, pagination, requestId, e.getMessage());
     } catch (Exception e) {
       log.atError()

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
@@ -25,8 +25,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
 import org.springframework.ai.chat.model.ToolContext;
-import org.springframework.lang.Nullable;
 
 /**
  * Abstract base class for paginated MCP search tools. Enforces a consistent processing pipeline via

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolResponse.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolResponse.java
@@ -16,7 +16,7 @@
 package com.contrast.labs.ai.mcp.contrast.tool.base;
 
 import java.util.List;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Generic paginated response wrapper for all list-returning MCP tools. Provides consistent

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParams.java
@@ -57,7 +57,7 @@ public record PaginationParams(
    */
   public static PaginationParams of(Integer page, Integer pageSize, int maxPageSize) {
     List<String> notices = new ArrayList<>();
-    maxPageSize = Math.max(1, maxPageSize);
+    int effectiveMaxPageSize = Math.max(1, maxPageSize);
 
     // Soft failure: invalid page → clamp to 1
     int actualPage = page != null && page > 0 ? page : 1;
@@ -66,17 +66,17 @@ public record PaginationParams(
     }
 
     // Soft failure: invalid pageSize → clamp to range with tool-specific max
-    int defaultSize = Math.min(DEFAULT_PAGE_SIZE, maxPageSize);
+    int defaultSize = Math.min(DEFAULT_PAGE_SIZE, effectiveMaxPageSize);
     int actualSize = pageSize != null && pageSize > 0 ? pageSize : defaultSize;
     if (pageSize != null && pageSize < 1) {
       notices.add(String.format("Invalid pageSize %d, using default %d", pageSize, defaultSize));
       actualSize = defaultSize;
-    } else if (pageSize != null && pageSize > maxPageSize) {
+    } else if (pageSize != null && pageSize > effectiveMaxPageSize) {
       notices.add(
           String.format(
               "Requested pageSize %d exceeds maximum %d, capped to %d",
-              pageSize, maxPageSize, maxPageSize));
-      actualSize = maxPageSize;
+              pageSize, effectiveMaxPageSize, effectiveMaxPageSize));
+      actualSize = effectiveMaxPageSize;
     }
 
     // Cap page so (page-1)*pageSize never overflows int.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
@@ -23,8 +23,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
 import org.springframework.ai.chat.model.ToolContext;
-import org.springframework.lang.Nullable;
 
 /**
  * Abstract base class for non-paginated MCP get tools. Enforces a consistent processing pipeline

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
@@ -99,11 +99,9 @@ public abstract class SingleTool<P extends ToolParams, R> extends BaseTool {
       return handleException(e, requestId, mapHttpErrorCode(e.getCode()), collector);
     } catch (HttpResponseException e) {
       return handleHttpResponseException(e, requestId, collector);
-    } catch (ActionableToolErrorException e) {
-      return handleException(e, requestId, e.getMessage(), collector);
-    } catch (IllegalArgumentException e) {
-      // User-input rejection raised mid-execution (e.g., resolveSessionMetadataFilters when an
-      // unknown field name is supplied). The exception message is the actionable user message.
+    } catch (ActionableToolErrorException | IllegalArgumentException e) {
+      // User-input rejection raised mid-execution. The exception message is the actionable user
+      // message.
       return handleException(e, requestId, e.getMessage(), collector);
     } catch (Exception e) {
       log.atError()

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/server/params/ServerFilterParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/server/params/ServerFilterParams.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.Getter;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /** Validated public parameters and wire translation for server searches. */
 @Getter

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolSortParser.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolSortParser.java
@@ -22,8 +22,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.jspecify.annotations.Nullable;
 import org.springframework.lang.NonNull;
-import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 
 /** Parses the shared public {@code property,DIRECTION} sort contract into wire syntax. */

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/RecommendationMarkdownRenderer.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/RecommendationMarkdownRenderer.java
@@ -244,22 +244,22 @@ final class RecommendationMarkdownRenderer {
   }
 
   private static String link(String text) {
-    text =
+    var normalized =
         LINK_DELIMITER_PATTERN.matcher(text).replaceAll(Matcher.quoteReplacement(LINK_DELIMITER));
     var delimiter = LINK_DELIMITER;
-    var delimiterIndex = text.indexOf(delimiter);
+    var delimiterIndex = normalized.indexOf(delimiter);
     if (delimiterIndex < 0) {
       // One 1.0.297 Spanish template uses $$ directly between its URL and label.
       delimiter = BARE_LINK_DELIMITER;
-      delimiterIndex = text.indexOf(delimiter);
+      delimiterIndex = normalized.indexOf(delimiter);
       if (delimiterIndex < 0) {
-        return text;
+        return normalized;
       }
     }
-    var url = text.substring(0, delimiterIndex).strip();
-    var label = text.substring(delimiterIndex + delimiter.length()).strip();
+    var url = normalized.substring(0, delimiterIndex).strip();
+    var label = normalized.substring(delimiterIndex + delimiter.length()).strip();
     if (!StringUtils.hasText(url) || !StringUtils.hasText(label)) {
-      return text.replace(delimiter, " ");
+      return normalized.replace(delimiter, " ");
     }
     return "[" + label + "](" + url + ")";
   }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/ArchitectureTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/ArchitectureTest.java
@@ -260,11 +260,11 @@ class ArchitectureTest {
                           .filter(m -> !m.getName().startsWith("get"))
                           .filter(m -> !m.getName().startsWith("set"))
                           .filter(m -> !m.getName().startsWith("is"))
-                          .filter(m -> !m.getName().equals("toString"))
-                          .filter(m -> !m.getName().equals("hashCode"))
-                          .filter(m -> !m.getName().equals("equals"))
-                          .filter(m -> !m.getName().equals("builder"))
-                          .filter(m -> !m.getName().equals("of"))
+                          .filter(m -> !"toString".equals(m.getName()))
+                          .filter(m -> !"hashCode".equals(m.getName()))
+                          .filter(m -> !"equals".equals(m.getName()))
+                          .filter(m -> !"builder".equals(m.getName()))
+                          .filter(m -> !"of".equals(m.getName()))
                           .count();
 
                   if (count > MAX_NON_ACCESSOR_METHODS) {

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/client/ContrastApiClientContractTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/client/ContrastApiClientContractTest.java
@@ -82,7 +82,7 @@ class ContrastApiClientContractTest {
   @Test
   void contrastApiClient_should_expose_transport_neutral_server_search() {
     assertThat(ContrastApiClient.class.getDeclaredMethods())
-        .filteredOn(method -> method.getName().equals("searchServers"))
+        .filteredOn(method -> "searchServers".equals(method.getName()))
         .singleElement()
         .satisfies(
             method -> {

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
@@ -231,6 +231,28 @@ class CursorPaginatedToolTest {
   }
 
   @Test
+  void executePipeline_should_surface_illegalArgumentException_message_as_user_error() {
+    var iaeMessage =
+        "Metadata field(s) not found: never_a_real_field_zzq_123. Available fields can be"
+            + " discovered via the Contrast UI.";
+    tool.setDoExecuteHandler(
+        (pagination, params, collector) -> {
+          throw new IllegalArgumentException(iaeMessage);
+        });
+
+    var result = tool.executePipeline(OPAQUE_CURSOR, 25, TestParams::valid);
+
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.errors())
+        .as("IllegalArgumentException message must surface verbatim as the user-facing error")
+        .singleElement()
+        .isEqualTo(iaeMessage);
+    assertThat(result.errors())
+        .as("IllegalArgumentException must not be masked as a generic internal error")
+        .noneMatch(e -> e.contains("An internal error occurred"));
+  }
+
+  @Test
   void executePipeline_should_track_duration() {
     tool.setDoExecuteHandler(
         (pagination, params, collector) -> CursorExecutionResult.of(List.of("item"), null, false));

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsTest.java
@@ -230,4 +230,22 @@ class PaginationParamsTest {
     assertThat(params.notices()).hasSize(1);
     assertThat(params.notices().getFirst()).contains("Invalid pageSize -1, using default 25");
   }
+
+  @Test
+  void testZeroMaxPageSizeClampsToOne() {
+    var params = PaginationParams.of(1, null, 0);
+
+    assertThat(params.page()).isEqualTo(1);
+    assertThat(params.pageSize()).isEqualTo(1);
+    assertThat(params.notices()).isEmpty();
+  }
+
+  @Test
+  void testNegativeMaxPageSizeClampsToOne() {
+    var params = PaginationParams.of(1, null, -5);
+
+    assertThat(params.page()).isEqualTo(1);
+    assertThat(params.pageSize()).isEqualTo(1);
+    assertThat(params.notices()).isEmpty();
+  }
 }

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/RecommendationMarkdownRendererTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/RecommendationMarkdownRendererTest.java
@@ -368,11 +368,13 @@ class RecommendationMarkdownRendererTest {
   }
 
   private static RecommendationData fixture(String name) throws IOException {
-    var input = RecommendationMarkdownRendererTest.class.getResourceAsStream(FIXTURE_ROOT + name);
-    assertThat(input).as("fixture %s must exist", name).isNotNull();
-    try (var reader = new InputStreamReader(input, StandardCharsets.UTF_8)) {
-      var sdk = new Gson().fromJson(reader, RecommendationResponse.class).getRecommendation();
-      return RecommendationData.from(sdk);
+    try (var input =
+        RecommendationMarkdownRendererTest.class.getResourceAsStream(FIXTURE_ROOT + name)) {
+      assertThat(input).as("fixture %s must exist", name).isNotNull();
+      try (var reader = new InputStreamReader(input, StandardCharsets.UTF_8)) {
+        var sdk = new Gson().fromJson(reader, RecommendationResponse.class).getRecommendation();
+        return RecommendationData.from(sdk);
+      }
     }
   }
 

--- a/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtension.java
+++ b/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtension.java
@@ -112,19 +112,16 @@ public class SDKExtension {
   }
 
   public ProtectData getProtectConfig(String orgId, String appId) throws IOException {
-    try (InputStream is =
-        contrastSDK.makeRequest(HttpMethod.GET, getProtectDataURL(orgId, appId)); ) {
-
-      var reader = new InputStreamReader(is, StandardCharsets.UTF_8);
+    try (InputStream is = contrastSDK.makeRequest(HttpMethod.GET, getProtectDataURL(orgId, appId));
+        Reader reader = new InputStreamReader(is, StandardCharsets.UTF_8)) {
       return gson.fromJson(reader, ProtectData.class);
     }
   }
 
   public CveData getAppsForCVE(String organizationId, String cveID) throws IOException {
     try (InputStream is =
-        contrastSDK.makeRequest(HttpMethod.GET, getCVEDataURL(organizationId, cveID)); ) {
-
-      var reader = new InputStreamReader(is, StandardCharsets.UTF_8);
+            contrastSDK.makeRequest(HttpMethod.GET, getCVEDataURL(organizationId, cveID));
+        Reader reader = new InputStreamReader(is, StandardCharsets.UTF_8)) {
       return gson.fromJson(reader, CveData.class);
     }
   }
@@ -157,9 +154,8 @@ public class SDKExtension {
   public List<LibraryObservation> getLibraryObservations(
       String organizationId, String applicationId, String libraryId, int pageSize)
       throws IOException, UnauthorizedException {
-    if (pageSize <= 0) {
-      pageSize = ValidationConstants.DEFAULT_LIBRARY_OBS_PAGE_SIZE;
-    }
+    var effectivePageSize =
+        pageSize <= 0 ? ValidationConstants.DEFAULT_LIBRARY_OBS_PAGE_SIZE : pageSize;
 
     var allObservations = new ArrayList<LibraryObservation>();
     int offset = 0;
@@ -167,7 +163,8 @@ public class SDKExtension {
 
     do {
       var url =
-          getLibraryObservationsUrl(organizationId, applicationId, libraryId, offset, pageSize);
+          getLibraryObservationsUrl(
+              organizationId, applicationId, libraryId, offset, effectivePageSize);
 
       try (InputStream is = contrastSDK.makeRequest(HttpMethod.GET, url);
           Reader reader = new InputStreamReader(is, StandardCharsets.UTF_8)) {
@@ -179,7 +176,7 @@ public class SDKExtension {
         }
 
         total = response.getTotal();
-        offset += pageSize;
+        offset += effectivePageSize;
       }
     } while (offset < total);
 
@@ -590,24 +587,23 @@ public class SDKExtension {
       String sort)
       throws IOException, UnauthorizedException {
 
-    // Set default values if not provided
-    if (limit == null) limit = DEFAULT_ATTACKS_LIMIT;
-    if (offset == null) offset = 0;
-    if (sort == null) sort = "-startTime";
-    if (filterBody == null) filterBody = AttacksFilterBody.builder().build();
+    var effectiveLimit = limit != null ? limit : DEFAULT_ATTACKS_LIMIT;
+    var effectiveOffset = offset != null ? offset : 0;
+    var effectiveSort = sort != null ? sort : "-startTime";
+    var effectiveFilterBody = filterBody != null ? filterBody : AttacksFilterBody.builder().build();
 
     var url =
         new URIBuilder()
             .appendPathSegments("ng", organizationId, "attacks")
             .appendQueryParam("expand", "skip_links")
-            .appendQueryParam("limit", String.valueOf(limit))
-            .appendQueryParam("offset", String.valueOf(offset))
-            .appendQueryParam("sort", sort)
+            .appendQueryParam("limit", String.valueOf(effectiveLimit))
+            .appendQueryParam("offset", String.valueOf(effectiveOffset))
+            .appendQueryParam("sort", effectiveSort)
             .toURIString();
 
     try (InputStream is =
             contrastSDK.makeRequestWithBody(
-                HttpMethod.POST, url, this.gson.toJson(filterBody), MediaType.JSON);
+                HttpMethod.POST, url, this.gson.toJson(effectiveFilterBody), MediaType.JSON);
         Reader reader = new InputStreamReader(is, StandardCharsets.UTF_8)) {
 
       // Parse complete JSON response including metadata

--- a/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKHelper.java
+++ b/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKHelper.java
@@ -194,18 +194,17 @@ public class SDKHelper {
       return null;
     }
 
-    // Trim whitespace
-    hostName = hostName.trim();
+    var trimmedHostName = hostName.trim();
 
     // Return null for empty strings (consistent with null handling)
-    if (hostName.isEmpty()) {
+    if (trimmedHostName.isEmpty()) {
       return null;
     }
 
     var result =
-        hostName.contains("://")
-            ? validateEmbeddedScheme(hostName)
-            : normalizeProtocol(protocol) + "://" + hostName;
+        trimmedHostName.contains("://")
+            ? validateEmbeddedScheme(trimmedHostName)
+            : normalizeProtocol(protocol) + "://" + trimmedHostName;
 
     // Remove trailing slash to prevent double slashes in URLs
     if (result.endsWith("/")) {

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/McpContrastApplicationToolRegistrationTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/McpContrastApplicationToolRegistrationTest.java
@@ -57,7 +57,7 @@ class McpContrastApplicationToolRegistrationTest {
   void toolsBean_should_explicitly_register_searchServersTool() throws Exception {
     var toolsMethod =
         Arrays.stream(McpContrastApplication.class.getDeclaredMethods())
-            .filter(method -> method.getName().equals("tools"))
+            .filter(method -> "tools".equals(method.getName()))
             .findFirst()
             .orElseThrow();
     var tools =

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtensionTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtensionTest.java
@@ -215,7 +215,7 @@ class SDKExtensionTest {
               eq(HttpMethod.GET),
               argThat(
                   url ->
-                      url.equals("/ng/org-123/protection/policy/app-456?expand=skip_links")
+                      "/ng/org-123/protection/policy/app-456?expand=skip_links".equals(url)
                           || (url.contains("/ng/org-123/protection/policy/app-456")
                               && url.contains("expand=skip_links"))));
     }

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataLocalParityTest.java
@@ -34,15 +34,13 @@ import org.junit.jupiter.api.Test;
 class GetSessionMetadataLocalParityTest {
 
   private GetSessionMetadataTool tool;
-  private ContrastSDKFactory sdkFactory;
-  private SDKExtensionFactory sdkExtensionFactory;
   private ContrastSDK sdk;
 
   @BeforeEach
   void setUp() {
     sdk = mock();
-    sdkFactory = mock();
-    sdkExtensionFactory = mock();
+    ContrastSDKFactory sdkFactory = mock();
+    SDKExtensionFactory sdkExtensionFactory = mock();
 
     when(sdkFactory.getSDK()).thenReturn(sdk);
     when(sdkFactory.getOrgId()).thenReturn("test-org-id");

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityLocalParityTest.java
@@ -40,16 +40,14 @@ class GetVulnerabilityLocalParityTest {
 
   private GetVulnerabilityTool tool;
   private VulnerabilityMapper mapper;
-  private ContrastSDKFactory sdkFactory;
-  private SDKExtensionFactory sdkExtensionFactory;
   private ContrastSDK sdk;
 
   @BeforeEach
   void setUp() {
     mapper = mock();
     sdk = mock();
-    sdkFactory = mock();
-    sdkExtensionFactory = mock();
+    ContrastSDKFactory sdkFactory = mock();
+    SDKExtensionFactory sdkExtensionFactory = mock();
 
     when(sdkFactory.getSDK()).thenReturn(sdk);
     when(sdkFactory.getOrgId()).thenReturn(ORG_ID);

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolIT.java
@@ -734,8 +734,8 @@ public class SearchVulnerabilitiesToolIT
                     .anyMatch(
                         t ->
                             t != null
-                                && (t.equalsIgnoreCase("SmartFix Remediated")
-                                    || t.equalsIgnoreCase("another tag"))));
+                                && ("SmartFix Remediated".equalsIgnoreCase(t)
+                                    || "another tag".equalsIgnoreCase(t))));
   }
 
   // ---------- Pagination ----------


### PR DESCRIPTION
<!-- pr-tools:stacked:v1 -->
<!-- pr-tools:parent-pr=249 -->
<!-- pr-tools:parent-branch=AIML-1416-pmd-baseline-cleanup -->
<!-- pr-tools:parent-base=AIML-1416-pmd-baselines-coverage -->
<!-- pr-tools:boundary-commit=03871ef3c2bc32846b8c2ed2aedde63cb9f5173b -->
<!-- pr-tools:managed:start -->
<!-- pr-tools:managed:end -->

**Jira:** [AIML-1416](https://contrast.atlassian.net/browse/AIML-1416)

## Summary

Enables 39 additional PMD rules across six categories (error-prone, best practices, design, performance, code style, multithreading) and fixes every violation they surfaced. This expands the PMD gate from the initial baseline-infrastructure PR to catch real bug patterns, parameter mutation, unclosed resources, and redundant syntax.

- 39 new rules now enforced across both modules
- All surfaced violations fixed (no baseline additions)
- `AvoidThrowingRawExceptionTypes` scoped to production sources only, since tests idiomatically throw raw exceptions to stub failures

## Why This Change Exists

The parent PRs established the PMD infrastructure (baselines, changed-file analysis, pre-push hook, CI integration) but started with a minimal rule set. This PR fills in the rules that matter for this codebase, drawn from the aiml-services PMD configuration and the full PMD catalog. Every rule was evaluated for applicability before inclusion.

## Approach

Rules were enabled in bulk, then `pmdMain`/`pmdTest` was run against the full source tree to surface violations. Each violation was fixed in the production or test code rather than baselined. Fixes fall into five categories, all mechanical and behavior-preserving.

## What Changed

### PMD rule configuration
- `config/pmd/ruleset.xml` — 38 new rules organized by category (error-prone, best practices, design, performance, code style, multithreading)
- `config/pmd/main-ruleset.xml` — `AvoidThrowingRawExceptionTypes` added as production-only, with updated description explaining why tests are excluded

### Parameter reassignment → local variables
- `PaginationParams.java` — `maxPageSize` parameter renamed to `effectiveMaxPageSize` local
- `SDKExtension.java` — `pageSize`, `limit`, `offset`, `sort`, `filterBody` parameters replaced with `effectiveX` locals in `getLibraryObservations` and `searchAttacks`
- `SDKHelper.java` — `hostName` parameter replaced with `trimmedHostName` local
- `RecommendationMarkdownRenderer.java` — `text` parameter replaced with `normalized` local in `link()`

### Identical catch branches merged
- `CursorPaginatedTool.java`, `PaginatedTool.java`, `SingleTool.java` — `ActionableToolErrorException` and `IllegalArgumentException` catches collapsed into multi-catch since both handlers were identical

### Resource closing
- `RecommendationMarkdownRendererTest.java` — `InputStream` from `getResourceAsStream` now wrapped in try-with-resources
- `SDKExtension.java` — `Reader` instances in `getProtectConfig` and `getAppsForCVE` moved into the try-with-resources declaration

### Literals-first comparisons
- `ArchitectureTest.java`, `ContrastApiClientContractTest.java`, `McpContrastApplicationToolRegistrationTest.java`, `SDKExtensionTest.java`, `SearchVulnerabilitiesToolIT.java` — flipped `x.equals("literal")` to `"literal".equals(x)` per `CompareObjectsWithEquals` / `LiteralsFirstInComparisons`

### Unused field removal
- `GetSessionMetadataLocalParityTest.java`, `GetVulnerabilityLocalParityTest.java` — `sdkFactory` and `sdkExtensionFactory` fields moved to local variables in `setUp()` since they were only used there

## Testing

All fixes are mechanical refactors that preserve behavior. The existing test suite validates correctness. `make check` passes with all 39 new rules active and zero baseline additions.


[AIML-1416]: https://contrast.atlassian.net/browse/AIML-1416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ