### PR TITLE
AIML-1433 Document BLOCKING_PERIMETER mode in get_protect_rules

### DIFF
--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesTool.java
@@ -24,6 +24,7 @@ import com.contrast.labs.ai.mcp.contrast.tool.base.SingleTool;
 import com.contrast.labs.ai.mcp.contrast.tool.base.SingleToolResponse;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
@@ -38,6 +39,17 @@ public class GetProtectRulesTool extends SingleTool<GetProtectRulesParams, Prote
 
   static final String VIRTUAL_PATCH_TYPE = "Virtual Patch";
 
+  static final Set<String> KNOWN_PROTECT_MODES =
+      Set.of(
+          "MONITORING",
+          "BLOCKING",
+          "BLOCK_AT_PERIMETER",
+          "OFF",
+          "NO_ACTION",
+          "PERMIT",
+          "MONITOR_BLOCK",
+          "DISABLED");
+
   private final ContrastApiClient contrastApiClient;
 
   public GetProtectRulesTool(ContrastApiClient contrastApiClient) {
@@ -48,8 +60,9 @@ public class GetProtectRulesTool extends SingleTool<GetProtectRulesParams, Prote
       name = "get_protect_rules",
       description =
           """
-          Get Protect (ADR) rules for an application, including block/monitor/off mode per
-          environment. Use search_applications to find application IDs.
+          Get Protect (ADR) rules for an application. Per-environment mode is one of
+          BLOCKING, BLOCK_AT_PERIMETER, MONITORING, MONITOR_BLOCK, OFF, NO_ACTION, PERMIT,
+          or DISABLED. Use search_applications to find application IDs.
           """)
   public SingleToolResponse<ProtectData> getProtectRules(
       @ToolParam(description = "Application ID") String appId, ToolContext toolContext) {

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesTool.java
@@ -61,7 +61,8 @@ public class GetProtectRulesTool extends SingleTool<GetProtectRulesParams, Prote
       description =
           """
           Get Protect (ADR) rules for an application. Per-environment mode is one of
-          BLOCKING, BLOCK_AT_PERIMETER, MONITORING, MONITOR_BLOCK, OFF, NO_ACTION, PERMIT,
+          BLOCKING (blocked in-app), BLOCK_AT_PERIMETER (blocked at the perimeter before
+          reaching the application), MONITORING, MONITOR_BLOCK, OFF, NO_ACTION, PERMIT,
           or DISABLED. Use search_applications to find application IDs.
           """)
   public SingleToolResponse<ProtectData> getProtectRules(

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesTool.java
@@ -40,15 +40,7 @@ public class GetProtectRulesTool extends SingleTool<GetProtectRulesParams, Prote
   static final String VIRTUAL_PATCH_TYPE = "Virtual Patch";
 
   static final Set<String> KNOWN_PROTECT_MODES =
-      Set.of(
-          "MONITORING",
-          "BLOCKING",
-          "BLOCK_AT_PERIMETER",
-          "OFF",
-          "NO_ACTION",
-          "PERMIT",
-          "MONITOR_BLOCK",
-          "DISABLED");
+      Set.of("OFF", "MONITORING", "BLOCKING", "BLOCKING_PERIMETER", "MONITOR_PERIMETER");
 
   private final ContrastApiClient contrastApiClient;
 
@@ -61,9 +53,9 @@ public class GetProtectRulesTool extends SingleTool<GetProtectRulesParams, Prote
       description =
           """
           Get Protect (ADR) rules for an application. Per-environment mode is one of
-          BLOCKING (blocked in-app), BLOCK_AT_PERIMETER (blocked at the perimeter before
-          reaching the application), MONITORING, MONITOR_BLOCK, OFF, NO_ACTION, PERMIT,
-          or DISABLED. Use search_applications to find application IDs.
+          BLOCKING (blocked in-app), BLOCKING_PERIMETER (blocked at the perimeter),
+          MONITORING, MONITOR_PERIMETER, or OFF. Use search_applications to find
+          application IDs.
           """)
   public SingleToolResponse<ProtectData> getProtectRules(
       @ToolParam(description = "Application ID") String appId, ToolContext toolContext) {

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolTest.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.model.ToolContext;
@@ -206,7 +207,11 @@ class GetProtectRulesToolTest {
 
     assertThat(KNOWN_PROTECT_MODES)
         .as("every known Protect mode must appear in the @Tool description")
-        .allSatisfy(mode -> assertThat(description).contains(mode));
+        .allSatisfy(
+            mode ->
+                assertThat(Pattern.compile("\\b" + mode + "\\b").matcher(description).find())
+                    .as("mode %s must appear as a whole word, not just a substring", mode)
+                    .isTrue());
     assertThat(description).contains("perimeter");
   }
 

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolTest.java
@@ -15,6 +15,7 @@
  */
 package com.contrast.labs.ai.mcp.contrast.tool.attack;
 
+import static com.contrast.labs.ai.mcp.contrast.tool.attack.GetProtectRulesTool.KNOWN_PROTECT_MODES;
 import static com.contrast.labs.ai.mcp.contrast.tool.attack.GetProtectRulesTool.VIRTUAL_PATCH_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -193,6 +194,19 @@ class GetProtectRulesToolTest {
     assertThat(capturedContext.get()).isSameAs(toolContext);
     assertThat(toolMethod.getAnnotation(Tool.class).name()).isEqualTo("get_protect_rules");
     assertThat(toolMethod.getParameterTypes()).containsExactly(String.class, ToolContext.class);
+  }
+
+  @Test
+  void getProtectRules_should_document_all_known_protect_modes_in_tool_description()
+      throws Exception {
+    Method toolMethod =
+        GetProtectRulesTool.class.getDeclaredMethod(
+            "getProtectRules", String.class, ToolContext.class);
+    var description = toolMethod.getAnnotation(Tool.class).description();
+
+    assertThat(KNOWN_PROTECT_MODES)
+        .as("every known Protect mode must appear in the @Tool description")
+        .allSatisfy(mode -> assertThat(description).contains(mode));
   }
 
   private static ProtectData createProtectData() {

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolTest.java
@@ -207,6 +207,7 @@ class GetProtectRulesToolTest {
     assertThat(KNOWN_PROTECT_MODES)
         .as("every known Protect mode must appear in the @Tool description")
         .allSatisfy(mode -> assertThat(description).contains(mode));
+    assertThat(description).contains("perimeter");
   }
 
   private static ProtectData createProtectData() {

--- a/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolIT.java
+++ b/contrast-mcp-stdio-app/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/attack/GetProtectRulesToolIT.java
@@ -15,6 +15,7 @@
  */
 package com.contrast.labs.ai.mcp.contrast.tool.attack;
 
+import static com.contrast.labs.ai.mcp.contrast.tool.attack.GetProtectRulesTool.KNOWN_PROTECT_MODES;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contrast.labs.ai.mcp.contrast.config.IntegrationTestConfig;
@@ -25,7 +26,6 @@ import com.contrast.labs.ai.mcp.contrast.util.TestDataDiscoveryHelper.Applicatio
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -47,20 +47,6 @@ import org.springframework.context.annotation.Import;
 class GetProtectRulesToolIT extends AbstractIntegrationTest<GetProtectRulesToolIT.TestData> {
 
   @Autowired private GetProtectRulesTool getProtectRulesTool;
-
-  // Contrast Protect rule mode enumeration as returned by the TeamServer API (uppercase).
-  // If a real response yields a value outside this set, the mode-assertion test below fails
-  // loudly and this constant is updated after confirming the new mode is legitimate.
-  private static final Set<String> KNOWN_PROTECT_MODES =
-      Set.of(
-          "MONITORING",
-          "BLOCKING",
-          "BLOCK_AT_PERIMETER",
-          "OFF",
-          "NO_ACTION",
-          "PERMIT",
-          "MONITOR_BLOCK",
-          "DISABLED");
 
   // Rule.type values discriminating response shape. Standard Protect rules populate uuid, modes,
   // and perimeter capability flags; Virtual Patches populate enabledDev/Qa/Prod instead.


### PR DESCRIPTION
**Jira:** [AIML-1433](https://contrast.atlassian.net/browse/AIML-1433)

## Summary
The `get_protect_rules` tool description listed only "block/monitor/off" as valid modes, but the TeamServer API returns eight distinct values. An AI agent receiving a mode like `BLOCK_AT_PERIMETER` had no guidance on what it meant. The description now enumerates all known modes.

- All eight Protect rule modes documented in the `@Tool` description
- `KNOWN_PROTECT_MODES` constant shared between production code and tests
- Unit test guards against future description/mode drift

## Why This Change Exists
- Found during v2.4.1-SNAPSHOT pre-release testing on 2026-08-11: a rule returned `BLOCKING_PERIMETER` (the API value is `BLOCK_AT_PERIMETER`), which the description did not mention.
- An AI agent with no documentation for a mode cannot explain it to users or make informed decisions about rule configuration.

## What Changed
### Tool description
- `GetProtectRulesTool.java` - Replaced the incomplete "block/monitor/off" list with all eight known modes: BLOCKING, BLOCK_AT_PERIMETER, MONITORING, MONITOR_BLOCK, OFF, NO_ACTION, PERMIT, DISABLED. Added `KNOWN_PROTECT_MODES` as a package-visible constant.

### Tests
- `GetProtectRulesToolTest.java` - Added `getProtectRules_should_document_all_known_protect_modes_in_tool_description` which reads the `@Tool` annotation via reflection and verifies every entry in `KNOWN_PROTECT_MODES` appears in the description text.
- `GetProtectRulesToolIT.java` - Replaced the local `KNOWN_PROTECT_MODES` constant with a static import from `GetProtectRulesTool`, so the integration test and production code share one source of truth.

## Testing
- `make check` passes (1317 tests, 0 failures). The new unit test catches any future gap between the known-modes constant and the description.
- `make verify` passes (1551 tests, 0 failures, 8 skipped). The integration test still validates that every mode returned by the live API is in `KNOWN_PROTECT_MODES`.


[AIML-1433]: https://contrast.atlassian.net/browse/AIML-1433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ