### PR TITLE
AIML-1375 Fix swallowed exception cause in base tool catch blocks

### DIFF
--- a/contrast-mcp-core/pmd-baseline.txt
+++ b/contrast-mcp-core/pmd-baseline.txt
@@ -4,14 +4,10 @@
 # Multiple violations of the same PMD rule in one file share one entry.
 # CPD entries are matched by participating files, not line number or token count.
 CPD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java,contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
-CPD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginationParams.java,contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginationParams.java
 CPD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/SearchAppVulnerabilitiesParams.java,contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/params/VulnerabilityFilterParams.java
 PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/hints/RuleHints.java|AvoidDuplicateLiterals
 PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/SearchAttacksTool.java|ExcessiveParameterList
 PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/attack/params/AttackFilterParams.java|ExcessiveParameterList
-PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java|FluentLogInCatchRequiresCause
-PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java|FluentLogInCatchRequiresCause
-PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java|FluentLogInCatchRequiresCause
 PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/server/SearchServersTool.java|ExcessiveParameterList
 PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/server/params/ServerFilterParams.java|ExcessiveParameterList
 PMD|contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/vulnerability/RecommendationMarkdownRenderer.java|AvoidDuplicateLiterals

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/CursorPaginatedTool.java
@@ -95,6 +95,7 @@ public abstract class CursorPaginatedTool<P extends ToolParams, R> extends BaseT
           .addKeyValue(LoggingKeys.REQUEST_ID, requestId)
           .addKeyValue(LoggingKeys.CURSOR, pagination.cursorPresence())
           .addKeyValue(LoggingKeys.EXCEPTION_TYPE, e.getClass().getSimpleName())
+          .setCause(e)
           .setMessage("Request failed unexpectedly")
           .log();
       return CursorToolResponse.error(

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java
@@ -124,6 +124,7 @@ public abstract class PaginatedTool<P extends ToolParams, R> extends BaseTool {
       log.atError()
           .addKeyValue(LoggingKeys.REQUEST_ID, requestId)
           .addKeyValue(LoggingKeys.EXCEPTION_TYPE, e.getClass().getSimpleName())
+          .setCause(e)
           .setMessage("Request failed unexpectedly")
           .log();
       return PaginatedToolResponse.error(

--- a/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
+++ b/contrast-mcp-core/src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java
@@ -107,6 +107,7 @@ public abstract class SingleTool<P extends ToolParams, R> extends BaseTool {
       log.atError()
           .addKeyValue(LoggingKeys.REQUEST_ID, requestId)
           .addKeyValue(LoggingKeys.EXCEPTION_TYPE, e.getClass().getSimpleName())
+          .setCause(e)
           .setMessage("Request failed unexpectedly")
           .log();
       return SingleToolResponse.error("An internal error occurred (ref: " + requestId + ")");

--- a/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseToolAuthenticationStrategyTest.java
+++ b/contrast-mcp-core/src/test/java/com/contrast/labs/ai/mcp/contrast/tool/base/BaseToolAuthenticationStrategyTest.java
@@ -17,24 +17,13 @@ package com.contrast.labs.ai.mcp.contrast.tool.base;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.ai.chat.model.ToolContext;
 
 class BaseToolAuthenticationStrategyTest {
-
-  private static final List<Path> PIPELINE_SOURCES =
-      List.of(
-          Path.of("src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/SingleTool.java"),
-          Path.of("src/main/java/com/contrast/labs/ai/mcp/contrast/tool/base/PaginatedTool.java"));
 
   @Test
   void executePipeline_should_remain_noop_when_authentication_strategy_is_not_configured() {
@@ -181,20 +170,6 @@ class BaseToolAuthenticationStrategyTest {
     assertThat(result.errors().get(0)).matches("An internal error occurred \\(ref: [0-9a-f]{8}\\)");
     assertThat(String.join(" ", result.errors())).doesNotContain("raw-token-value");
     assertThat(events).containsExactly("authenticate");
-  }
-
-  static Stream<Path> pipelineSources() {
-    return PIPELINE_SOURCES.stream();
-  }
-
-  // Log builders in pipeline classes must not attach the throwable — it can leak sensitive content.
-  @ParameterizedTest
-  @MethodSource("pipelineSources")
-  void executePipeline_unexpected_error_logs_should_not_attach_stack_traces(Path sourcePath)
-      throws Exception {
-    var source = Files.readString(sourcePath, StandardCharsets.UTF_8);
-
-    assertThat(source).doesNotContain(".setCause(e)");
   }
 
   @Test


### PR DESCRIPTION
**Jira:** [AIML-1375](https://contrast.atlassian.net/browse/AIML-1375)

## Summary
Attach exception causes to the generic catch blocks in the three base tool classes so unexpected failures log their stack trace instead of swallowing it. This makes production incidents diagnosable without reproducing them, as proven necessary by AIML-1374.

- Exception stack traces now appear in server-side logs for unexpected errors
- Removed the source-scanning test that actively prohibited `.setCause(e)`
- Tightened the PMD baseline by removing the three grandfathered `FluentLogInCatchRequiresCause` violations

## Why This Change Exists
- AIML-1374 was hard to diagnose because the generic catch blocks logged "Request failed unexpectedly" with no stack trace. The exception cause was swallowed.
- A source-scanning test prohibited `.setCause(e)` based on a theoretical credential-leak concern. Investigation confirmed no such path exists in either the hosted or local SDK deployment, and server logs already contain far more sensitive context than an exception stack trace.

## What Changed
### Base tool catch blocks
- `CursorPaginatedTool.java` — added `.setCause(e)` to the fluent log call in the generic catch block
- `PaginatedTool.java` — same
- `SingleTool.java` — same

### Test cleanup
- `BaseToolAuthenticationStrategyTest.java` — removed the `executePipeline_unexpected_error_logs_should_not_attach_stack_traces` parameterized test, its `PIPELINE_SOURCES` constant, `pipelineSources()` method source, and now-unused imports

### PMD baseline
- `pmd-baseline.txt` — removed three `FluentLogInCatchRequiresCause` entries; `pmdBaselineTighten` also removed one stale CPD entry

## Testing
- `make verify` passes (1551 tests, 0 failures)
- Existing `BaseToolAuthenticationStrategyTest` tests still verify the error-handling pipeline behavior (generic error message returned, no credential leakage to the user-facing response)
- The PMD rule `FluentLogInCatchRequiresCause` now passes without baseline exemptions


[AIML-1375]: https://contrast.atlassian.net/browse/AIML-1375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ