### PR TITLE
AIML-1140 Update copyright headers to 2026

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 MCP Contrast
-Copyright 2025 Contrast Security
+Copyright 2026 Contrast Security
 
 This product includes software developed by Contrast Security.
 

--- a/buildSrc/src/main/java/com/contrast/labs/build/ChangedJavaFiles.java
+++ b/buildSrc/src/main/java/com/contrast/labs/build/ChangedJavaFiles.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.build;
 
 import java.io.File;

--- a/buildSrc/src/main/java/com/contrast/labs/build/EnvFileParser.java
+++ b/buildSrc/src/main/java/com/contrast/labs/build/EnvFileParser.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.build;
 
 import java.io.File;

--- a/buildSrc/src/main/java/com/contrast/labs/build/JacocoChangedFileCoverage.java
+++ b/buildSrc/src/main/java/com/contrast/labs/build/JacocoChangedFileCoverage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.build;
 
 import java.io.File;

--- a/buildSrc/src/test/java/com/contrast/labs/build/ChangedJavaFilesTest.java
+++ b/buildSrc/src/test/java/com/contrast/labs/build/ChangedJavaFilesTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.build;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/buildSrc/src/test/java/com/contrast/labs/build/EnvFileParserTest.java
+++ b/buildSrc/src/test/java/com/contrast/labs/build/EnvFileParserTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.build;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/buildSrc/src/test/java/com/contrast/labs/build/JacocoChangedFileCoverageTest.java
+++ b/buildSrc/src/test/java/com/contrast/labs/build/JacocoChangedFileCoverageTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.build;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/client/ContrastApiClient.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/client/ContrastApiClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/hints/HintGenerator.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/hints/HintGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.hints;
 
 import org.springframework.util.StringUtils;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/hints/HintProvider.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/hints/HintProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.hints;
 
 import java.util.Collections;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/hints/HintUtils.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/hints/HintUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.hints;
 
 import java.util.ArrayList;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/hints/RuleHints.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/hints/RuleHints.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.hints;
 
 import java.util.Arrays;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/ApplicationData.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/ApplicationData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/AttackSummary.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/AttackSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/LibraryLibraryObservation.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/LibraryLibraryObservation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.result;
 
 import com.contrast.labs.ai.mcp.contrast.sdkextension.data.LibraryExtended;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/Metadata.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/Metadata.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.result;
 
 public record Metadata(String name, String value) {}

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/RouteCoverageResponseLight.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/RouteCoverageResponseLight.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/RouteLight.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/RouteLight.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/RunBookEnum.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/RunBookEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/ScanProject.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/ScanProject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/StackLib.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/StackLib.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.result;
 
 public record StackLib(String stackTraceLine, String libraryHash) {}

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/VulnLight.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/VulnLight.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/Vulnerability.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/result/Vulnerability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/ExtendedTraceFilterBody.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/ExtendedTraceFilterBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/App.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/App.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/Cve.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/Cve.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/CveData.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/CveData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/CvssV2.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/CvssV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/CvssV3.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/CvssV3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/ImpactStats.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/ImpactStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/LibrariesExtended.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/LibrariesExtended.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/Library.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/Library.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/LibraryExtended.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/LibraryExtended.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/LibraryVulnerabilityExtended.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/LibraryVulnerabilityExtended.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/ProtectData.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/ProtectData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/Rule.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/Rule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/Server.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/Application.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/Attack.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/Attack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/AttackEvent.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/AttackEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/AttacksFilterBody.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/AttacksFilterBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/AttacksResponse.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/AttacksResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/Chapter.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/Chapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/Event.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/Event.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/EventDetails.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/EventDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/EventSummary.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/EventSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/HttpRequest.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/HttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/Request.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/Request.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/Server.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/StackFrame.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/StackFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/Story.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/Story.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/UserInput.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/UserInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/AppMetadataField.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/AppMetadataField.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.sdkextension.data.application;
 
 import lombok.Data;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/AppMetadataFieldsResponse.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/AppMetadataFieldsResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.sdkextension.data.application;
 
 import java.util.List;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/AppMetadataFilter.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/AppMetadataFilter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.sdkextension.data.application;
 
 import lombok.AllArgsConstructor;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/Application.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/Application.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.sdkextension.data.application;
 
 import com.google.gson.annotations.SerializedName;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/ApplicationsFilterRequest.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/ApplicationsFilterRequest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.sdkextension.data.application;
 
 import java.util.List;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/ApplicationsResponse.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/ApplicationsResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.sdkextension.data.application;
 
 import com.google.gson.annotations.SerializedName;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/Field.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/Field.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.sdkextension.data.application;
 
 import com.google.gson.annotations.SerializedName;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/Metadata.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/Metadata.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.sdkextension.data.application;
 
 import com.google.gson.annotations.SerializedName;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/routecoverage/App.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/routecoverage/App.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/routecoverage/Observation.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/routecoverage/Observation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/routecoverage/Route.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/routecoverage/Route.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/routecoverage/RouteCoverageBySessionIDAndMetadataRequestExtended.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/routecoverage/RouteCoverageBySessionIDAndMetadataRequestExtended.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.sdkextension.data.routecoverage;
 
 import com.contrastsecurity.models.RouteCoverageBySessionIDAndMetadataRequest;

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/routecoverage/RouteCoverageResponse.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/routecoverage/RouteCoverageResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/routecoverage/Server.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/routecoverage/Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/sca/LibraryObservation.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/sca/LibraryObservation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/sca/LibraryObservationsResponse.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/sca/LibraryObservationsResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/sessionmetadata/AgentSession.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/sessionmetadata/AgentSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/sessionmetadata/MetadataField.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/sessionmetadata/MetadataField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/sessionmetadata/MetadataSession.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/sessionmetadata/MetadataSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/sessionmetadata/SessionMetadataResponse.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/sessionmetadata/SessionMetadataResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/application/params/ApplicationFilterParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/application/params/ApplicationFilterParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/application/params/GetSessionMetadataParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/application/params/GetSessionMetadataParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/GetProtectRulesParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/GetProtectRulesParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/AuthenticationStrategy.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/AuthenticationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseToolParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseToolParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorExecutionResult.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorExecutionResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorToolResponse.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorToolResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/ExecutionResult.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/ExecutionResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelper.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/LoggingKeys.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/LoggingKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/NoticeCollector.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/NoticeCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolResponse.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolResponse.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/ToolParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/ToolParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/RouteMapper.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/RouteMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/params/RouteCoverageParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/params/RouteCoverageParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/params/ListApplicationLibrariesParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/params/ListApplicationLibrariesParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/params/ListApplicationsByCveParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/library/params/ListApplicationsByCveParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/sast/params/GetSastProjectParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/sast/params/GetSastProjectParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/DateSpec.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/DateSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/EnumSetSpec.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/EnumSetSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/IntSpec.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/IntSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/MetadataJsonFilterSpec.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/MetadataJsonFilterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringListSpec.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringListSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringSpec.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/TimestampSpec.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/TimestampSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContext.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/UnresolvedMetadataFilter.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/UnresolvedMetadataFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ValidationConstants.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ValidationConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/HttpRequestRedactor.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/HttpRequestRedactor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityContext.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityMapper.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityStatusNormalizer.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityStatusNormalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/GetVulnerabilityParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/GetVulnerabilityParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/ListVulnerabilityTypesParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/ListVulnerabilityTypesParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParams.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/util/TimestampFormatter.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/util/TimestampFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/ArchitectureTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/ArchitectureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/BuildCompatibilityTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/BuildCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/CoreBoundaryTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/CoreBoundaryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/HintGeneratorTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/HintGeneratorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/client/ContrastApiClientContractTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/client/ContrastApiClientContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/hints/HintProviderTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/hints/HintProviderTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.hints;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/result/AttackSummaryTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/result/AttackSummaryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/result/RouteCoverageResponseLightTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/result/RouteCoverageResponseLightTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/result/RouteLightTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/result/RouteLightTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/result/RunBookEnumTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/result/RunBookEnumTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.result;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/result/ScanProjectTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/result/ScanProjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/result/VulnerabilityTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/result/VulnerabilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/CveTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/CveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/LibrariesExtendedTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/LibrariesExtendedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/LibraryExtendedTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/LibraryExtendedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/LibraryVulnerabilityExtendedTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/LibraryVulnerabilityExtendedTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.sdkextension.data;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/AttacksFilterBodyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/AttacksFilterBodyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/AttacksResponseTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/adr/AttacksResponseTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.sdkextension.data.adr;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/ApplicationTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/application/ApplicationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.sdkextension.data.application;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/routecoverage/RouteTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/routecoverage/RouteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/server/ServersResponseEnvelopeTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/data/server/ServersResponseEnvelopeTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.sdkextension.data.server;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/params/ApplicationFilterParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/params/ApplicationFilterParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/params/GetSessionMetadataParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/params/GetSessionMetadataParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/GetProtectRulesParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/GetProtectRulesParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseToolAuthenticationStrategyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseToolAuthenticationStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorExecutionResultTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorExecutionResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParamsPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParamsPropertyTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.tool.base;
 
 import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.DEFAULT_PAGE_SIZE;

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorToolResponseTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorToolResponseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/ExecutionResultTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/ExecutionResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelperPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelperPropertyTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.tool.base;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelperTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/FilterHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/NoticeCollectorTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/NoticeCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolResponseTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolResponseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsPropertyTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.tool.base;
 
 import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.DEFAULT_PAGE_SIZE;

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/ResponseEnvelopeSerializationTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/ResponseEnvelopeSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolResponseTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolResponseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/RouteMapperPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/RouteMapperPropertyTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.tool.coverage;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/RouteMapperTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/RouteMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/params/RouteCoverageParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/params/RouteCoverageParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/params/ListApplicationLibrariesParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/params/ListApplicationLibrariesParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/params/ListApplicationsByCveParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/params/ListApplicationsByCveParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/params/GetSastProjectParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/params/GetSastProjectParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/DateSpecTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/DateSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/EnumSetSpecPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/EnumSetSpecPropertyTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.tool.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/EnumSetSpecTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/EnumSetSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/IntSpecPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/IntSpecPropertyTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.tool.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/IntSpecTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/IntSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/MetadataJsonFilterSpecTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/MetadataJsonFilterSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringListSpecPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringListSpecPropertyTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.tool.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringListSpecTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringListSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringSpecTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/StringSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/TimestampSpecTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/TimestampSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolSortParserPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolSortParserPropertyTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.tool.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContextPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContextPropertyTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.tool.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContextTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ToolValidationContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/UnresolvedMetadataFilterTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/UnresolvedMetadataFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ValidationConstantsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/validation/ValidationConstantsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/HttpRequestRedactorPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/HttpRequestRedactorPropertyTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/HttpRequestRedactorTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/HttpRequestRedactorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/RecommendationMarkdownRendererPropertyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/RecommendationMarkdownRendererPropertyTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityMapperTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityMapperTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.tool.vulnerability;
 
 import static com.contrast.labs.ai.mcp.contrast.tool.validation.ValidationConstants.AUTO_REMEDIATED_VULN_STATUS;

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityStatusNormalizerTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityStatusNormalizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/GetVulnerabilityParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/GetVulnerabilityParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/ListVulnerabilityTypesParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/ListVulnerabilityTypesParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParamsTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/McpContrastApplication.java
+++ b/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/McpContrastApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/client/SdkApiClient.java
+++ b/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/client/SdkApiClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/config/ContrastProperties.java
+++ b/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/config/ContrastProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/config/ContrastSDKFactory.java
+++ b/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/config/ContrastSDKFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/config/SDKExtensionFactory.java
+++ b/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/config/SDKExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/DateAsEpochTypeAdapter.java
+++ b/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/DateAsEpochTypeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtension.java
+++ b/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKHelper.java
+++ b/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/LocalSdkPaginatedTool.java
+++ b/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/LocalSdkPaginatedTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/LocalSdkSingleTool.java
+++ b/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/LocalSdkSingleTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastResultsTool.java
+++ b/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastResultsTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/sast/params/GetSastResultsParams.java
+++ b/contrast-mcp-stdio-app/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/sast/params/GetSastResultsParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/AnonymousLibraryExtendedBuilder.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/AnonymousLibraryExtendedBuilder.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast;
 
 import static org.mockito.Mockito.lenient;

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/AnonymousLibraryExtendedBuilderTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/AnonymousLibraryExtendedBuilderTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/AnonymousProjectBuilder.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/AnonymousProjectBuilder.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast;
 
 import static org.mockito.Mockito.lenient;

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/AnonymousScanBuilder.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/AnonymousScanBuilder.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast;
 
 import static org.mockito.Mockito.lenient;

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/ApplicationJsonParsingTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/ApplicationJsonParsingTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/config/ContrastPropertiesTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/config/ContrastPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/config/ContrastSDKFactoryTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/config/ContrastSDKFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/config/IntegrationTestConfig.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/config/IntegrationTestConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/config/SDKExtensionFactoryTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/config/SDKExtensionFactoryTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.config;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/DateAsEpochTypeAdapterTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/DateAsEpochTypeAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/ExtendedTraceFilterBodyTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/ExtendedTraceFilterBodyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtensionDateSerializationTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtensionDateSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtensionTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKHelperTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/sdkextension/SDKHelperTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.contrast.labs.ai.mcp.contrast.sdkextension;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataLocalParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/GetSessionMetadataToolIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsLocalParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/application/SearchApplicationsToolIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesLocalParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksLocalParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksToolIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/LocalSdkPaginatedToolTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/LocalSdkPaginatedToolTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool.base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.contrast.labs.ai.mcp.contrast.config.ContrastSDKFactory;
+import com.contrast.labs.ai.mcp.contrast.config.SDKExtensionFactory;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.SDKExtension;
+import com.contrastsecurity.sdk.ContrastSDK;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LocalSdkPaginatedToolTest {
+
+  @Mock private ContrastSDKFactory sdkFactory;
+  @Mock private SDKExtensionFactory sdkExtensionFactory;
+  @InjectMocks private TestLocalSdkPaginatedTool tool;
+
+  @Test
+  void getContrastSDK_should_delegate_to_factory() {
+    ContrastSDK expected = mock();
+    when(sdkFactory.getSDK()).thenReturn(expected);
+
+    assertThat(tool.getContrastSDK()).isSameAs(expected);
+  }
+
+  @Test
+  void getOrgId_should_delegate_to_factory() {
+    when(sdkFactory.getOrgId()).thenReturn("org-123");
+
+    assertThat(tool.getOrgId()).isEqualTo("org-123");
+  }
+
+  @Test
+  void getSDKExtension_should_delegate_to_factory() {
+    SDKExtension expected = mock();
+    when(sdkExtensionFactory.getSDKExtension()).thenReturn(expected);
+
+    assertThat(tool.getSDKExtension()).isSameAs(expected);
+  }
+
+  static class TestLocalSdkPaginatedTool extends LocalSdkPaginatedTool<ToolParams, String> {
+
+    @Override
+    protected ExecutionResult<String> doExecute(
+        PaginationParams pagination, ToolParams params, NoticeCollector collector) {
+      return new ExecutionResult<>(List.of("test"), 1);
+    }
+  }
+}

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/LocalSdkSingleToolTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/LocalSdkSingleToolTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Contrast Security
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.contrast.labs.ai.mcp.contrast.tool.base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.contrast.labs.ai.mcp.contrast.config.ContrastSDKFactory;
+import com.contrast.labs.ai.mcp.contrast.config.SDKExtensionFactory;
+import com.contrast.labs.ai.mcp.contrast.sdkextension.SDKExtension;
+import com.contrastsecurity.sdk.ContrastSDK;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LocalSdkSingleToolTest {
+
+  @Mock private ContrastSDKFactory sdkFactory;
+  @Mock private SDKExtensionFactory sdkExtensionFactory;
+  @InjectMocks private TestLocalSdkSingleTool tool;
+
+  @Test
+  void getContrastSDK_should_delegate_to_factory() {
+    ContrastSDK expected = mock();
+    when(sdkFactory.getSDK()).thenReturn(expected);
+
+    assertThat(tool.getContrastSDK()).isSameAs(expected);
+  }
+
+  @Test
+  void getOrgId_should_delegate_to_factory() {
+    when(sdkFactory.getOrgId()).thenReturn("org-456");
+
+    assertThat(tool.getOrgId()).isEqualTo("org-456");
+  }
+
+  @Test
+  void getSDKExtension_should_delegate_to_factory() {
+    SDKExtension expected = mock();
+    when(sdkExtensionFactory.getSDKExtension()).thenReturn(expected);
+
+    assertThat(tool.getSDKExtension()).isSameAs(expected);
+  }
+
+  static class TestLocalSdkSingleTool extends LocalSdkSingleTool<ToolParams, String> {
+
+    @Override
+    protected String doExecute(ToolParams params, NoticeCollector collector) {
+      return "test";
+    }
+  }
+}

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageLocalParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/coverage/GetRouteCoverageToolIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesLocalParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationLibrariesToolIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveLocalParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/library/ListApplicationsByCveToolIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectLocalParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastProjectToolIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastResultsToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastResultsToolIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastResultsToolTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/GetSastResultsToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/params/GetSastResultsParamsTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/sast/params/GetSastResultsParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityLocalParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/GetVulnerabilityToolIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesLocalParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/ListVulnerabilityTypesToolIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesLocalParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchAppVulnerabilitiesToolIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesLocalParityTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesLocalParityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/SearchVulnerabilitiesToolIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/TracesJsonFixture.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/TracesJsonFixture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityMapperTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/VulnerabilityMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/util/AbstractIntegrationTest.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/util/AbstractIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/util/IntegrationTestDataCache.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/util/IntegrationTestDataCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/util/IntegrationTestDiskCache.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/util/IntegrationTestDiskCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/util/TestDataDiscoveryHelper.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/util/TestDataDiscoveryHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Contrast Security
+ * Copyright 2026 Contrast Security
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
**Jira:** [AIML-1140](https://contrast.atlassian.net/browse/AIML-1140)

## Summary

Updates all Java source files to carry the correct 2026 copyright year. 224 files had their existing "Copyright 2025" bumped to "Copyright 2026", and 42 files that were missing any header received the full Apache 2.0 block. No functional code changes.

- Every `*.java` file under `src/` now has a consistent Apache 2.0 header with "Copyright 2026 Contrast Security"
- Two new test classes fill pre-existing coverage gaps in `LocalSdkPaginatedTool` and `LocalSdkSingleTool` that the header change surfaced

## Why This Change Exists

Alex flagged stale 2025 headers during PR #162 review. A full-repo audit found 224 files still carrying the old year and 42 files with no copyright header at all. Per team policy, headers are updated annually.

## What Changed

### Copyright year bump (224 files)
All `*.java` files containing `Copyright 2025 Contrast Security` were updated to `Copyright 2026 Contrast Security`. Single-line mechanical replacement.

### Missing headers added (42 files)
Files that had no copyright header at all received the full 16-line Apache 2.0 block. These fell into two groups: older SDK extension and hint types that predated the header convention, and newer jqwik property tests added without headers.

### New tests (2 files)
- `LocalSdkPaginatedToolTest.java` — verifies the three delegation methods in the paginated bridge class
- `LocalSdkSingleToolTest.java` — same for the single-item bridge class

These classes had pre-existing coverage below the 85% changed-file floor. The copyright header edit made them "changed", surfacing the gap.

## Testing

- `make check` passes with 1322 tests, 0 failures
- Changed-file coverage gate passes for all 268 files
- No functional code was altered, so existing tests cover all behavior


[AIML-1140]: https://contrast.atlassian.net/browse/AIML-1140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ